### PR TITLE
Fix NameError in sensor.network_clients

### DIFF
--- a/custom_components/meraki_ha/sensor/network_clients.py
+++ b/custom_components/meraki_ha/sensor/network_clients.py
@@ -5,7 +5,7 @@ represents a sensor in Home Assistant displaying the number of clients
 connected to a specific Meraki network.
 """
 import logging # Added logging
-from typing import Any, Optional # Added Optional, Any
+from typing import Any, Optional, Dict
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import callback # For coordinator updates


### PR DESCRIPTION
Corrects a NameError for 'Dict' in
`custom_components/meraki_ha/sensor/network_clients.py` by ensuring `Dict` is imported from the `typing` module.

This error was causing the sensor platform to fail during import. Other sensor files were reviewed and their typing imports appear correct.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
