### PR TITLE
[patch] Use explicit imports to address loading error

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import (
+from custom_components.meraki_ha.const import (
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
     CONF_RELAXED_TAG_MATCHING,
@@ -19,7 +19,7 @@ from .const import (
     DOMAIN,
     PLATFORMS, # List of platforms (e.g., ["sensor", "switch"])
 )
-from .coordinators.base_coordinator import MerakiDataUpdateCoordinator
+from custom_components.meraki_ha.coordinators.base_coordinator import MerakiDataUpdateCoordinator
 # Obsolete imports for MerakiNetworkCoordinator and MerakiSsidCoordinator are removed.
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List # Keep List, Dict, Any if still used for type
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from meraki.exceptions import APIError as MerakiSDKAPIError
 
-from ..meraki_api import MerakiAPIClient # Import the refactored client
+from custom_components.meraki_ha.meraki_api import MerakiAPIClient # Import the refactored client
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -16,8 +16,8 @@ from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import selector
 
-from .authentication import validate_meraki_credentials
-from .const import (
+from custom_components.meraki_ha.authentication import validate_meraki_credentials
+from custom_components.meraki_ha.const import (
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
     CONF_RELAXED_TAG_MATCHING,

--- a/custom_components/meraki_ha/coordinators/__init__.py
+++ b/custom_components/meraki_ha/coordinators/__init__.py
@@ -9,14 +9,14 @@ distribution from the Meraki API.
 """
 
 # Import and re-export key coordinator classes for simpler access from other modules.
-from .base_coordinator import MerakiDataUpdateCoordinator
-from .api_data_fetcher import MerakiApiDataFetcher
-from .data_aggregation_coordinator import DataAggregationCoordinator
-from .data_processor import MerakiDataProcessor # Added for completeness if used externally
-from .data_aggregator import DataAggregator     # Added for completeness if used externally
-from .device_coordinator import MerakiDeviceCoordinator # If still used
-from .device_tag_update_coordinator import DeviceTagUpdateCoordinator # If still used
-from .tag_eraser_coordinator import TagEraserCoordinator # If still used
+from custom_components.meraki_ha.coordinators.base_coordinator import MerakiDataUpdateCoordinator
+from custom_components.meraki_ha.coordinators.api_data_fetcher import MerakiApiDataFetcher
+from custom_components.meraki_ha.coordinators.data_aggregation_coordinator import DataAggregationCoordinator
+from custom_components.meraki_ha.coordinators.data_processor import MerakiDataProcessor # Added for completeness if used externally
+from custom_components.meraki_ha.coordinators.data_aggregator import DataAggregator     # Added for completeness if used externally
+from custom_components.meraki_ha.coordinators.device_coordinator import MerakiDeviceCoordinator # If still used
+from custom_components.meraki_ha.coordinators.device_tag_update_coordinator import DeviceTagUpdateCoordinator # If still used
+from custom_components.meraki_ha.coordinators.tag_eraser_coordinator import TagEraserCoordinator # If still used
 
 
 # __all__ defines the public API of this module when `from .coordinators import *`

--- a/custom_components/meraki_ha/coordinators/api_data_fetcher.py
+++ b/custom_components/meraki_ha/coordinators/api_data_fetcher.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from meraki.exceptions import APIError as MerakiSDKAPIError
 
-from ..meraki_api import MerakiAPIClient
+from custom_components.meraki_ha.meraki_api import MerakiAPIClient
 # Obsolete imports for MerakiApiException and related custom exceptions are removed
 # as MerakiSDKAPIError from meraki.exceptions is used directly.
 

--- a/custom_components/meraki_ha/coordinators/base_coordinator.py
+++ b/custom_components/meraki_ha/coordinators/base_coordinator.py
@@ -18,12 +18,12 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from ..const import DOMAIN, ERASE_TAGS_WARNING
-from .api_data_fetcher import MerakiApiDataFetcher
-from ..meraki_api import MerakiApiError # MerakiApiError for exception handling
-from .data_aggregation_coordinator import DataAggregationCoordinator
+from custom_components.meraki_ha.const import DOMAIN, ERASE_TAGS_WARNING
+from custom_components.meraki_ha.coordinators.api_data_fetcher import MerakiApiDataFetcher
+from custom_components.meraki_ha.meraki_api import MerakiApiError # MerakiApiError for exception handling
+from custom_components.meraki_ha.coordinators.data_aggregation_coordinator import DataAggregationCoordinator
 # Obsolete coordinators (DeviceTagFetchCoordinator, MerakiNetworkCoordinator, MerakiSsidCoordinator) removed.
-from .tag_eraser_coordinator import TagEraserCoordinator
+from custom_components.meraki_ha.coordinators.tag_eraser_coordinator import TagEraserCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
 
         # Initialize the MerakiAPIClient for SDK interactions.
         # This client is passed to the api_fetcher and its lifecycle managed here.
-        from ..meraki_api import MerakiAPIClient # Local import to avoid potential circulars
+        from custom_components.meraki_ha.meraki_api import MerakiAPIClient # Local import to avoid potential circulars
         self.meraki_client: MerakiAPIClient = MerakiAPIClient(
             api_key=api_key,
             org_id=org_id

--- a/custom_components/meraki_ha/coordinators/data_aggregation_coordinator.py
+++ b/custom_components/meraki_ha/coordinators/data_aggregation_coordinator.py
@@ -17,12 +17,12 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 # SsidStatusCalculator is used by DataAggregator, not directly here.
-from .data_aggregator import DataAggregator
-from .data_processor import MerakiDataProcessor
+from custom_components.meraki_ha.coordinators.data_aggregator import DataAggregator
+from custom_components.meraki_ha.coordinators.data_processor import MerakiDataProcessor
 
 if TYPE_CHECKING:
     # To avoid circular import issues, type hint the parent coordinator.
-    from .base_coordinator import MerakiDataUpdateCoordinator
+    from custom_components.meraki_ha.coordinators.base_coordinator import MerakiDataUpdateCoordinator
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class DataAggregationCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
                                         # So, it should be initialized here.
         )
         # Re-instating SsidStatusCalculator initialization for DataAggregator
-        from ..helpers.ssid_status_calculator import SsidStatusCalculator
+        from custom_components.meraki_ha.helpers.ssid_status_calculator import SsidStatusCalculator
         self.ssid_status_calculator: SsidStatusCalculator = SsidStatusCalculator()
         self.data_aggregator = DataAggregator( # Re-initialize with calculator
             relaxed_tag_match=self.relaxed_tag_match,

--- a/custom_components/meraki_ha/coordinators/data_aggregator.py
+++ b/custom_components/meraki_ha/coordinators/data_aggregator.py
@@ -8,8 +8,8 @@ to determine the operational status of SSIDs based on device information.
 import logging
 from typing import Any, Dict, List
 
-from .data_processor import MerakiDataProcessor # For type hinting data_processor
-from ..helpers.ssid_status_calculator import SsidStatusCalculator
+from custom_components.meraki_ha.coordinators.data_processor import MerakiDataProcessor # For type hinting data_processor
+from custom_components.meraki_ha.helpers.ssid_status_calculator import SsidStatusCalculator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/coordinators/data_processor.py
+++ b/custom_components/meraki_ha/coordinators/data_processor.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     # Avoid circular import at runtime, only for type checking
     # Ensure this path is correct; if coordinator.py was deleted, it might be base_coordinator
-    from .base_coordinator import MerakiDataUpdateCoordinator 
+    from custom_components.meraki_ha.coordinators.base_coordinator import MerakiDataUpdateCoordinator 
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/meraki_api/__init__.py
+++ b/custom_components/meraki_ha/meraki_api/__init__.py
@@ -1,8 +1,8 @@
 # /config/custom_components/meraki_ha/meraki_api/__init__.py
 """Meraki API client and exceptions."""
 
-from ._api_client import MerakiAPIClient
-from .exceptions import (
+from custom_components.meraki_ha.meraki_api._api_client import MerakiAPIClient
+from custom_components.meraki_ha.meraki_api.exceptions import (
     MerakiApiError,  # Alias for MerakiApiException
     MerakiApiException,  # Base exception
     MerakiApiConnectionError,

--- a/custom_components/meraki_ha/sensor/__init__.py
+++ b/custom_components/meraki_ha/sensor/__init__.py
@@ -14,17 +14,17 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 # Import specific sensor entity classes
-from .connected_clients import MerakiConnectedClientsSensor
-from .device_status import MerakiDeviceStatusSensor
-from .network_clients import MerakiNetworkClientCountSensor
-from .radio_settings import MerakiRadioSettingsSensor
-from .ssid import create_ssid_sensors # Function to create multiple SSID-related sensors
-from .ssid_availability import MerakiSSIDAvailabilitySensor
-from .uplink_status import MerakiUplinkStatusSensor
+from custom_components.meraki_ha.sensor.connected_clients import MerakiConnectedClientsSensor
+from custom_components.meraki_ha.sensor.device_status import MerakiDeviceStatusSensor
+from custom_components.meraki_ha.sensor.network_clients import MerakiNetworkClientCountSensor
+from custom_components.meraki_ha.sensor.radio_settings import MerakiRadioSettingsSensor
+from custom_components.meraki_ha.sensor.ssid import create_ssid_sensors # Function to create multiple SSID-related sensors
+from custom_components.meraki_ha.sensor.ssid_availability import MerakiSSIDAvailabilitySensor
+from custom_components.meraki_ha.sensor.uplink_status import MerakiUplinkStatusSensor
 
 # Import from parent directory for constants and coordinator type
-from ..const import ATTR_SSIDS, DATA_COORDINATOR, DOMAIN # ATTR_SSIDS for device-specific SSIDs
-from ..coordinators.base_coordinator import MerakiDataUpdateCoordinator # Corrected import path
+from custom_components.meraki_ha.const import ATTR_SSIDS, DATA_COORDINATOR, DOMAIN # ATTR_SSIDS for device-specific SSIDs
+from custom_components.meraki_ha.coordinators.base_coordinator import MerakiDataUpdateCoordinator # Corrected import path
 
 # Obsolete imports for MerakiAPIClient and get_network_ids_and_names are removed.
 


### PR DESCRIPTION
Replaces internal relative imports within the `meraki_ha` custom component with explicit imports of the form
`custom_components.meraki_ha.module.submodule`.

This change affects core files including coordinators, helpers, top-level __init__.py, config_flow.py, and sensor setup.

This is an attempt to resolve the persistent
`No module named 'custom_components.meraki_api'` error, which is hypothesized to be a side effect of the
"Detected blocking call to import_module" warning that occurs when Home Assistant loads the `meraki_ha` integration. Using explicit imports might create a more resilient import context if the default package context is being disrupted during the initial load.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
