### PR TITLE
fix(api): Refactor API client to prevent NoneType error

The API endpoint classes were caching the `api_client.dashboard` object in their `__init__` methods. This created a race condition where the `dashboard` object could be `None` if accessed before the `MerakiAPIClient` had been fully initialized.

This commit refactors the endpoint classes to access the `dashboard` object dynamically via `self._api_client.dashboard` in their methods. This ensures that the `dashboard` object is always accessed in its initialized state, preventing the `NoneType` error.

The tests for the API endpoints have been updated to reflect this change.

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/appliance.py
+++ b/custom_components/meraki_ha/core/api/endpoints/appliance.py
@@ -34,7 +34,6 @@ class ApplianceEndpoints:
 
         """
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
         self._hass = hass
 
     @handle_meraki_errors
@@ -57,7 +56,7 @@ class ApplianceEndpoints:
 
         """
         traffic = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceTraffic,
+            self._api_client.dashboard.appliance.getNetworkApplianceTraffic,
             networkId=network_id,
             timespan=timespan,
         )
@@ -82,7 +81,7 @@ class ApplianceEndpoints:
 
         """
         vlans = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceVlans,
+            self._api_client.dashboard.appliance.getNetworkApplianceVlans,
             networkId=network_id,
         )
         validated = validate_response(vlans)
@@ -112,7 +111,7 @@ class ApplianceEndpoints:
 
         """
         vlan = await self._api_client.run_sync(
-            self._dashboard.appliance.updateNetworkApplianceVlan,
+            self._api_client.dashboard.appliance.updateNetworkApplianceVlan,
             networkId=network_id,
             vlanId=vlan_id,
             **kwargs,
@@ -138,7 +137,7 @@ class ApplianceEndpoints:
 
         """
         rules = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceFirewallL3FirewallRules,
+            self._api_client.dashboard.appliance.getNetworkApplianceFirewallL3FirewallRules,
             networkId=network_id,
         )
         validated = validate_response(rules)
@@ -166,7 +165,7 @@ class ApplianceEndpoints:
 
         """
         rules = await self._api_client.run_sync(
-            self._dashboard.appliance.updateNetworkApplianceFirewallL3FirewallRules,
+            self._api_client.dashboard.appliance.updateNetworkApplianceFirewallL3FirewallRules,
             networkId=network_id,
             **kwargs,
         )
@@ -191,7 +190,7 @@ class ApplianceEndpoints:
 
         """
         settings = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceTrafficShaping,
+            self._api_client.dashboard.appliance.getNetworkApplianceTrafficShaping,
             networkId=network_id,
         )
         validated = validate_response(settings)
@@ -219,7 +218,7 @@ class ApplianceEndpoints:
 
         """
         settings = await self._api_client.run_sync(
-            self._dashboard.appliance.updateNetworkApplianceTrafficShaping,
+            self._api_client.dashboard.appliance.updateNetworkApplianceTrafficShaping,
             networkId=network_id,
             **kwargs,
         )
@@ -244,7 +243,7 @@ class ApplianceEndpoints:
 
         """
         status = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceVpnSiteToSiteVpn,
+            self._api_client.dashboard.appliance.getNetworkApplianceVpnSiteToSiteVpn,
             networkId=network_id,
         )
         validated = validate_response(status)
@@ -268,7 +267,7 @@ class ApplianceEndpoints:
 
         """
         status = await self._api_client.run_sync(
-            self._dashboard.appliance.updateNetworkApplianceVpnSiteToSiteVpn,
+            self._api_client.dashboard.appliance.updateNetworkApplianceVpnSiteToSiteVpn,
             networkId=network_id,
             **kwargs,
         )
@@ -296,7 +295,7 @@ class ApplianceEndpoints:
 
         """
         uplinks = await self._api_client.run_sync(
-            self._dashboard.appliance.getDeviceApplianceUplinksSettings,
+            self._api_client.dashboard.appliance.getDeviceApplianceUplinksSettings,
             serial=serial,
         )
         validated = validate_response(uplinks)
@@ -325,7 +324,7 @@ class ApplianceEndpoints:
 
         """
         result = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceContentFiltering,
+            self._api_client.dashboard.appliance.getNetworkApplianceContentFiltering,
             networkId=network_id,
         )
         validated = validate_response(result)
@@ -354,7 +353,7 @@ class ApplianceEndpoints:
 
         """
         result = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceContentFilteringCategories,
+            self._api_client.dashboard.appliance.getNetworkApplianceContentFilteringCategories,
             networkId=network_id,
         )
         validated = validate_response(result)
@@ -380,7 +379,7 @@ class ApplianceEndpoints:
 
         """
         result = await self._api_client.run_sync(
-            self._dashboard.devices.rebootDevice,
+            self._api_client.dashboard.devices.rebootDevice,
             serial=serial,
         )
         validated = validate_response(result)
@@ -404,7 +403,7 @@ class ApplianceEndpoints:
 
         """
         ports = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkAppliancePorts,
+            self._api_client.dashboard.appliance.getNetworkAppliancePorts,
             networkId=network_id,
         )
         validated = validate_response(ports)
@@ -428,7 +427,7 @@ class ApplianceEndpoints:
 
         """
         settings = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceSettings,
+            self._api_client.dashboard.appliance.getNetworkApplianceSettings,
             networkId=network_id,
         )
         validated = validate_response(settings)
@@ -455,7 +454,7 @@ class ApplianceEndpoints:
 
         """
         rules = await self._api_client.run_sync(
-            self._dashboard.appliance.getNetworkApplianceL7FirewallRules,
+            self._api_client.dashboard.appliance.getNetworkApplianceL7FirewallRules,
             networkId=network_id,
         )
         validated = validate_response(rules)
@@ -485,7 +484,7 @@ class ApplianceEndpoints:
 
         """
         rules = await self._api_client.run_sync(
-            self._dashboard.appliance.updateNetworkApplianceL7FirewallRules,
+            self._api_client.dashboard.appliance.updateNetworkApplianceL7FirewallRules,
             networkId=network_id,
             **kwargs,
         )
@@ -516,7 +515,7 @@ class ApplianceEndpoints:
 
         """
         result = await self._api_client.run_sync(
-            self._dashboard.appliance.updateNetworkApplianceContentFiltering,
+            self._api_client.dashboard.appliance.updateNetworkApplianceContentFiltering,
             networkId=network_id,
             **kwargs,
         )
@@ -540,7 +539,7 @@ class ApplianceEndpoints:
 
         """
         statuses = await self._api_client.run_sync(
-            self._dashboard.appliance.getOrganizationApplianceUplinkStatuses,
+            self._api_client.dashboard.appliance.getOrganizationApplianceUplinkStatuses,
             organizationId=self._api_client.organization_id,
             total_pages="all",
         )

--- a/custom_components/meraki_ha/core/api/endpoints/camera.py
+++ b/custom_components/meraki_ha/core/api/endpoints/camera.py
@@ -32,14 +32,13 @@ class CameraEndpoints:
 
         """
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
 
     @handle_meraki_errors
     @async_timed_cache()
     async def get_camera_sense_settings(self, serial: str) -> dict[str, Any]:
         """Get sense settings for a specific camera."""
         settings = await self._api_client.run_sync(
-            self._dashboard.camera.getDeviceCameraSense, serial=serial
+            self._api_client.dashboard.camera.getDeviceCameraSense, serial=serial
         )
         validated = validate_response(settings)
         if not isinstance(validated, dict):
@@ -52,7 +51,7 @@ class CameraEndpoints:
     async def get_camera_video_settings(self, serial: str) -> dict[str, Any]:
         """Get video settings for a specific camera."""
         settings = await self._api_client.run_sync(
-            self._dashboard.camera.getDeviceCameraVideoSettings, serial=serial
+            self._api_client.dashboard.camera.getDeviceCameraVideoSettings, serial=serial
         )
         validated = validate_response(settings)
         if not isinstance(validated, dict):
@@ -65,7 +64,7 @@ class CameraEndpoints:
     async def get_device_camera_video_link(self, serial: str) -> dict[str, Any]:
         """Get video link for a specific camera."""
         link = await self._api_client.run_sync(
-            self._dashboard.camera.getDeviceCameraVideoLink, serial=serial
+            self._api_client.dashboard.camera.getDeviceCameraVideoLink, serial=serial
         )
         validated = validate_response(link)
         if not isinstance(validated, dict):
@@ -79,7 +78,7 @@ class CameraEndpoints:
     ) -> dict[str, Any]:
         """Update video settings for a specific camera."""
         result = await self._api_client.run_sync(
-            self._dashboard.camera.updateDeviceCameraVideoSettings,
+            self._api_client.dashboard.camera.updateDeviceCameraVideoSettings,
             serial=serial,
             **kwargs,
         )
@@ -95,7 +94,7 @@ class CameraEndpoints:
     ) -> dict[str, Any]:
         """Update sense settings for a specific camera."""
         result = await self._api_client.run_sync(
-            self._dashboard.camera.updateDeviceCameraSense,
+            self._api_client.dashboard.camera.updateDeviceCameraSense,
             serial=serial,
             **kwargs,
         )
@@ -112,7 +111,7 @@ class CameraEndpoints:
     ) -> list[dict[str, Any]]:
         """Get recent analytics for a specific camera."""
         recent = await self._api_client.run_sync(
-            self._dashboard.camera.getDeviceCameraAnalyticsRecent,
+            self._api_client.dashboard.camera.getDeviceCameraAnalyticsRecent,
             serial=serial,
             objectType=object_type,
         )
@@ -129,7 +128,7 @@ class CameraEndpoints:
     ) -> list[dict[str, Any]]:
         """Get analytics zones for a specific camera."""
         zones = await self._api_client.run_sync(
-            self._dashboard.camera.getDeviceCameraAnalyticsZones,
+            self._api_client.dashboard.camera.getDeviceCameraAnalyticsZones,
             serial=serial,
         )
         validated = validate_response(zones)
@@ -144,7 +143,7 @@ class CameraEndpoints:
     ) -> dict[str, Any]:
         """Generate a snapshot of what the camera sees."""
         snapshot = await self._api_client.run_sync(
-            self._dashboard.camera.generateDeviceCameraSnapshot,
+            self._api_client.dashboard.camera.generateDeviceCameraSnapshot,
             serial=serial,
             **kwargs,
         )

--- a/custom_components/meraki_ha/core/api/endpoints/devices.py
+++ b/custom_components/meraki_ha/core/api/endpoints/devices.py
@@ -30,7 +30,6 @@ class DevicesEndpoints:
 
         """
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
 
     @handle_meraki_errors
     async def get_device_clients(self, serial: str) -> list[dict[str, Any]]:
@@ -47,7 +46,7 @@ class DevicesEndpoints:
 
         """
         clients = await self._api_client.run_sync(
-            self._dashboard.devices.getDeviceClients,
+            self._api_client.dashboard.devices.getDeviceClients,
             serial,
             timespan=300,  # 5 minutes to get current clients
         )
@@ -71,7 +70,7 @@ class DevicesEndpoints:
 
         """
         device = await self._api_client.run_sync(
-            self._dashboard.devices.getDevice,
+            self._api_client.dashboard.devices.getDevice,
             serial=serial,
         )
         validated = validate_response(device)
@@ -96,7 +95,7 @@ class DevicesEndpoints:
 
         """
         device = await self._api_client.run_sync(
-            self._dashboard.devices.updateDevice,
+            self._api_client.dashboard.devices.updateDevice,
             serial=serial,
             **kwargs,
         )

--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -32,7 +32,6 @@ class NetworkEndpoints:
 
         """
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
 
     @handle_meraki_errors
     @async_timed_cache(timeout=60)
@@ -50,7 +49,7 @@ class NetworkEndpoints:
 
         """
         clients = await self._api_client.run_sync(
-            self._dashboard.networks.getNetworkClients,
+            self._api_client.dashboard.networks.getNetworkClients,
             networkId=network_id,
             total_pages="all",
         )
@@ -79,7 +78,7 @@ class NetworkEndpoints:
 
         """
         traffic = await self._api_client.run_sync(
-            self._dashboard.networks.getNetworkTraffic,
+            self._api_client.dashboard.networks.getNetworkTraffic,
             networkId=network_id,
             deviceType=device_type,
             timespan=86400,  # 24 hours
@@ -106,7 +105,7 @@ class NetworkEndpoints:
 
         """
         webhooks = await self._api_client.run_sync(
-            self._dashboard.networks.getNetworkWebhooksHttpServers,
+            self._api_client.dashboard.networks.getNetworkWebhooksHttpServers,
             networkId=network_id,
         )
         validated = validate_response(webhooks)
@@ -127,7 +126,7 @@ class NetworkEndpoints:
 
         """
         await self._api_client.run_sync(
-            self._dashboard.networks.deleteNetworkWebhooksHttpServer,
+            self._api_client.dashboard.networks.deleteNetworkWebhooksHttpServer,
             networkId=network_id,
             httpServerId=webhook_id,
         )
@@ -174,7 +173,7 @@ class NetworkEndpoints:
                 await self.delete_webhook(network_id, existing_webhook["id"])
 
             await self._api_client.run_sync(
-                self._dashboard.networks.createNetworkWebhooksHttpServer,
+                self._api_client.dashboard.networks.createNetworkWebhooksHttpServer,
                 networkId=network_id,
                 url=webhook_url,
                 sharedSecret=secret,
@@ -194,7 +193,7 @@ class NetworkEndpoints:
         networks = await self._api_client.organization.get_organization_networks()
         for network in networks:
             await self._api_client.run_sync(
-                self._dashboard.networks.deleteNetworkWebhooksHttpServer,
+                self._api_client.dashboard.networks.deleteNetworkWebhooksHttpServer,
                 networkId=network["id"],
                 httpServerId=webhook_id,
             )
@@ -218,7 +217,7 @@ class NetworkEndpoints:
 
         """
         history = await self._api_client.run_sync(
-            self._dashboard.camera.getNetworkCameraAnalyticsRecent,
+            self._api_client.dashboard.camera.getNetworkCameraAnalyticsRecent,
             networkId=network_id,
             objectType=object_type,
         )

--- a/custom_components/meraki_ha/core/api/endpoints/organization.py
+++ b/custom_components/meraki_ha/core/api/endpoints/organization.py
@@ -32,7 +32,6 @@ class OrganizationEndpoints:
 
         """
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
 
     @handle_meraki_errors
     @async_timed_cache(timeout=3600)
@@ -46,7 +45,7 @@ class OrganizationEndpoints:
 
         """
         org = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganization,
+            self._api_client.dashboard.organizations.getOrganization,
             organizationId=self._api_client.organization_id,
         )
         validated = validate_response(org)
@@ -67,7 +66,7 @@ class OrganizationEndpoints:
 
         """
         networks = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganizationNetworks,
+            self._api_client.dashboard.organizations.getOrganizationNetworks,
             organizationId=self._api_client.organization_id,
         )
         validated = validate_response(networks)
@@ -88,7 +87,7 @@ class OrganizationEndpoints:
 
         """
         upgrades = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganizationFirmwareUpgrades,
+            self._api_client.dashboard.organizations.getOrganizationFirmwareUpgrades,
             organizationId=self._api_client.organization_id,
         )
         validated = validate_response(upgrades)
@@ -109,7 +108,7 @@ class OrganizationEndpoints:
 
         """
         statuses = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganizationDeviceStatuses,
+            self._api_client.dashboard.organizations.getOrganizationDeviceStatuses,
             organizationId=self._api_client.organization_id,
         )
         validated = validate_response(statuses)
@@ -130,7 +129,7 @@ class OrganizationEndpoints:
 
         """
         availabilities = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganizationDevicesAvailabilities,
+            self._api_client.dashboard.organizations.getOrganizationDevicesAvailabilities,
             organizationId=self._api_client.organization_id,
             total_pages="all",
         )
@@ -154,7 +153,7 @@ class OrganizationEndpoints:
 
         """
         devices = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganizationDevices,
+            self._api_client.dashboard.organizations.getOrganizationDevices,
             organizationId=self._api_client.organization_id,
         )
         validated = validate_response(devices)
@@ -175,7 +174,7 @@ class OrganizationEndpoints:
 
         """
         orgs = await self._api_client.run_sync(
-            self._dashboard.organizations.getOrganizations
+            self._api_client.dashboard.organizations.getOrganizations
         )
         validated = validate_response(orgs)
         if not isinstance(validated, list):

--- a/custom_components/meraki_ha/core/api/endpoints/switch.py
+++ b/custom_components/meraki_ha/core/api/endpoints/switch.py
@@ -32,7 +32,6 @@ class SwitchEndpoints:
 
         """
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
 
     @handle_meraki_errors
     @async_timed_cache(timeout=60)
@@ -52,7 +51,7 @@ class SwitchEndpoints:
 
         """
         statuses = await self._api_client.run_sync(
-            self._dashboard.switch.getDeviceSwitchPortsStatuses, serial=serial
+            self._api_client.dashboard.switch.getDeviceSwitchPortsStatuses, serial=serial
         )
         validated = validate_response(statuses)
         if not isinstance(validated, list):
@@ -76,7 +75,7 @@ class SwitchEndpoints:
 
         """
         ports = await self._api_client.run_sync(
-            self._dashboard.switch.getDeviceSwitchPorts, serial=serial
+            self._api_client.dashboard.switch.getDeviceSwitchPorts, serial=serial
         )
         validated = validate_response(ports)
         if not isinstance(validated, list):

--- a/custom_components/meraki_ha/core/api/endpoints/wireless.py
+++ b/custom_components/meraki_ha/core/api/endpoints/wireless.py
@@ -22,7 +22,6 @@ class WirelessEndpoints:
     def __init__(self, api_client: "MerakiAPIClient") -> None:
         """Initialize the endpoint."""
         self._api_client = api_client
-        self._dashboard = api_client.dashboard
 
     @handle_meraki_errors
     @async_timed_cache()
@@ -40,7 +39,7 @@ class WirelessEndpoints:
 
         """
         ssids = await self._api_client.run_sync(
-            self._dashboard.wireless.getNetworkWirelessSsids,
+            self._api_client.dashboard.wireless.getNetworkWirelessSsids,
             networkId=network_id,
         )
         validated = validate_response(ssids)
@@ -65,7 +64,7 @@ class WirelessEndpoints:
 
         """
         settings = await self._api_client.run_sync(
-            self._dashboard.wireless.getDeviceWirelessRadioSettings,
+            self._api_client.dashboard.wireless.getDeviceWirelessRadioSettings,
             serial=serial,
         )
         validated = validate_response(settings)
@@ -95,7 +94,7 @@ class WirelessEndpoints:
 
         """
         ssid = await self._api_client.run_sync(
-            self._dashboard.wireless.getNetworkWirelessSsid,
+            self._api_client.dashboard.wireless.getNetworkWirelessSsid,
             networkId=network_id,
             number=number,
         )
@@ -120,7 +119,7 @@ class WirelessEndpoints:
             The wireless settings.
         """
         settings = await self._api_client.run_sync(
-            self._dashboard.wireless.getNetworkWirelessSettings,
+            self._api_client.dashboard.wireless.getNetworkWirelessSettings,
             networkId=network_id,
         )
         validated = validate_response(settings)
@@ -146,7 +145,7 @@ class WirelessEndpoints:
             The updated settings.
         """
         settings = await self._api_client.run_sync(
-            self._dashboard.wireless.updateNetworkWirelessSettings,
+            self._api_client.dashboard.wireless.updateNetworkWirelessSettings,
             networkId=network_id,
             **kwargs,
         )
@@ -178,7 +177,7 @@ class WirelessEndpoints:
 
         """
         ssid = await self._api_client.run_sync(
-            self._dashboard.wireless.updateNetworkWirelessSsid,
+            self._api_client.dashboard.wireless.updateNetworkWirelessSsid,
             networkId=network_id,
             number=number,
             **kwargs,
@@ -208,7 +207,7 @@ class WirelessEndpoints:
 
         """
         profiles = await self._api_client.run_sync(
-            self._dashboard.wireless.getNetworkWirelessRfProfiles,
+            self._api_client.dashboard.wireless.getNetworkWirelessRfProfiles,
             networkId=network_id,
         )
         validated = validate_response(profiles)
@@ -238,7 +237,7 @@ class WirelessEndpoints:
 
         """
         rules = await self._api_client.run_sync(
-            self._dashboard.wireless.getNetworkWirelessSsidL7FirewallRules,
+            self._api_client.dashboard.wireless.getNetworkWirelessSsidL7FirewallRules,
             networkId=network_id,
             number=number,
         )
@@ -272,7 +271,7 @@ class WirelessEndpoints:
 
         """
         rules = await self._api_client.run_sync(
-            self._dashboard.wireless.updateNetworkWirelessSsidL7FirewallRules,
+            self._api_client.dashboard.wireless.updateNetworkWirelessSsidL7FirewallRules,
             networkId=network_id,
             number=number,
             **kwargs,

--- a/tests/core/api/endpoints/test_appliance.py
+++ b/tests/core/api/endpoints/test_appliance.py
@@ -35,11 +35,11 @@ def coordinator():
 
 
 @pytest.fixture
-def api_client(hass, mock_dashboard, coordinator):
+def api_client(hass, mock_dashboard):
     """Fixture for a MerakiAPIClient instance."""
-    with patch("meraki.DashboardAPI", return_value=mock_dashboard):
-        client = MerakiAPIClient(hass=hass, api_key="test-key", org_id="test-org")
-        yield client
+    client = MerakiAPIClient(hass=hass, api_key="test-key", org_id="test-org")
+    client.dashboard = mock_dashboard
+    yield client
 
 
 @pytest.fixture


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
