### PR TITLE
fix: Restore missing SSID entities

### DIFF
--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -166,7 +166,9 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ]
             if "ssids" in data:
                 data["ssids"] = [
-                    s for s in data["ssids"] if s.get("networkId") in enabled_network_ids
+                    s
+                    for s in data["ssids"]
+                    if s.get("networkId") in enabled_network_ids
                 ]
 
     async def _async_remove_disabled_devices(self, data: dict[str, Any]) -> None:


### PR DESCRIPTION
This commit fixes a regression where SSID entities would disappear when networks were disabled.

The `_filter_enabled_networks` function in the `MerakiDataUpdateCoordinator` was only filtering the `networks` list and not the `devices` or `ssids` lists. This caused an inconsistency where the integration would attempt to set up SSID entities for disabled networks, fail because the network data was missing, and ultimately not create any SSID entities at all.

The fix extends the filtering logic to the `devices` and `ssids` lists, ensuring that only data related to enabled networks is processed.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
