### PR TITLE
Fix: Correct manifest.json for hassfest validation

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -10,7 +10,7 @@
   "quality_scale": "platinum",
   "requirements": ["meraki", "aiohttp"],
   "loggers": ["meraki_ha"],
-  "platforms": ["sensor", "switch"],
+  "integration_type": "hub",
   "dependencies": [],
   "after_dependencies": []
 }


### PR DESCRIPTION
Removed the "platforms" key and added "integration_type": "hub" to `custom_components/meraki_ha/manifest.json`.

This resolves the `hassfest` validation error:
"[MANIFEST] Invalid manifest: extra keys not allowed @ data['platforms']"

The "platforms" key is no longer a valid top-level key in the manifest. The "integration_type" key is now required for integrations.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
