### PR TITLE
Fix: Use getNetwork (singular) in api_data_fetcher.py.

### DIFF
--- a/custom_components/meraki_ha/coordinators/api_data_fetcher.py
+++ b/custom_components/meraki_ha/coordinators/api_data_fetcher.py
@@ -242,7 +242,7 @@ class MerakiApiDataFetcher:
             
             # Attempt to get all networks the API key has access to
             # Using getNetworks (camelCase) as getOrganizations was also camelCase
-            all_networks_response = await self.meraki_client.networks.getNetworks(
+            all_networks_response = await self.meraki_client.networks.getNetwork(
                 total_pages="all"
             )
 


### PR DESCRIPTION
Based on Python's AttributeError hint ("Did you mean: 'getNetwork'?"), this commit changes the call in `async_get_networks` from `self.meraki_client.networks.getNetworks(total_pages="all")` to
`self.meraki_client.networks.getNetwork(total_pages="all")`.

This aims to resolve the persistent `AttributeError` encountered during the fetching of all networks for subsequent filtering.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
