### PR TITLE
[patch] I'm attempting to fix the "No module named custom_components.meraki_a…

### DIFF
--- a/custom_components/meraki_ha/coordinators/base_coordinator.py
+++ b/custom_components/meraki_ha/coordinators/base_coordinator.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from ..const import DOMAIN, ERASE_TAGS_WARNING
 from .api_data_fetcher import MerakiApiDataFetcher
-from ..meraki_api.exceptions import MerakiApiError # MerakiApiError for exception handling
+from ..meraki_api import MerakiApiError # MerakiApiError for exception handling
 from .data_aggregation_coordinator import DataAggregationCoordinator
 # Obsolete coordinators (DeviceTagFetchCoordinator, MerakiNetworkCoordinator, MerakiSsidCoordinator) removed.
 from .tag_eraser_coordinator import TagEraserCoordinator


### PR DESCRIPTION
…pi" error.

I've simplified the import of `MerakiApiError` in `coordinators/base_coordinator.py` to use the re-export from `meraki_api/__init__.py`.

This change is an attempt to address the `No module named 'custom_components.meraki_api'` error, which might be related to how Home Assistant's loader interacts with the component's import context, especially in light of the "blocking call to import_module" warning.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
