### PR TITLE
fix: Correct capitalization for getOrganizationDevices method

### DIFF
--- a/custom_components/meraki_ha/coordinators/api_data_fetcher.py
+++ b/custom_components/meraki_ha/coordinators/api_data_fetcher.py
@@ -369,7 +369,7 @@ class MerakiApiDataFetcher:
         """
         _LOGGER.debug("Fetching organization devices for org ID: %s using SDK", org_id)
         try:
-            return await self.meraki_client.organizations.get_organization_devices(
+            return await self.meraki_client.organizations.getOrganizationDevices(
                 organization_id=org_id
             )
         except MerakiSDKAPIError as e:

--- a/custom_components/meraki_ha/tests/test_api_data_fetcher.py
+++ b/custom_components/meraki_ha/tests/test_api_data_fetcher.py
@@ -67,13 +67,13 @@ async def test_async_get_organization_devices_success(
     data_fetcher: MerakiApiDataFetcher, mock_meraki_client: MagicMock
 ):
     """Test successful fetching of organization devices."""
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(
         return_value=MOCK_ORG_DEVICES
     )
     
     result = await data_fetcher.async_get_organization_devices(org_id="test_org_id")
     
-    mock_meraki_client.organizations.get_organization_devices.assert_called_once_with(
+    mock_meraki_client.organizations.getOrganizationDevices.assert_called_once_with(
         organization_id="test_org_id"
     )
     assert result == MOCK_ORG_DEVICES
@@ -82,7 +82,7 @@ async def test_async_get_organization_devices_api_error(
     data_fetcher: MerakiApiDataFetcher, mock_meraki_client: MagicMock, caplog
 ):
     """Test API error when fetching organization devices."""
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(
         side_effect=MerakiSDKAPIError(MagicMock(status=500, reason="Server Error"), "test API error")
     )
     
@@ -97,7 +97,7 @@ async def test_async_get_organization_devices_unexpected_exception(
     data_fetcher: MerakiApiDataFetcher, mock_meraki_client: MagicMock, caplog
 ):
     """Test unexpected exception when fetching organization devices."""
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(
         side_effect=Exception("Something broke badly")
     )
     
@@ -279,7 +279,7 @@ async def test_fetch_all_data_success(
     """Test successful fetching of all data types."""
     # Setup mocks for all underlying fetch methods
     mock_meraki_client.organizations.getOrganizationNetworks = AsyncMock(return_value=MOCK_NETWORKS)
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(return_value=MOCK_ORG_DEVICES)
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(return_value=MOCK_ORG_DEVICES)
     
     # Mock SSIDs for each network
     def mock_get_ssids(network_id):
@@ -341,7 +341,7 @@ async def test_fetch_all_data_devices_fail(
 ):
     """Test fetch_all_data when fetching devices fails."""
     mock_meraki_client.organizations.getOrganizationNetworks = AsyncMock(return_value=MOCK_NETWORKS) # Networks succeed
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(return_value=None) # Devices fail
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(return_value=None) # Devices fail
     hass_mock_instance = MagicMock()
 
     with pytest.raises(UpdateFailed) as excinfo:
@@ -355,7 +355,7 @@ async def test_fetch_all_data_ssids_fail_for_one_network(
 ):
     """Test fetch_all_data when fetching SSIDs fails for one network but continues for others."""
     mock_meraki_client.organizations.getOrganizationNetworks = AsyncMock(return_value=MOCK_NETWORKS)
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(return_value=MOCK_ORG_DEVICES)
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(return_value=MOCK_ORG_DEVICES)
     mock_meraki_client.networks.get_network_clients = AsyncMock(return_value=[]) # No clients for simplicity here
 
     # SSIDs for N_123 fail, N_124 succeed
@@ -384,7 +384,7 @@ async def test_fetch_all_data_clients_fail_for_one_network(
 ):
     """Test fetch_all_data when fetching clients fails for one network."""
     mock_meraki_client.organizations.getOrganizationNetworks = AsyncMock(return_value=MOCK_NETWORKS)
-    mock_meraki_client.organizations.get_organization_devices = AsyncMock(return_value=MOCK_ORG_DEVICES)
+    mock_meraki_client.organizations.getOrganizationDevices = AsyncMock(return_value=MOCK_ORG_DEVICES)
     mock_meraki_client.wireless.get_network_wireless_ssids = AsyncMock(return_value=[]) # No SSIDs
 
     def mock_get_clients_partial_fail(network_id, timespan):


### PR DESCRIPTION
Corrected a capitalization error in the Meraki API call for fetching organization-wide devices. The method name was changed from `get_organization_devices` (snake_case) to the correct `getOrganizationDevices` (camelCase) in `MerakiApiDataFetcher.py`.

This resolves an `AttributeError` that occurred because the SDK uses camelCase for this specific method on the `AsyncOrganizations` object.

The corresponding mocks in the unit tests
(`test_api_data_fetcher.py`) have also been verified to use the correct camelCase method name, ensuring test alignment with the fix.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
