### PR TITLE
refactor: centralize frontend panel registration

### DIFF
--- a/custom_components/meraki_ha/frontend.py
+++ b/custom_components/meraki_ha/frontend.py
@@ -1,0 +1,48 @@
+"""Starting setup task: Frontend."""
+from __future__ import annotations
+import json
+from pathlib import Path
+import aiofiles
+from homeassistant.core import HomeAssistant
+from homeassistant.components import frontend
+from homeassistant.components.http import StaticPathConfig
+from homeassistant.config_entries import ConfigEntry
+from .const import DOMAIN
+
+async def async_register_frontend(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Register the frontend."""
+    # Setup panel
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                url_path=f"/api/panel_custom/{DOMAIN}",
+                path=str(Path(__file__).parent / "www"),
+                cache_headers=False,
+            ),
+        ],
+    )
+
+    # Register panel
+    manifest_path = Path(__file__).parent / "manifest.json"
+    async with aiofiles.open(manifest_path, encoding="utf-8") as f:
+        manifest_data = await f.read()
+        manifest = json.loads(manifest_data)
+    version = manifest.get("version", "0.0.0")
+    module_url = f"/api/panel_custom/{DOMAIN}/meraki-panel.js?v={version}"
+    frontend.async_register_built_in_panel(
+        hass,
+        component_name="custom",
+        sidebar_title=entry.title,
+        sidebar_icon="mdi:router-network",
+        frontend_url_path="meraki",
+        config={
+            "_panel_custom": {
+                "name": "meraki-panel",
+                "module_url": module_url,
+                "embed_iframe": False,
+                "trust_external_script": True,
+            },
+            "config_entry_id": entry.entry_id,
+        },
+        require_admin=True,
+    )


### PR DESCRIPTION
Refactored the frontend panel registration by moving all related logic from `__init__.py` to a new `frontend.py` file. This change improves code organization and separation of concerns, following the best practices established by the HACS integration.

The new `async_register_frontend` function in `frontend.py` now handles the registration of the static path and the custom panel. The `__init__.py` file has been updated to call this new function, resulting in a cleaner and more maintainable codebase.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
