### PR TITLE
fix(startup): Resolve circular dependency and modernize setup

This commit resolves a persistent startup error by addressing two separate issues: a circular dependency and an outdated integration setup process.

- **Circular Dependency:** Defers the import of `MerakiDataCoordinator` in
  `options_flow.py` to break a circular dependency between
  `config_flow.py`, `options_flow.py`, `meraki_data_coordinator.py`, and
  `__init__.py`. This was the root cause of the `AbortFlow` import error.

- **Modernize Setup:** Refactors `__init__.py` to align with modern Home
  Assistant best practices by:
  - Removing the legacy `async_setup` function.
  - Removing the deprecated `CONFIG_SCHEMA`.
  - Simplifying the update listener to use `async_reload_entry`.

These changes together ensure a stable and reliable startup process.

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -36,19 +36,10 @@ from .webhook import async_register_webhook, async_unregister_webhook
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = cv.deprecated(cv.empty_config_schema(DOMAIN))
 
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Meraki integration."""
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Meraki from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    return True
-
-
-async def async_setup_or_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up or update Meraki from a config entry."""
-    _LOGGER.debug("Setting up or updating Meraki entry: %s", entry.entry_id)
-
     entry_data = hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
 
     try:
@@ -160,21 +151,14 @@ async def async_setup_or_update_entry(hass: HomeAssistant, entry: ConfigEntry) -
             entry, data={**entry.data, "webhook_id": webhook_id, "secret": secret}
         )
 
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Meraki from a config entry."""
-    if not await async_setup_or_update_entry(hass, entry):
-        return False
-
-    entry.async_on_unload(entry.add_update_listener(async_update_entry))
-    return True
-
-
-async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Update a given config entry."""
-    await async_setup_or_update_entry(hass, entry)
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when it has changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
