### PR TITLE
fix: restore side panel by registering frontend

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -23,6 +23,11 @@ from .const import (
 )
 from .core.api.client import MerakiAPIClient
 from .core.repositories.camera_repository import CameraRepository
+from .frontend import (
+    async_register_panel,
+    async_register_static_path,
+    async_unregister_frontend,
+)
 from .core.repository import MerakiRepository
 from .discovery.service import DeviceDiscoveryService
 from .meraki_data_coordinator import MerakiDataCoordinator
@@ -141,6 +146,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     discovered_entities = await discovery_service.discover_entities()
     entry_data["entities"] = discovered_entities
 
+    # Register frontend panel
+    await async_register_static_path(hass)
+    await async_register_panel(hass, entry)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     if "webhook_id" not in entry.data:
@@ -172,6 +181,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if "web_server" in entry_data:
             server = entry_data["web_server"]
             await server.stop()
+        async_unregister_frontend(hass)
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/meraki_ha/www/dist/index.html
+++ b/custom_components/meraki_ha/www/dist/index.html
@@ -20,7 +20,7 @@
       }
     </script>
     <script type="module" crossorigin src="/assets/index-BJfEfB35.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DFEcFG7l.css" />
+    <link rel="stylesheet" crossorigin href="/assets/index-DFEcFG7l.css">
   </head>
   <body class="bg-light-background dark:bg-dark-background">
     <div id="root"></div>

--- a/custom_components/meraki_ha/www/package-lock.json
+++ b/custom_components/meraki_ha/www/package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1323,6 +1324,7 @@
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1372,6 +1374,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1733,6 +1736,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -2395,6 +2399,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4293,6 +4298,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4502,6 +4508,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4514,6 +4521,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5607,6 +5615,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
The Meraki side panel was not appearing in Home Assistant because the necessary functions to register the frontend were not being called during the integration's setup process.

This change re-introduces the calls to `async_register_static_path` and `async_register_panel` in the `async_setup_entry` function within `__init__.py`. It also adds the corresponding `async_unregister_frontend` call to `async_unload_entry` to ensure proper cleanup when the integration is unloaded.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
