### PR TITLE
fix: Pass hass object to MerakiAPIClient constructor

- Updated the `MerakiAPIClient` instantiation in `custom_components/meraki_ha/__init__.py` to pass the `hass` object, as required by the updated constructor. This resolves a `TypeError` that was preventing the integration from loading.

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -50,6 +50,7 @@ async def async_setup_or_update_entry(hass: HomeAssistant, entry: ConfigEntry) -
     try:
         if DATA_CLIENT not in entry_data:
             entry_data[DATA_CLIENT] = MerakiAPIClient(
+                hass,
                 api_key=entry.data[CONF_MERAKI_API_KEY],
                 org_id=entry.data[CONF_MERAKI_ORG_ID],
             )


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
