### PR TITLE
fix(config_flow): Remove deprecated handler registration

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -25,7 +25,6 @@ from .schemas import CONFIG_SCHEMA, OPTIONS_SCHEMA
 _LOGGER = logging.getLogger(__name__)
 
 
-@config_entries.HANDLERS.register(DOMAIN)
 class ConfigFlowHandler(config_entries.ConfigFlow):
     """Handle a config flow for Meraki."""
 


### PR DESCRIPTION
Removed the `@config_entries.HANDLERS.register(DOMAIN)` decorator from the `ConfigFlowHandler`. This legacy method of registration was causing a critical failure in Home Assistant's modern integration loader, resulting in the misleading "Platform meraki_ha.config_flow not found" error.

By removing this decorator, the integration now relies on the standard discovery mechanism (`"config_flow": true` in `manifest.json`), which correctly and reliably loads the configuration flow. This change resolves the persistent startup failure.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
