### PR TITLE
Fix: Use `getNetwork()` with no arguments in `api_data_fetcher.py`.

### DIFF
--- a/custom_components/meraki_ha/coordinators/api_data_fetcher.py
+++ b/custom_components/meraki_ha/coordinators/api_data_fetcher.py
@@ -236,13 +236,13 @@ class MerakiApiDataFetcher:
         _LOGGER.debug("Fetching networks for org ID: %s using SDK", org_id)
         try:
             _LOGGER.info(
-                "Executing updated async_get_networks with getNetworks (fetch all and filter) for org ID %s.",
+                "Executing async_get_networks with getNetwork() (singular, no args) for org ID %s.",
                 org_id,
             )
             
             # Attempt to get all networks the API key has access to
             # Using getNetworks (camelCase) as getOrganizations was also camelCase
-            all_networks_response = await self.meraki_client.networks.getNetworks()
+            all_networks_response = await self.meraki_client.networks.getNetwork()
 
             if all_networks_response is None:
                 _LOGGER.warning(


### PR DESCRIPTION
Based on Python's `AttributeError` hint ("Did you mean: 'getNetwork'?") and subsequent `TypeError` when `total_pages` was used with `getNetwork()`, this commit changes the call in `async_get_networks` to `await self.meraki_client.networks.getNetwork()`.

This attempts to list all networks by calling `getNetwork()` without any arguments, which might be the correct invocation for your specific `meraki` library version.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
