### PR TITLE
Fix: Add missing organizations property to MerakiAPIClient.

### DIFF
--- a/custom_components/meraki_ha/meraki_api/_api_client.py
+++ b/custom_components/meraki_ha/meraki_api/_api_client.py
@@ -65,6 +65,11 @@ class MerakiAPIClient:
         return self._sdk.networks
 
     @property
+    def organizations(self) -> Any: # Or a more specific type like 'OrganizationsController' if known
+        """Provides access to the SDK's organizations controller."""
+        return self._sdk.organizations
+
+    @property
     def sensor(self) -> Any:
         """Provides access to the SDK's sensor controller."""
         return self._sdk.sensor


### PR DESCRIPTION
The `MerakiAPIClient` class in `meraki_api/_api_client.py` was missing an `@property` for `organizations` that exposes the underlying SDK's organizations controller. This caused an `AttributeError: 'MerakiAPIClient' object has no attribute 'organizations'` when `authentication.py` attempted to call
`client.organizations.getOrganizations()`.

This change adds the required `organizations` property, enabling the authentication flow to correctly call `getOrganizations`.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
