### PR TITLE
fix(ci): install jq in deploy workflow

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -60,6 +60,9 @@ jobs:
           echo "Successfully copied latest code to ${DestinationPath}."
           echo "Deployment complete."
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Restart Home Assistant
         shell: bash
         env:


### PR DESCRIPTION
The `deploy-local.yml` workflow was failing because the `jq` command was not found. This change adds a step to install `jq` using `apt-get` before it is used to parse the Home Assistant API response.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
