### PR TITLE
fix: Correct handler instantiation

### DIFF
--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -159,7 +159,6 @@ class DeviceDiscoveryService:
                     device,
                     self._config_entry,
                     self._control_service,
-                    self._network_control_service,
                 )
 
             entities = await handler.discover_entities()


### PR DESCRIPTION
- Updated the `MTHandler` instantiation in `custom_components/meraki_ha/discovery/service.py` to pass the correct number of arguments. This resolves a `TypeError` that was preventing the integration from loading.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
