### PR TITLE
feat: configure dependabot to target beta branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,9 @@ updates:
     schedule:
       interval: daily
       time: '06:00'
-    prefix-add: '[patch]'
+    commit-message:
+      prefix: '[patch]'
+    target-branch: "beta"
   - package-ecosystem: "docker"
     # Location of the Dockerfile
     directory: "/docker-runner"
@@ -15,7 +17,7 @@ updates:
     # The image to monitor for new releases. 
     # Dependabot tracks the versions of the 'actions/runner' on GitHub.
     # It detects that the ARG is tied to this dependency.
-    target-branch: "main" 
+    target-branch: "beta"
     labels:
       - "runner-update"
       - "dependencies"
@@ -24,3 +26,5 @@ updates:
       args:
         # Monitored ARG variable name (must match your Dockerfile)
         - RUNNER_VERSION
+    commit-message:
+      prefix: '[patch]'


### PR DESCRIPTION
Configures dependabot to target the beta branch by default, and to use the prefix [patch] on its merge requests.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
