### PR TITLE
fix: Synchronize 'Enabled Networks' config with web UI

### DIFF
--- a/custom_components/meraki_ha/web_api.py
+++ b/custom_components/meraki_ha/web_api.py
@@ -107,6 +107,10 @@ async def handle_get_config(
     ]
     config_entry = hass.config_entries.async_get_entry(config_entry_id)
     enabled_networks = config_entry.options.get(CONF_ENABLED_NETWORKS)
+    if enabled_networks is None:
+        enabled_networks = [
+            n["id"] for n in coordinator.data.get("networks", []) if "id" in n
+        ]
 
     manifest_path = os.path.join(os.path.dirname(__file__), "manifest.json")
     async with aiofiles.open(manifest_path, mode="r") as f:


### PR DESCRIPTION
This commit fixes a bug where the "Enabled Networks" configuration was not correctly synchronized with the toggle buttons in the web UI.

The `websocket_get_config` function in `web_api.py` was sending `null` to the frontend when the `enabled_networks` option was not set, while the data coordinator was correctly defaulting to all networks being enabled. This caused a state mismatch.

The fix ensures that the WebSocket API provides a consistent default for the `enabled_networks` list. If the configuration option is not set, it will now default to a list of all available network IDs, mirroring the logic in the data coordinator. This ensures that the UI accurately reflects the backend state.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
