### PR TITLE
Implement device name formatting option

### DIFF
--- a/custom_components/meraki_ha/coordinators/base_coordinator.py
+++ b/custom_components/meraki_ha/coordinators/base_coordinator.py
@@ -117,6 +117,10 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         # Ensure `self.data` is initialized to an empty dict, as expected by DataUpdateCoordinator.
         self.data: Dict[str, Any] = {}
 
+    @property
+    def device_name_format(self) -> str:
+        """Return the device name format option."""
+        return self.config_entry.options.get("device_name_format", "omitted")
 
     async def _async_update_data(self) -> Dict[str, Any]:
         """Fetch, process, and aggregate data from the Meraki API.


### PR DESCRIPTION
This commit enables the "Device Name Format" option (prefix, suffix, omitted) for Meraki devices in Home Assistant.

Changes:
- Added a `device_name_format` property to `MerakiDataUpdateCoordinator` to retrieve the current setting from config entry options.
- Modified `MerakiEntity.device_info` to:
    - Fetch the `device_name_format` option via the coordinator.
    - Use `map_meraki_model_to_device_type` to get a displayable device type (e.g., "Switch", "Wireless").
    - Apply the prefix or suffix to the device name if the option is set accordingly and the device type is known.
    - Use this formatted name when providing `DeviceInfo` for physical Meraki devices.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
