### PR TITLE
Revert: Remove granular diagnostic logging from authentication.py.

### DIFF
--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -52,19 +52,9 @@ class MerakiAuthentication:
         _LOGGER.debug("Preparing to validate Meraki credentials for organization %s using SDK", self.org_id)
         # Corrected attribute names to self.api_key and self.org_id as per class __init__
         client: MerakiAPIClient = MerakiAPIClient(api_key=self.api_key, org_id=self.org_id)
-        _LOGGER.info(f"MerakiAPIClient 'client' instantiated: {client}")
         
         try:
             _LOGGER.debug("Fetching networks for organization %s using Meraki SDK", self.org_id)
-            try:
-                networks_controller = client.networks
-                _LOGGER.info(f"Accessed client.networks successfully. Object: {networks_controller}")
-                _LOGGER.info(f"Meraki client.networks object type: {type(networks_controller)}")
-                _LOGGER.info(f"Meraki client.networks methods/attributes: {dir(networks_controller)}")
-            except Exception as e_access:
-                _LOGGER.error(f"Error accessing client.networks: {e_access}", exc_info=True)
-                # Re-raise the exception to ensure the flow is interrupted as it would be by the failing call
-                raise
             networks: List[Dict[str, Any]] = await client.networks.get_organization_networks(
                 organization_id=self.org_id
             )


### PR DESCRIPTION
This reverts the changes made in branch fix/meraki-auth-granular-diagnostics that added detailed logging for client instantiation and client.networks access.

The purpose of this revert is to address an "Invalid flow specified" error that appeared after those logging changes were introduced. This aims to return the integration to the state where it was encountering an AttributeError during authentication, to allow for further focused debugging of that specific issue.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
