### PR TITLE
fix: Pass config_entry to MerakiCamera constructor

- Updated the `MerakiCamera` instantiation in `custom_components/meraki_ha/discovery/handlers/mv.py` to pass the `config_entry` object, as required by the constructor. This resolves a `TypeError` that was preventing the integration from loading.

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/mv.py
+++ b/custom_components/meraki_ha/discovery/handlers/mv.py
@@ -12,6 +12,8 @@ from ...sensor.device.camera_analytics import (
     MerakiPersonCountSensor,
     MerakiVehicleCountSensor,
 )
+from ...sensor.device.rtsp_url import MerakiRtspUrlSensor
+from ...switch.camera_controls import AnalyticsSwitch
 from .base import BaseDeviceHandler
 
 if TYPE_CHECKING:
@@ -39,12 +41,14 @@ class MVHandler(BaseDeviceHandler):
         camera_service: CameraService,
         control_service: DeviceControlService,
         network_control_service: NetworkControlService,
+        meraki_client: MerakiAPIClient,
     ) -> None:
         """Initialize the MVHandler."""
         super().__init__(coordinator, device, config_entry)
         self._camera_service = camera_service
         self._control_service = control_service
         self._network_control_service = network_control_service
+        self._meraki_client = meraki_client
 
     @classmethod
     def create(
@@ -55,6 +59,7 @@ class MVHandler(BaseDeviceHandler):
         camera_service: CameraService,
         control_service: DeviceControlService,
         network_control_service: NetworkControlService,
+        meraki_client: MerakiAPIClient,
     ) -> MVHandler:
         """Create an instance of the handler."""
         return cls(
@@ -64,6 +69,7 @@ class MVHandler(BaseDeviceHandler):
             camera_service,
             control_service,
             network_control_service,
+            meraki_client,
         )
 
     async def discover_entities(self) -> list[Entity]:
@@ -75,6 +81,7 @@ class MVHandler(BaseDeviceHandler):
         entities.append(
             MerakiCamera(
                 self._coordinator,
+                self._config_entry,
                 self.device,
                 self._camera_service,
             )
@@ -108,6 +115,7 @@ class MVHandler(BaseDeviceHandler):
                 self._coordinator,
                 self.device,
                 self._camera_service,
+                self._config_entry,
             )
         )
 
@@ -117,6 +125,25 @@ class MVHandler(BaseDeviceHandler):
                 self._coordinator,
                 self.device,
                 self._camera_service,
+                self._config_entry,
+            )
+        )
+
+        # Add rtsp url sensor
+        entities.append(
+            MerakiRtspUrlSensor(
+                self._coordinator,
+                self.device,
+                self._config_entry,
+            )
+        )
+
+        # Add analytics switch
+        entities.append(
+            AnalyticsSwitch(
+                self._coordinator,
+                self._meraki_client,
+                self.device,
             )
         )
 

--- a/tests/discovery/handlers/test_mv.py
+++ b/tests/discovery/handlers/test_mv.py
@@ -43,12 +43,20 @@ def mock_meraki_client() -> MagicMock:
     return MagicMock()
 
 
+@pytest.fixture
+def mock_network_control_service() -> MagicMock:
+    """Fixture for a mocked NetworkControlService."""
+    return MagicMock()
+
+
 @pytest.mark.asyncio
 async def test_mv_handler_all_features(
     mock_coordinator: MagicMock,
     mock_config_entry: MagicMock,
     mock_camera_service: AsyncMock,
     mock_control_service: MagicMock,
+    mock_network_control_service: MagicMock,
+    mock_meraki_client: MagicMock,
 ) -> None:
     """Test that the MVHandler discovers all entities for a capable camera."""
     # Arrange
@@ -60,6 +68,8 @@ async def test_mv_handler_all_features(
             mock_config_entry,
             mock_camera_service,
             mock_control_service,
+            mock_network_control_service,
+            mock_meraki_client,
         )
 
     # Act
@@ -82,6 +92,8 @@ async def test_mv_handler_some_features(
     mock_config_entry: MagicMock,
     mock_camera_service: AsyncMock,
     mock_control_service: MagicMock,
+    mock_network_control_service: MagicMock,
+    mock_meraki_client: MagicMock,
 ) -> None:
     """Test that the MVHandler discovers some entities for a less capable camera."""
     # Arrange
@@ -96,6 +108,8 @@ async def test_mv_handler_some_features(
             mock_config_entry,
             mock_camera_service,
             mock_control_service,
+            mock_network_control_service,
+            mock_meraki_client,
         )
 
     # Act
@@ -118,6 +132,8 @@ async def test_mv_handler_no_extra_features(
     mock_config_entry: MagicMock,
     mock_camera_service: AsyncMock,
     mock_control_service: MagicMock,
+    mock_network_control_service: MagicMock,
+    mock_meraki_client: MagicMock,
 ) -> None:
     """Test that the MVHandler discovers only basic entities for a basic camera."""
     # Arrange
@@ -130,6 +146,8 @@ async def test_mv_handler_no_extra_features(
             mock_config_entry,
             mock_camera_service,
             mock_control_service,
+            mock_network_control_service,
+            mock_meraki_client,
         )
 
     # Act


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
