### PR TITLE
fix(core): Await all MerakiAPIClient instantiations

The `MerakiAPIClient` has an asynchronous constructor that was not being awaited in all call sites, leading to a `RuntimeWarning` during integration setup and authentication flows.

This commit resolves the issue by adding the required `await` keyword to the `MerakiAPIClient` instantiation in both `custom_components/meraki_ha/__init__.py` and `custom_components/meraki_ha/authentication.py`.

Additionally, the unit tests in `tests/test_authentication.py` have been updated to use `AsyncMock` for patching the client, ensuring they are compatible with the asynchronous nature of the constructor.

### DIFF
--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -63,7 +63,7 @@ class MerakiAuthentication:
             MerakiConnectionError: If there is a connection error.
 
         """
-        client = MerakiAPIClient(
+        client = await MerakiAPIClient(
             hass=self.hass,
             api_key=self.api_key,
             org_id=self.organization_id,

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -26,6 +26,7 @@ async def test_validate_meraki_credentials(hass: HomeAssistant) -> None:
     """
     with patch(
         "custom_components.meraki_ha.authentication.MerakiAPIClient",
+        new_callable=AsyncMock,
     ) as mock_client:
         mock_client.return_value.organization.get_organizations = AsyncMock(
             return_value=[{"id": "test-org-id", "name": "Test Org"}],
@@ -47,6 +48,7 @@ async def test_validate_meraki_credentials_invalid_org(hass: HomeAssistant) -> N
     with (
         patch(
             "custom_components.meraki_ha.authentication.MerakiAPIClient",
+            new_callable=AsyncMock,
         ) as mock_client,
         pytest.raises(ValueError),
     ):
@@ -69,6 +71,7 @@ async def test_validate_meraki_credentials_auth_failed(hass: HomeAssistant) -> N
     with (
         patch(
             "custom_components.meraki_ha.authentication.MerakiAPIClient",
+            new_callable=AsyncMock,
         ) as mock_client,
         pytest.raises(ConfigEntryAuthFailed),
     ):


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
