### PR TITLE
[patch] I've resolved the hassfest manifest error and version bumping failures.

### DIFF
--- a/.github/workflows/version_and_release.yaml
+++ b/.github/workflows/version_and_release.yaml
@@ -65,8 +65,30 @@ jobs:
           fi
           echo "Increment Type: $increment_type"
 
-          # Bump version in manifest.json
-          bump2version --verbose --allow-dirty "$increment_type" custom_components/meraki_ha/manifest.json
+          # Calculate the new version based on current_version and increment_type
+          calculated_new_version_string=""
+          # Ensure current_version is in X.Y.Z format, otherwise this parsing will fail or produce unexpected results.
+          # Consider adding error handling or validation for current_version format if necessary.
+          IFS='.' read -r -a version_parts <<< "$current_version"
+          major_part=${version_parts[0]}
+          minor_part=${version_parts[1]}
+          patch_part=${version_parts[2]}
+
+          if [[ "$increment_type" == "major" ]]; then
+            major_part=$((major_part + 1))
+            minor_part=0
+            patch_part=0
+          elif [[ "$increment_type" == "minor" ]]; then
+            minor_part=$((minor_part + 1))
+            patch_part=0
+          elif [[ "$increment_type" == "patch" ]]; then
+            patch_part=$((patch_part + 1))
+          fi
+          calculated_new_version_string="$major_part.$minor_part.$patch_part"
+          echo "Calculated New Version String: $calculated_new_version_string"
+
+          # Bump version in manifest.json using the calculated new version
+          bump2version --verbose --allow-dirty --current-version "$current_version" --new-version "$calculated_new_version_string" custom_components/meraki_ha/manifest.json
           
           base_version=$(jq -r .version custom_components/meraki_ha/manifest.json)
           echo "Base Version from manifest after bump: $base_version"


### PR DESCRIPTION
Here's what I did:

- In `custom_components/meraki_ha/manifest.json`:
    - I removed the deprecated `platforms` key to meet `hassfest` validation requirements.

- In `.github/workflows/version_and_release.yaml`:
    - I modified the 'Increment Version' step to manually calculate the target version (major, minor, patch) based on the current version from the manifest.
    - I changed the `bump2version` command to use explicit `--current-version` and `--new-version` arguments, along with the file path. This will ensure reliable version updating.
    - This change addresses previous issues where `bump2version` was not correctly interpreting the 'part' argument.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
