### PR TITLE
fix(ci): Sanitize Home Assistant token in deploy workflow

This change prevents a `curl` error in the `deploy-local.yml` workflow caused by trailing whitespace in the `HA_TOKEN` secret.

The error "Missing expected CR after header value" indicates that the `Authorization` header is malformed. This is typically caused by a newline or carriage return character at the end of the token secret.

This commit adds a step to sanitize the `HA_TOKEN` variable by stripping any newline or carriage return characters before it is used in the `curl` command. This makes the workflow more robust and prevents failures caused by improperly formatted secrets.

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -71,9 +71,13 @@ jobs:
         run: |
           echo "Attempting to restart Home Assistant..."
 
+          # Sanitize the Home Assistant token to remove any trailing newlines or whitespace.
+          # This prevents "Missing expected CR after header value" errors from curl.
+          CLEAN_HA_TOKEN=$(echo -n "$HA_TOKEN" | tr -d '\n\r')
+
           # Step 1a: Check Configuration
           echo "Checking Home Assistant configuration..."
-          CHECK_RESULT=$(curl -sS -X POST -H "Authorization: Bearer $HA_TOKEN" \
+          CHECK_RESULT=$(curl -sS -X POST -H "Authorization: Bearer $CLEAN_HA_TOKEN" \
                -H "Content-Type: application/json" \
                "$HA_URL/api/config/core/check_config")
 
@@ -97,7 +101,7 @@ jobs:
 
           # Step 1b: Trigger Restart
           echo "Triggering Home Assistant restart..."
-          curl -X POST -H "Authorization: Bearer $HA_TOKEN" \
+          curl -X POST -H "Authorization: Bearer $CLEAN_HA_TOKEN" \
                -H "Content-Type: application/json" \
                "$HA_URL/api/services/home_assistant/restart"
 


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
