### PR TITLE
fix(deps): Unpin pytest to resolve dependency conflict

Unpins the `pytest` version in `requirements_dev.txt` to resolve a `ResolutionImpossible` error during installation.

The previously pinned version (`8.4.2`) conflicted with other packages, preventing the installation of development dependencies. Removing the pin allows `pip` to select a compatible version of `pytest`, which unblocks the environment setup.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ voluptuous==0.15.2
 pyyaml==6.0.3
 playwright
 pytest-homeassistant-custom-component
-pytest==8.4.2
+pytest
 pytest-cov
 pytest-asyncio
 codecov


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
