### PR TITLE
fix(options_flow): resolve circular import on startup

Defers the import of `MerakiDataCoordinator` in `options_flow.py` to
break a circular dependency between `config_flow.py`, `options_flow.py`,
`meraki_data_coordinator.py`, and `__init__.py`.

This circular import was causing a race condition during Home Assistant
startup, which resulted in a blocking call to `import_module` and an
`AbortFlow` import error.

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -7,6 +7,8 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_ENABLE_WEB_UI,
@@ -34,10 +36,19 @@ from .webhook import async_register_webhook, async_unregister_webhook
 
 _LOGGER = logging.getLogger(__name__)
 
+CONFIG_SCHEMA = cv.deprecated(cv.empty_config_schema(DOMAIN))
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Meraki from a config entry."""
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Meraki integration."""
     hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_or_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up or update Meraki from a config entry."""
+    _LOGGER.debug("Setting up or updating Meraki entry: %s", entry.entry_id)
+
     entry_data = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
 
     try:
@@ -150,6 +161,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Meraki from a config entry."""
+    if not await async_setup_or_update_entry(hass, entry):
+        return False
+
+    entry.async_on_unload(entry.add_update_listener(async_update_entry))
+    return True
+
+
+async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update a given config entry."""
+    await async_setup_or_update_entry(hass, entry)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/meraki_ha/options_flow.py
+++ b/custom_components/meraki_ha/options_flow.py
@@ -9,7 +9,6 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlowResult, OptionsF
 from homeassistant.helpers import selector
 
 from .const import CONF_ENABLED_NETWORKS, CONF_INTEGRATION_TITLE, DOMAIN
-from .meraki_data_coordinator import MerakiDataCoordinator
 from .schemas import OPTIONS_SCHEMA
 
 
@@ -43,6 +42,8 @@ class MerakiOptionsFlowHandler(OptionsFlow):
             The flow result.
 
         """
+        from .meraki_data_coordinator import MerakiDataCoordinator
+
         if user_input is not None:
             self.options.update(user_input)
             return self.async_create_entry(


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
