### PR TITLE
Fix AttributeError in MerakiDeviceTracker icon property

### DIFF
--- a/custom_components/meraki_ha/device_tracker.py
+++ b/custom_components/meraki_ha/device_tracker.py
@@ -189,4 +189,4 @@ class MerakiDeviceTracker(
     @property
     def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
-        return "mdi:lan-connect" if self.is_connected else "mdi:lan-disconnect"
+        return "mdi:lan-connect" if self._attr_is_connected else "mdi:lan-disconnect"


### PR DESCRIPTION
Changes the `icon` property in the `MerakiDeviceTracker` class (in `custom_components/meraki_ha/device_tracker.py`) to use `self._attr_is_connected` instead of `self.is_connected`.

This resolves an `AttributeError` that occurred during entity setup because `self.is_connected` was not yet available, while `self._attr_is_connected` (which is set in `__init__` via `_update_attributes`) is.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
