### PR TITLE
Fix ModuleNotFoundError for coordinator imports

### DIFF
--- a/custom_components/meraki_ha/device_tracker.py
+++ b/custom_components/meraki_ha/device_tracker.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 # Assuming MerakiDataUpdateCoordinator is the central coordinator for
 # the Meraki integration and it's correctly defined in .coordinator
 from .const import DATA_COORDINATOR, DOMAIN
-from .coordinator import MerakiDataUpdateCoordinator
+from .coordinators import MerakiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/network_setup.py
+++ b/custom_components/meraki_ha/network_setup.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 # The import `from .coordinators import MerakiCoordinator, async_create_meraki_network_devices`
 # suggests MerakiCoordinator might be an alias or a base type.
 # For this context, we'll assume MerakiDataUpdateCoordinator is the intended concrete type.
-from .coordinator import MerakiDataUpdateCoordinator
+from .coordinators import MerakiDataUpdateCoordinator
 # The function `async_create_meraki_network_devices` seems to be missing from
 # the provided file structure in `.coordinators` or needs to be defined/imported correctly.
 # For now, I will assume it's available and correctly imported for the purpose of docstrings.

--- a/custom_components/meraki_ha/switch/__init__.py
+++ b/custom_components/meraki_ha/switch/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 # Import constants and the central data coordinator
 from ..const import ATTR_SSIDS, DATA_COORDINATOR, DOMAIN
-from ..coordinator import MerakiDataUpdateCoordinator
+from ..coordinators import MerakiDataUpdateCoordinator
 # Import the specific switch entity and any utility functions
 from .ssid_switch import MerakiSSIDSwitch, match_device_to_ssid
 

--- a/custom_components/meraki_ha/switch/ssid_switch.py
+++ b/custom_components/meraki_ha/switch/ssid_switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity # Changed from DataUpdateCoordinator
 
 # Assuming MerakiDataUpdateCoordinator is the specific coordinator type
-from ..coordinator import MerakiDataUpdateCoordinator
+from ..coordinators import MerakiDataUpdateCoordinator
 from ..const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Corrects the import path for `MerakiDataUpdateCoordinator` and other potential coordinator imports across multiple files. The path was changed from using a singular `.coordinator` or `..coordinator` to the correct plural form `.coordinators` or `..coordinators` to match the directory structure.

This resolves `ModuleNotFoundError` errors that were occurring during the setup of various platforms (device_tracker, switch) and in other modules like network_setup.py.

Affected files include:
- device_tracker.py
- network_setup.py
- switch/__init__.py
- switch/ssid_switch.py

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
