### PR TITLE
I've made a fix to correct how parameters are passed to `getOrganizat…

### DIFF
--- a/custom_components/meraki_ha/coordinators/api_data_fetcher.py
+++ b/custom_components/meraki_ha/coordinators/api_data_fetcher.py
@@ -370,7 +370,7 @@ class MerakiApiDataFetcher:
         _LOGGER.debug("Fetching organization devices for org ID: %s using SDK", org_id)
         try:
             return await self.meraki_client.organizations.getOrganizationDevices(
-                organization_id=org_id
+                org_id
             )
         except MerakiSDKAPIError as e:
             _LOGGER.warning(

--- a/custom_components/meraki_ha/tests/test_api_data_fetcher.py
+++ b/custom_components/meraki_ha/tests/test_api_data_fetcher.py
@@ -74,7 +74,7 @@ async def test_async_get_organization_devices_success(
     result = await data_fetcher.async_get_organization_devices(org_id="test_org_id")
     
     mock_meraki_client.organizations.getOrganizationDevices.assert_called_once_with(
-        organization_id="test_org_id"
+        "test_org_id"
     )
     assert result == MOCK_ORG_DEVICES
 


### PR DESCRIPTION
…ionDevices`.

This resolves a `TypeError` that was happening when the `getOrganizationDevices` method was called. The `organizationId` parameter is now passed as a positional argument instead of a keyword argument.

The method call in `MerakiApiDataFetcher.async_get_organization_devices` was changed from: `getOrganizationDevices(organization_id=org_id)`
to:
`getOrganizationDevices(org_id)`

Additionally, the corresponding mock call assertions in the unit tests (`test_api_data_fetcher.py`) have been updated to reflect this change, ensuring that `assert_called_once_with("test_org_id")` is used.

This addresses the "missing 1 required positional argument: 'organizationId'" error and ensures devices can be fetched correctly for an organization.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
