### PR TITLE
I will fix the device naming conflict caused by MerakiDeviceTracker.

### DIFF
--- a/custom_components/meraki_ha/device_tracker.py
+++ b/custom_components/meraki_ha/device_tracker.py
@@ -174,15 +174,7 @@ class MerakiDeviceTracker(
 
         return {
             "identifiers": {(DOMAIN, parent_identifier_value)},
-            # The name of this client device entity itself is handled by _attr_name
-            # This device_info is for the parent/associated device in HA.
-            # For clarity, we can use a generic name for the client "device" type
-            # or specific if available (e.g. from 'ap_name')
-            "name": f"Meraki Client on {parent_identifier_value}", # This name is for the device entry this entity is linked to
-            "manufacturer": self._client_info_data.get("manufacturer", "Unknown Manufacturer"), # TODO: derive from MAC if possible
-            "model": "Client Device",
-            # No firmware version for a client device in this context
-            # "sw_version": "", 
+            # No 'name', 'manufacturer', or 'model' for the parent device here
         }
 
     # Icon can be dynamic based on connection state


### PR DESCRIPTION
I will modify the `device_info` property in the `MerakiDeviceTracker` class (in `custom_components/meraki_ha/device_tracker.py`) to only return device identifiers. The `name`, `model`, and `manufacturer` keys will be removed from the returned dictionary.

This will prevent the device tracker entities from attempting to name their parent devices (e.g., Access Points or Switches), which was conflicting with and overriding the correctly formatted names provided by other entities inheriting from the `MerakiEntity` base class.

The physical Meraki devices should now consistently get their names (respecting the 'device_name_format' option) from entities like `MerakiDeviceStatusSensor`.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
