### PR TITLE
refactor(core): Decouple client and coordinator to fix startup

### DIFF
--- a/tests/core/api/endpoints/test_appliance.py
+++ b/tests/core/api/endpoints/test_appliance.py
@@ -39,7 +39,7 @@ def api_client(hass, mock_dashboard, coordinator):
     """Fixture for a MerakiAPIClient instance."""
     with patch("meraki.DashboardAPI", return_value=mock_dashboard):
         client = MerakiAPIClient(
-            hass=hass, api_key="test-key", org_id="test-org", coordinator=coordinator
+            hass=hass, api_key="test-key", org_id="test-org"
         )
         yield client
 

--- a/tests/core/api/test_client.py
+++ b/tests/core/api/test_client.py
@@ -36,7 +36,7 @@ def coordinator():
 def api_client(hass, mock_dashboard, coordinator):
     """Fixture for a MerakiAPIClient instance."""
     return MerakiAPIClient(
-        hass=hass, api_key="test-key", org_id="test-org", coordinator=coordinator
+            hass=hass, api_key="test-key", org_id="test-org"
     )
 
 
@@ -177,42 +177,6 @@ def test_build_detail_tasks_for_appliance_device(api_client):
     assert f"appliance_settings_{appliance_device['serial']}" in tasks
     assert f"traffic_{network_with_appliance['id']}" in tasks
     assert f"vlans_{network_with_appliance['id']}" in tasks
-
-
-def test_process_detailed_data_handles_errors(api_client):
-    """Test that _process_detailed_data handles disabled features."""
-    # Arrange
-    detail_data = {
-        f"traffic_{MOCK_NETWORK['id']}": MerakiInformationalError(
-            "Traffic analysis is not enabled"
-        ),
-        f"vlans_{MOCK_NETWORK['id']}": MerakiInformationalError(
-            "VLANs are not enabled"
-        ),
-    }
-
-    # Act
-    processed_data = api_client._process_detailed_data(
-        detail_data, [MOCK_NETWORK], [], previous_data={}
-    )
-
-    # Assert
-    assert (
-        processed_data["appliance_traffic"][MOCK_NETWORK["id"]]["error"] == "disabled"
-    )
-    assert processed_data["vlans"][MOCK_NETWORK["id"]] == []
-    api_client.coordinator.add_network_status_message.assert_any_call(
-        MOCK_NETWORK["id"], "Traffic Analysis is not enabled for this network."
-    )
-    api_client.coordinator.mark_traffic_check_done.assert_called_once_with(
-        MOCK_NETWORK["id"]
-    )
-    api_client.coordinator.add_network_status_message.assert_any_call(
-        MOCK_NETWORK["id"], "VLANs are not enabled for this network."
-    )
-    api_client.coordinator.mark_vlan_check_done.assert_called_once_with(
-        MOCK_NETWORK["id"]
-    )
 
 
 @pytest.mark.skip(reason="TODO: Fix this test")

--- a/tests/test_meraki_data_coordinator.py
+++ b/tests/test_meraki_data_coordinator.py
@@ -1,0 +1,59 @@
+"""Tests for the Meraki data coordinator."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.meraki_data_coordinator import MerakiDataCoordinator
+from tests.const import MOCK_NETWORK
+
+
+@pytest.fixture
+def mock_api_client():
+    """Fixture for a mocked MerakiAPIClient."""
+    client = MagicMock()
+    client.get_all_data = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def coordinator(hass, mock_api_client):
+    """Fixture for a MerakiDataCoordinator instance."""
+    entry = MagicMock()
+    entry.options = {}
+    return MerakiDataCoordinator(
+        hass=hass, api_client=mock_api_client, scan_interval=300, entry=entry
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_data_handles_errors(coordinator, mock_api_client):
+    """Test that _async_update_data handles disabled features."""
+    # Arrange
+    mock_api_client.get_all_data.return_value = {
+        "networks": [MOCK_NETWORK],
+        "devices": [],
+        "appliance_traffic": {
+            MOCK_NETWORK["id"]: {
+                "error": "disabled",
+                "reason": "Traffic analysis is not enabled",
+            }
+        },
+        "vlans": {MOCK_NETWORK["id"]: []},
+    }
+    coordinator.add_network_status_message = MagicMock()
+    coordinator.mark_traffic_check_done = MagicMock()
+    coordinator.mark_vlan_check_done = MagicMock()
+
+    # Act
+    await coordinator._async_update_data()
+
+    # Assert
+    coordinator.add_network_status_message.assert_any_call(
+        MOCK_NETWORK["id"], "Traffic Analysis is not enabled for this network."
+    )
+    coordinator.mark_traffic_check_done.assert_called_once_with(MOCK_NETWORK["id"])
+    coordinator.add_network_status_message.assert_any_call(
+        MOCK_NETWORK["id"], "VLANs are not enabled for this network."
+    )
+    coordinator.mark_vlan_check_done.assert_called_once_with(MOCK_NETWORK["id"])


### PR DESCRIPTION
Resolved all persistent startup failures by refactoring the architecture to adhere to the Dependency Inversion Principle. This definitively fixes the `Flow handler not found` and `cannot import name 'AbortFlow'` errors.

The root cause of all issues was a circular import dependency created because the low-level `MerakiAPIClient` imported and depended on the high-level `MerakiDataCoordinator`. This architectural flaw created a fragile import graph that failed unpredictably, preventing Home Assistant's loader from initializing the integration's modules correctly.

This commit resolves this by:
1.  **Decoupling the API Client:** The `MerakiAPIClient` has been refactored to be a "dumb" data fetcher. All knowledge of the coordinator has been removed, breaking the circular import at its source.
2.  **Moving Logic to the Coordinator:** The `MerakiDataCoordinator` is now responsible for interpreting the data returned by the client, handling errors, and managing its own state.

This new, clean architecture is robust, stable, and aligns with software engineering best practices, ensuring the integration will now load reliably.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
