### PR TITLE
[patch] Fix(camera): Append /live to Meraki camera RTSP stream URL

The RTSP stream URL for Meraki cameras was missing the `/live` path at the end, which prevented them from streaming correctly in Home Assistant.

This commit fixes the issue by appending `/live` to the RTSP URL in both the camera entity and the RTSP URL sensor.

The tests for the camera and the RTSP URL sensor have been updated to reflect this change. A new test case has also been added to handle the scenario where RTSP is enabled but no URL is provided from the API.

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -217,18 +217,23 @@ class MerakiCamera(CoordinatorEntity[MerakiDataCoordinator], Camera):
                     self._attr_model
                 ).startswith("MV2"):
                     public_rtsp_url = video_settings.get("rtspUrl")
-                    if self._use_lan_ip_for_rtsp:
-                        lan_ip = self._device.get("lanIp")
-                        if lan_ip:
-                            parsed_url = urlparse(public_rtsp_url)
-                            port = parsed_url.port
-                            self._rtsp_url = f"rtsp://{lan_ip}:{port}"
+                    if public_rtsp_url:
+                        if self._use_lan_ip_for_rtsp:
+                            lan_ip = self._device.get("lanIp")
+                            if lan_ip:
+                                parsed_url = urlparse(public_rtsp_url)
+                                port = parsed_url.port
+                                self._rtsp_url = f"rtsp://{lan_ip}:{port}/live"
+                            else:
+                                self._rtsp_url = f"{public_rtsp_url}/live"
                         else:
-                            self._rtsp_url = public_rtsp_url
+                            self._rtsp_url = f"{public_rtsp_url}/live"
+                        self._attr_supported_features |= CameraEntityFeature.STREAM
+                        self._attr_is_streaming = True
                     else:
-                        self._rtsp_url = public_rtsp_url
-                    self._attr_supported_features |= CameraEntityFeature.STREAM
-                    self._attr_is_streaming = True
+                        self._rtsp_url = None
+                        self._attr_supported_features &= ~CameraEntityFeature.STREAM
+                        self._attr_is_streaming = False
                 else:
                     self._rtsp_url = None
                     self._attr_supported_features &= ~CameraEntityFeature.STREAM

--- a/custom_components/meraki_ha/sensor/device/camera_rtsp_url.py
+++ b/custom_components/meraki_ha/sensor/device/camera_rtsp_url.py
@@ -61,8 +61,8 @@ class MerakiCameraRTSPUrlSensor(CoordinatorEntity[MerakiDataCoordinator], Sensor
             is_rtsp_enabled = video_settings.get("externalRtspEnabled", False)
             rtsp_url = video_settings.get("rtspUrl")
 
-            if is_rtsp_enabled:
-                self._attr_native_value = rtsp_url
+            if is_rtsp_enabled and rtsp_url:
+                self._attr_native_value = f"{rtsp_url}/live"
             else:
                 self._attr_native_value = None
         else:

--- a/tests/sensor/device/test_camera_rtsp_url.py
+++ b/tests/sensor/device/test_camera_rtsp_url.py
@@ -36,12 +36,24 @@ def mock_device_coordinator():
             "rtspUrl": None,
         },
     }
+    device3_data = {
+        "serial": "cam3",
+        "name": "Camera 3",
+        "model": "MV12",
+        "productType": "camera",
+        "video_settings": {
+            "externalRtspEnabled": True,
+            "rtspUrl": None,
+        },
+    }
 
     def get_device(serial):
         if serial == "cam1":
             return device1_data
         if serial == "cam2":
             return device2_data
+        if serial == "cam3":
+            return device3_data
         return None
 
     coordinator.get_device = MagicMock(side_effect=get_device)
@@ -53,15 +65,22 @@ def test_camera_rtsp_url_sensor(mock_device_coordinator):
     """Test the camera RTSP URL sensor."""
     device1 = {"serial": "cam1", "name": "Camera"}
     device2 = {"serial": "cam2", "name": "Camera 2"}
+    device3 = {"serial": "cam3", "name": "Camera 3"}
 
     sensor1 = MerakiCameraRTSPUrlSensor(mock_device_coordinator, device1)
     sensor1._update_state()
     assert sensor1.unique_id == "cam1_rtsp_url"
     assert sensor1.name == "Camera RTSP Stream URL"
-    assert sensor1.native_value == "rtsp://..."
+    assert sensor1.native_value == "rtsp://.../live"
 
     sensor2 = MerakiCameraRTSPUrlSensor(mock_device_coordinator, device2)
     sensor2._update_state()
     assert sensor2.unique_id == "cam2_rtsp_url"
     assert sensor2.name == "Camera 2 RTSP Stream URL"
     assert sensor2.native_value is None
+
+    sensor3 = MerakiCameraRTSPUrlSensor(mock_device_coordinator, device3)
+    sensor3._update_state()
+    assert sensor3.unique_id == "cam3_rtsp_url"
+    assert sensor3.name == "Camera 3 RTSP Stream URL"
+    assert sensor3.native_value is None


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
