### PR TITLE
fix(ci): handle non-JSON responses in deploy workflow

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -73,9 +73,17 @@ jobs:
 
           # Step 1a: Check Configuration
           echo "Checking Home Assistant configuration..."
-          CHECK_RESULT=$(curl -X POST -H "Authorization: Bearer $HA_TOKEN" \
+          CHECK_RESULT=$(curl -sS -X POST -H "Authorization: Bearer $HA_TOKEN" \
                -H "Content-Type: application/json" \
                "$HA_URL/api/config/core/check_config")
+
+          # Verify that the response from the server is JSON before trying to parse it.
+          if ! echo "$CHECK_RESULT" | grep -q '^{'; then
+            echo "Error: API response does not appear to be valid JSON."
+            echo "Received response:"
+            echo "$CHECK_RESULT"
+            exit 1
+          fi
 
           ERRORS=$(echo "$CHECK_RESULT" | jq -r '.errors')
 


### PR DESCRIPTION
This change makes the `deploy-local.yml` workflow more robust.

- Installs `jq` to ensure it's available in the runner environment.
- Adds a check to verify that the response from the Home Assistant API is valid JSON before attempting to parse it with `jq`. This prevents the `jq: parse error: Invalid numeric literal` error that occurs when the API returns a non-JSON response (e.g., an HTML error page).
- Adds `-sS` to the `curl` command to suppress progress output while still showing errors.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
