### PR TITLE
[minor] feat: Add client device tracking capability

### DIFF
--- a/custom_components/meraki_ha/device_tracker.py
+++ b/custom_components/meraki_ha/device_tracker.py
@@ -34,7 +34,7 @@ async def async_setup_entry(
     """Set up Meraki device tracker entities from a config entry.
 
     This function is called by Home Assistant to initialize device tracker
-    entities based on the Meraki devices discovered by the central data
+    entities based on the Meraki clients discovered by the central data
     update coordinator.
 
     Args:
@@ -47,43 +47,40 @@ async def async_setup_entry(
     ]
 
     # Ensure coordinator data is available
-    if coordinator.data is None or "devices" not in coordinator.data:
+    if coordinator.data is None or "clients" not in coordinator.data:  # Ensure 'clients' key exists
         _LOGGER.warning(
-            "No device data available from Meraki coordinator. Cannot set up device trackers."
+            "No client data available from Meraki coordinator. Cannot set up device trackers."
         )
         return
 
-    devices: List[Dict[str, Any]] = coordinator.data.get("devices", [])
-    if not devices:
-        _LOGGER.info("No Meraki devices found to set up device trackers.")
+    clients: List[Dict[str, Any]] = coordinator.data.get("clients", []) # Get clients list
+    if not clients:
+        _LOGGER.info("No Meraki clients found to set up device trackers.")
         return
 
     entities: List[MerakiDeviceTracker] = []
-    for device_data in devices:
-        # Ensure essential device data (serial, model, name) is present
-        if not all(k in device_data for k in ["serial", "model", "name"]):
+    for client_data in clients:
+        # Ensure essential client data (e.g., MAC address) is present
+        if "mac" not in client_data:
             _LOGGER.warning(
-                "Skipping device tracker setup for device with missing "
-                "essential data: %s",
-                device_data.get("serial", "Unknown Serial"),
+                "Skipping device tracker setup for client with missing MAC address: %s",
+                client_data,
             )
             continue
-        entities.append(MerakiDeviceTracker(coordinator, device_data))
+        entities.append(MerakiDeviceTracker(coordinator, client_data))
 
     if entities:
         async_add_entities(entities)
-        _LOGGER.info("Added %d Meraki device trackers.", len(entities))
+        _LOGGER.info("Added %d Meraki client trackers.", len(entities))
 
 
 class MerakiDeviceTracker(
     CoordinatorEntity[MerakiDataUpdateCoordinator], TrackerEntity
 ):
-    """Representation of a Meraki device as a Home Assistant device tracker.
+    """Representation of an individual client device connected to a Meraki network.
 
-    This entity tracks the "connectivity" or "activity" of a Meraki
-    device (like an access point) by checking if it has any connected
-    clients. It is not tracking individual clients, but rather the
-    device itself.
+    This entity tracks the connectivity of a single client (e.g., a laptop,
+    phone) by checking its presence in the Meraki coordinator's data.
     """
 
     # For Home Assistant 2022.11+ to use device name as base
@@ -92,30 +89,28 @@ class MerakiDeviceTracker(
     def __init__(
         self,
         coordinator: MerakiDataUpdateCoordinator,
-        device_info: Dict[str, Any],  # Renamed for clarity
+        client_info: Dict[str, Any],
     ) -> None:
-        """Initialize the Meraki device tracker.
+        """Initialize the Meraki client device tracker.
 
         Args:
             coordinator: The `MerakiDataUpdateCoordinator` for data updates.
-            device_info: A dictionary containing the Meraki device's
-                         information, including 'serial', 'name',
-                         'model', etc.
+            client_info: A dictionary containing the client's
+                         information, including 'mac', 'ip', 'description',
+                         'ap_serial' (if connected to an AP), etc.
         """
         super().__init__(coordinator)  # Initialize CoordinatorEntity
-        self._device_info_data: Dict[str, Any] = device_info
-        # Let HA generate from device name if _attr_has_entity_name is True
-        self._attr_name = None
-        # Or set explicitly:
-        # self._attr_name = device_info["name"]
-        self._attr_unique_id = (
-            f"{self._device_info_data['serial']}_device_tracker"
-        )
+        self._client_info_data: Dict[str, Any] = client_info
+        # Name can be client's description or IP if description is not available
+        self._attr_name = self._client_info_data.get(
+            "description"
+        ) or self._client_info_data.get("ip")
+        self._attr_unique_id = f"{self._client_info_data['mac']}_client_tracker"
 
         # Initial update of attributes based on current data
         self._update_attributes()
 
-    @callback  # For properties derived from coordinator data
+    @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_attributes()
@@ -124,89 +119,74 @@ class MerakiDeviceTracker(
     def _update_attributes(self) -> None:
         """Update entity attributes based on coordinator data.
 
-        This method finds the current device's data from the
-        coordinator's latest device list and updates the
-        `is_connected` status.
+        This method checks if the current client (identified by MAC address)
+        is present in the coordinator's list of active clients.
         """
-        # Find this specific device in the coordinator's latest data
-        current_device_data: Optional[Dict[str, Any]] = None
-        if self.coordinator.data and "devices" in self.coordinator.data:
-            for dev_data in self.coordinator.data["devices"]:
-                if dev_data.get("serial") == self._device_info_data["serial"]:
-                    current_device_data = dev_data
+        self._attr_is_connected = False  # Default to not connected
+        client_mac = self._client_info_data["mac"]
+
+        if self.coordinator.data and "clients" in self.coordinator.data:
+            active_clients: List[Dict[str, Any]] = self.coordinator.data["clients"]
+            for client_data in active_clients:
+                if client_data.get("mac") == client_mac:
+                    self._attr_is_connected = True
+                    # Update client info if more details are available from active list
+                    self._client_info_data.update(client_data) 
                     break
         
-        if current_device_data:
-            # Assuming 'connected_clients_count' is populated by the
-            # coordinator (e.g., by MerakiDeviceCoordinator) for MR/GR
-            # devices. If not, this logic needs adjustment based on
-            # available data. The original code checked
-            # `len(meraki_device.get("clients")) > 0`.
-            # Let's assume a field like 'connected_clients_count' exists
-            # from prior processing.
-            connected_clients_count: int = current_device_data.get(
-                "connected_clients_count", 0
+        _LOGGER.debug(
+            "Client tracker %s (MAC: %s) is_connected: %s",
+            self._attr_name,
+            client_mac,
+            self._attr_is_connected,
+        )
+        if not self._attr_is_connected:
+             _LOGGER.debug( # More specific log if client not found in active list
+                "Client tracker %s (MAC: %s) not found in coordinator's active client list.",
+                self._attr_name,
+                client_mac,
             )
-            self._attr_is_connected = connected_clients_count > 0
-            _LOGGER.debug(
-                "Device tracker %s (%s) connected_clients_count: %d, "
-                "is_connected: %s",
-                self._device_info_data.get("name"),
-                self._device_info_data["serial"],
-                connected_clients_count,
-                self._attr_is_connected,
-            )
-        else:
-            _LOGGER.warning(
-                "Device tracker %s (%s) could not find its data in "
-                "coordinator update. Setting is_connected to False.",
-                self._device_info_data.get("name"),
-                self._device_info_data["serial"],
-            )
-            self._attr_is_connected = False
 
-    # No need for a separate @property is_connected if _attr_is_connected
-    # is set in _update_attributes and updated via _handle_coordinator_update.
-    # If direct calculation is preferred over storing in _attr_is_connected:
-    # @property
-    # def is_connected(self) -> bool:
-    #     """Return true if device has connected clients or is active."""
-    #     # Find this specific device in coordinator's latest data
-    #     if self.coordinator.data and "devices" in self.coordinator.data:
-    #         for dev_data in self.coordinator.data["devices"]:
-    #             if dev_data.get("serial") == self._device_info_data["serial"]:
-    #                 # Logic based on 'connected_clients_count' or similar
-    #                 return dev_data.get("connected_clients_count", 0) > 0
-    #     return False  # Default to False if data not found
 
     @property
     def source_type(self) -> SourceType:
-        """Return the source type of the device tracker (router/AP)."""
-        # Indicates the device itself is a network device
-        return SourceType.ROUTER
+        """Return the source type of the device tracker."""
+        return SourceType.ROUTER # Client is tracked by the router/AP
 
     @property
     def device_info(self) -> Dict[str, Any]:
-        """Return device information for linking this entity to the registry.
+        """Return device information for linking this entity to the parent Meraki device.
 
         This information is used by Home Assistant to correctly group
         entities and display device details in the UI.
         """
+        # Link to the AP the client is connected to, or the network.
+        # This assumes 'ap_serial' or 'network_id' is in _client_info_data
+        # Default to network if AP serial is not present
+        parent_identifier_value = self._client_info_data.get(
+            "ap_serial"
+        ) or self._client_info_data.get("networkId", "meraki_network")
+
+        # Use client's description or IP as name, fallback to MAC
+        entity_name = self._client_info_data.get(
+            "description"
+        ) or self._client_info_data.get("ip", self._client_info_data["mac"])
+
         return {
-            "identifiers": {(DOMAIN, self._device_info_data["serial"])},
-            "name": str(self._device_info_data["name"]),  # Ensure name is string
-            "manufacturer": "Cisco Meraki",
-            # Ensure model is string
-            "model": str(self._device_info_data.get("model", "Unknown")),
-            # Ensure sw_version is string
-            "sw_version": str(self._device_info_data.get("firmware", "")),
-            # If network is also a device
-            # "via_device": (DOMAIN, self._device_info_data.get("networkId")),
+            "identifiers": {(DOMAIN, parent_identifier_value)},
+            # The name of this client device entity itself is handled by _attr_name
+            # This device_info is for the parent/associated device in HA.
+            # For clarity, we can use a generic name for the client "device" type
+            # or specific if available (e.g. from 'ap_name')
+            "name": f"Meraki Client on {parent_identifier_value}", # This name is for the device entry this entity is linked to
+            "manufacturer": self._client_info_data.get("manufacturer", "Unknown Manufacturer"), # TODO: derive from MAC if possible
+            "model": "Client Device",
+            # No firmware version for a client device in this context
+            # "sw_version": "", 
         }
 
-    # Potentially add other properties if needed, e.g., location,
-    # battery_level (if applicable)
-    # @property
-    # def icon(self) -> str:
-    #     """Return the icon to use in the frontend, if any."""
-    #     return "mdi:router-wireless" if self.is_connected else "mdi:router-wireless-off"
+    # Icon can be dynamic based on connection state
+    @property
+    def icon(self) -> str:
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:lan-connect" if self.is_connected else "mdi:lan-disconnect"

--- a/custom_components/meraki_ha/tests/test_device_tracker.py
+++ b/custom_components/meraki_ha/tests/test_device_tracker.py
@@ -1,0 +1,357 @@
+"""Tests for the Meraki Client Device Tracker entities."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.components.device_tracker import SourceType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from custom_components.meraki_ha.const import DATA_COORDINATOR, DOMAIN
+from custom_components.meraki_ha.device_tracker import (
+    MerakiDeviceTracker,
+    async_setup_entry,
+)
+
+# --- Mock Data ---
+MOCK_CLIENT_1 = {
+    "mac": "AA:BB:CC:DD:EE:01",
+    "description": "Client One",
+    "ip": "192.168.1.101",
+    "ap_serial": "Q2AB-CDEF-GHIJ",  # Serial of the AP it's connected to
+    "networkId": "L_123456789",
+    "status": "Online",
+    "manufacturer": "Apple, Inc.",
+    "os": "macOS",
+}
+MOCK_CLIENT_2 = {
+    "mac": "AA:BB:CC:DD:EE:02",
+    "description": "Client Two",
+    "ip": "192.168.1.102",
+    "networkId": "L_123456789",  # No AP serial, should link to network
+    "status": "Online",
+    "manufacturer": "Samsung",
+}
+MOCK_CLIENT_NO_DESC_IP = {
+    "mac": "AA:BB:CC:DD:EE:03",
+    "networkId": "L_123456789",
+    "status": "Online",
+}
+
+MOCK_CONFIG_ENTRY_ID = "test_entry_id"
+
+@pytest.fixture
+def mock_config_entry() -> ConfigEntry:
+    """Mock a Home Assistant ConfigEntry."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = MOCK_CONFIG_ENTRY_ID
+    return entry
+
+@pytest.fixture
+def mock_coordinator(hass: HomeAssistant) -> MagicMock:
+    """Mock the MerakiDataUpdateCoordinator."""
+    coordinator = MagicMock(spec=DataUpdateCoordinator)
+    coordinator.hass = hass
+    coordinator.data = {"clients": []} # Default to no clients
+    # Mock the listener management methods
+    coordinator.async_add_listener = MagicMock()
+    coordinator.async_remove_listener = MagicMock()
+    return coordinator
+
+def setup_hass_domain_data(
+    hass: HomeAssistant, entry_id: str, coordinator: MagicMock
+):
+    """Set up the hass.data structure for the Meraki domain."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry_id] = {DATA_COORDINATOR: coordinator}
+
+
+# --- Test Cases ---
+
+async def test_async_setup_entry_creates_trackers(
+    hass: HomeAssistant, mock_coordinator: MagicMock, mock_config_entry: ConfigEntry
+):
+    """Test that device trackers are created for clients."""
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_1, MOCK_CLIENT_2]}
+    setup_hass_domain_data(hass, mock_config_entry.entry_id, mock_coordinator)
+    
+    mock_async_add_entities = AsyncMock()
+    
+    await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+    
+    assert mock_async_add_entities.call_count == 1
+    created_entities = mock_async_add_entities.call_args[0][0]
+    assert len(created_entities) == 2
+    
+    entity_macs = {entity._client_info_data["mac"] for entity in created_entities}
+    assert MOCK_CLIENT_1["mac"] in entity_macs
+    assert MOCK_CLIENT_2["mac"] in entity_macs
+
+    for entity in created_entities:
+        assert isinstance(entity, MerakiDeviceTracker)
+        if entity._client_info_data["mac"] == MOCK_CLIENT_1["mac"]:
+            assert entity.unique_id == f"{MOCK_CLIENT_1['mac']}_client_tracker"
+            assert entity.name == MOCK_CLIENT_1["description"]
+        elif entity._client_info_data["mac"] == MOCK_CLIENT_2["mac"]:
+            assert entity.unique_id == f"{MOCK_CLIENT_2['mac']}_client_tracker"
+            assert entity.name == MOCK_CLIENT_2["description"]
+
+async def test_async_setup_entry_no_clients(
+    hass: HomeAssistant, mock_coordinator: MagicMock, mock_config_entry: ConfigEntry
+):
+    """Test that no entities are created if the coordinator provides no client data."""
+    mock_coordinator.data = {"clients": []} # No clients
+    setup_hass_domain_data(hass, mock_config_entry.entry_id, mock_coordinator)
+    
+    mock_async_add_entities = AsyncMock()
+    
+    await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+    
+    mock_async_add_entities.assert_not_called()
+
+async def test_async_setup_entry_coordinator_data_none(
+    hass: HomeAssistant, mock_coordinator: MagicMock, mock_config_entry: ConfigEntry
+):
+    """Test that no entities are created if coordinator.data is None."""
+    mock_coordinator.data = None # Coordinator data is None
+    setup_hass_domain_data(hass, mock_config_entry.entry_id, mock_coordinator)
+    
+    mock_async_add_entities = AsyncMock()
+    
+    await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+    
+    mock_async_add_entities.assert_not_called()
+
+async def test_async_setup_entry_clients_key_missing(
+    hass: HomeAssistant, mock_coordinator: MagicMock, mock_config_entry: ConfigEntry
+):
+    """Test that no entities are created if 'clients' key is missing in coordinator.data."""
+    mock_coordinator.data = {} # 'clients' key missing
+    setup_hass_domain_data(hass, mock_config_entry.entry_id, mock_coordinator)
+    
+    mock_async_add_entities = AsyncMock()
+    
+    await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+    
+    mock_async_add_entities.assert_not_called()
+
+async def test_async_setup_entry_missing_client_mac(
+    hass: HomeAssistant, mock_coordinator: MagicMock, mock_config_entry: ConfigEntry
+):
+    """Test that clients with missing MAC addresses are skipped."""
+    client_missing_mac = MOCK_CLIENT_1.copy()
+    del client_missing_mac["mac"]
+    mock_coordinator.data = {"clients": [client_missing_mac, MOCK_CLIENT_2]}
+    setup_hass_domain_data(hass, mock_config_entry.entry_id, mock_coordinator)
+    
+    mock_async_add_entities = AsyncMock()
+    
+    await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+    
+    assert mock_async_add_entities.call_count == 1
+    created_entities = mock_async_add_entities.call_args[0][0]
+    assert len(created_entities) == 1
+    assert created_entities[0]._client_info_data["mac"] == MOCK_CLIENT_2["mac"]
+
+
+def test_meraki_device_tracker_properties_connected_to_ap(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test properties of a connected MerakiDeviceTracker linked to an AP."""
+    # Simulate client is initially present in coordinator data
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_1]} 
+    
+    tracker = MerakiDeviceTracker(mock_coordinator, MOCK_CLIENT_1)
+    tracker.hass = hass # Assign hass for entity registry linking
+    
+    assert tracker.unique_id == f"{MOCK_CLIENT_1['mac']}_client_tracker"
+    assert tracker.name == MOCK_CLIENT_1["description"]
+    assert tracker.is_connected is True
+    assert tracker.source_type == SourceType.ROUTER
+    assert tracker.icon == "mdi:lan-connect"
+    
+    device_info = tracker.device_info
+    assert device_info is not None
+    assert device_info["identifiers"] == {(DOMAIN, MOCK_CLIENT_1["ap_serial"])}
+    # The device_info name should refer to the parent device (AP in this case)
+    assert device_info["name"] == f"Meraki Client on {MOCK_CLIENT_1['ap_serial']}"
+    assert device_info["model"] == "Client Device"
+    assert device_info["manufacturer"] == MOCK_CLIENT_1["manufacturer"]
+
+def test_meraki_device_tracker_properties_connected_to_network(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test properties of a connected MerakiDeviceTracker linked to a Network."""
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_2]}
+    
+    tracker = MerakiDeviceTracker(mock_coordinator, MOCK_CLIENT_2)
+    tracker.hass = hass
+    
+    assert tracker.unique_id == f"{MOCK_CLIENT_2['mac']}_client_tracker"
+    assert tracker.name == MOCK_CLIENT_2["description"]
+    assert tracker.is_connected is True
+    
+    device_info = tracker.device_info
+    assert device_info is not None
+    # Linked to networkId as ap_serial is missing
+    assert device_info["identifiers"] == {(DOMAIN, MOCK_CLIENT_2["networkId"])}
+    assert device_info["name"] == f"Meraki Client on {MOCK_CLIENT_2['networkId']}"
+    assert device_info["model"] == "Client Device"
+    assert device_info["manufacturer"] == MOCK_CLIENT_2["manufacturer"]
+
+def test_meraki_device_tracker_properties_disconnected(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test properties when the client is not in the coordinator's data (disconnected)."""
+    # Client MOCK_CLIENT_1 is used to initialize, but not present in coordinator.data
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_2]} # MOCK_CLIENT_1 is not here
+    
+    tracker = MerakiDeviceTracker(mock_coordinator, MOCK_CLIENT_1)
+    tracker.hass = hass
+    
+    # _update_attributes would have been called in __init__
+    # based on the coordinator state at that time.
+    assert tracker.is_connected is False 
+    assert tracker.icon == "mdi:lan-disconnect"
+    assert tracker.name == MOCK_CLIENT_1["description"] # Name should still be from initial info
+
+
+def test_meraki_device_tracker_name_fallback(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test name fallback if description is missing."""
+    client_no_desc_ip_copy = MOCK_CLIENT_NO_DESC_IP.copy()
+    client_no_desc_ip_copy["ip"] = "192.168.1.103"
+    mock_coordinator.data = {"clients": [client_no_desc_ip_copy]}
+
+    tracker_ip = MerakiDeviceTracker(mock_coordinator, client_no_desc_ip_copy)
+    assert tracker_ip.name == "192.168.1.103"
+
+    client_no_desc_no_ip = MOCK_CLIENT_NO_DESC_IP.copy()
+    # 'ip' is not in client_no_desc_no_ip
+    mock_coordinator.data = {"clients": [client_no_desc_no_ip]}
+    tracker_mac = MerakiDeviceTracker(mock_coordinator, client_no_desc_no_ip)
+    # Based on current implementation, name attribute is set in init.
+    # If description and IP are None, _attr_name will be None.
+    # Home Assistant might then use entity_id or device name.
+    # For this test, we check it's None as per current code.
+    assert tracker_mac.name is None # Or it could be the MAC address if we want to implement that fallback for _attr_name
+
+
+async def test_coordinator_updates_client_disconnects(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test entity state update when a client disconnects."""
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_1]}
+    
+    tracker = MerakiDeviceTracker(mock_coordinator, MOCK_CLIENT_1)
+    tracker.hass = hass
+    tracker.async_write_ha_state = MagicMock() # Mock this method
+    
+    # Initial state
+    assert tracker.is_connected is True
+    assert tracker.icon == "mdi:lan-connect"
+    
+    # Simulate client disconnects - update coordinator data
+    mock_coordinator.data = {"clients": []} 
+    
+    # Manually call the update handler (as the actual coordinator update is mocked)
+    tracker._handle_coordinator_update()
+    # await hass.async_block_till_done() # Not strictly necessary here as we call directly
+    
+    assert tracker.is_connected is False
+    assert tracker.icon == "mdi:lan-disconnect"
+    tracker.async_write_ha_state.assert_called_once()
+
+async def test_coordinator_updates_client_connects(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test entity state update when a client connects."""
+    # Initially client is not present
+    mock_coordinator.data = {"clients": []}
+    
+    tracker = MerakiDeviceTracker(mock_coordinator, MOCK_CLIENT_1)
+    tracker.hass = hass
+    tracker.async_write_ha_state = MagicMock()
+    
+    assert tracker.is_connected is False
+    assert tracker.icon == "mdi:lan-disconnect"
+    
+    # Simulate client connects - update coordinator data
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_1]}
+    
+    tracker._handle_coordinator_update()
+    
+    assert tracker.is_connected is True
+    assert tracker.icon == "mdi:lan-connect"
+    tracker.async_write_ha_state.assert_called_once()
+
+async def test_coordinator_updates_client_info_changes(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+):
+    """Test entity state update when client information (e.g., description) changes."""
+    initial_client_data = MOCK_CLIENT_1.copy()
+    mock_coordinator.data = {"clients": [initial_client_data]}
+    
+    tracker = MerakiDeviceTracker(mock_coordinator, initial_client_data)
+    tracker.hass = hass
+    tracker.async_write_ha_state = MagicMock()
+    
+    assert tracker.name == MOCK_CLIENT_1["description"]
+    assert tracker._client_info_data["ip"] == MOCK_CLIENT_1["ip"]
+
+    # Simulate client info changes in coordinator data
+    updated_client_data = MOCK_CLIENT_1.copy()
+    updated_client_data["description"] = "Client One Updated"
+    updated_client_data["ip"] = "192.168.1.201" # IP also changed
+    mock_coordinator.data = {"clients": [updated_client_data]}
+    
+    tracker._handle_coordinator_update()
+    
+    # Name is set at __init__ and not updated by _handle_coordinator_update by default.
+    # This is standard HA behavior for `name` unless explicitly coded.
+    # The test confirms _client_info_data IS updated.
+    assert tracker.name == MOCK_CLIENT_1["description"] # Name remains initial
+    assert tracker._client_info_data["description"] == "Client One Updated"
+    assert tracker._client_info_data["ip"] == "192.168.1.201"
+    assert tracker.is_connected is True # Still connected
+    tracker.async_write_ha_state.assert_called_once()
+
+async def test_entity_added_to_platform_and_coordinator(
+    hass: HomeAssistant, mock_coordinator: MagicMock, mock_config_entry: ConfigEntry
+):
+    """Test that the entity correctly subscribes to coordinator updates when added."""
+    mock_coordinator.data = {"clients": [MOCK_CLIENT_1]}
+    setup_hass_domain_data(hass, mock_config_entry.entry_id, mock_coordinator)
+
+    # Patch the MerakiDeviceTracker's methods for subscribing to coordinator
+    with patch.object(MerakiDeviceTracker, 'async_added_to_hass', new_callable=AsyncMock) as mock_added_to_hass, \
+         patch.object(MerakiDeviceTracker, '_handle_coordinator_update', new=MagicMock()) as mock_handle_update:
+
+        mock_async_add_entities = AsyncMock()
+        await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+
+        assert mock_async_add_entities.call_count == 1
+        created_entities = mock_async_add_entities.call_args[0][0]
+        tracker = created_entities[0]
+
+        # Simulate Home Assistant adding the entity to the platform
+        await tracker.async_added_to_hass()
+
+        # Check that it called the original async_added_to_hass (which calls super)
+        mock_added_to_hass.assert_called_once()
+        
+        # Check that it registered itself with the coordinator
+        # This is implicitly tested by _handle_coordinator_update being callable
+        # and the fact that CoordinatorEntity.__init__ sets this up.
+        # We can also check if add_listener was called on coordinator by CoordinatorEntity.
+        # The CoordinatorEntity's async_added_to_hass calls self.coordinator.async_add_listener(self._handle_coordinator_update)
+        # So, if our mock_coordinator.async_add_listener was called, it means setup is correct.
+        mock_coordinator.async_add_listener.assert_called_with(tracker._handle_coordinator_update)
+        
+        # Also, the initial state should be set by calling _handle_coordinator_update
+        mock_handle_update.assert_called_once() # Called during __init__
+
+```


### PR DESCRIPTION
This commit introduces the ability to track individual client devices connected to Meraki networks.

Key changes:
- Modified `MerakiDeviceTracker` to represent individual clients, using their MAC address for unique identification. The entity now reflects the client's connection status.
- Updated `async_setup_entry` in `device_tracker.py` to create these client-specific tracker entities.
- Enhanced `MerakiApiDataFetcher` to retrieve a list of active clients from the Meraki API, including details like MAC, IP, description, and connected AP. This data is now part of the overall data fetched by the coordinator.
- Added a comprehensive suite of unit tests in `tests/test_device_tracker.py` to validate the new client tracking functionality, including entity creation, property correctness, and response to coordinator updates.

This allows you to create automations and gain insights based on the presence and connectivity of individual client devices within your Meraki networks.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
