### PR TITLE
[patch] Fix: Correct strings.json structure for hassfest validation

### DIFF
--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -46,17 +46,15 @@
     }
   },
   "state": {
-    "sensor": {
-      "meraki_wan1_connectivity": {
-        "connected": "Connected",
-        "disconnected": "Disconnected",
-        "unknown": "Unknown"
-      },
-      "meraki_wan2_connectivity": {
-        "connected": "Connected",
-        "disconnected": "Disconnected",
-        "unknown": "Unknown"
-      }
+    "sensor__meraki_wan1_connectivity": {
+      "connected": "Connected",
+      "disconnected": "Disconnected",
+      "unknown": "Unknown"
+    },
+    "sensor__meraki_wan2_connectivity": {
+      "connected": "Connected",
+      "disconnected": "Disconnected",
+      "unknown": "Unknown"
     }
   }
 }


### PR DESCRIPTION
The 'state' section in `custom_components/meraki_ha/strings.json` was causing a validation error with `hassfest` due to an incorrect structure. The error indicated "extra keys not allowed @ data['state']" because of a nested 'sensor' key.

This commit restructures the 'state' section by removing the intermediary 'sensor' key and prefixing the actual state keys (e.g., `meraki_wan1_connectivity`) with `sensor__` to follow the expected format for sensor states.

For example:
`state.sensor.meraki_wan1_connectivity` is now
`state.sensor__meraki_wan1_connectivity`.

The TurboJPEG warning observed in the build logs was also investigated. It appears to be an issue related to the `ghcr.io/home-assistant/hassfest` Docker image environment lacking `libturbojpeg-dev` or having a configuration issue. This cannot be directly addressed by changes in this repository. The primary build failure was due to the `strings.json` format.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
