### PR TITLE
fix(core): await MerakiAPIClient initialization

The MerakiAPIClient has an asynchronous constructor that was not being awaited during instantiation in `async_setup_entry`. This resulted in a `RuntimeWarning` and prevented the integration from loading correctly.

This change adds the required `await` keyword to resolve the issue.

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         if DATA_CLIENT not in entry_data:
-            entry_data[DATA_CLIENT] = MerakiAPIClient(
+            entry_data[DATA_CLIENT] = await MerakiAPIClient(
                 hass,
                 api_key=entry.data[CONF_MERAKI_API_KEY],
                 org_id=entry.data[CONF_MERAKI_ORG_ID],


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
