### PR TITLE
refactor(sensor): Improve MT sensor definition structure

Refactor the Meraki MT sensor implementation to be more modular and maintainable.

- Introduce a new `MTSensorEntityDescription` class that includes a `value_key` attribute.
- Move the mapping between a sensor type and its specific data field in the API payload from a hardcoded dictionary in the base class into the sensor definitions themselves.
- This makes the code cleaner and more extensible for adding future sensors.

### DIFF
--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -1,9 +1,15 @@
 """Base class for Meraki MT sensor entities."""
 
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -15,30 +21,38 @@ from ...meraki_data_coordinator import MerakiDataCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, kw_only=True)
+class MTSensorEntityDescription(SensorEntityDescription):
+    """Describes a Meraki MT sensor entity."""
+
+    value_key: str | None = None
+
+
 class MerakiMtSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Meraki MT sensor."""
+
+    entity_description: MTSensorEntityDescription
 
     def __init__(
         self,
         coordinator: MerakiDataCoordinator,
         device: dict[str, Any],
-        entity_description: SensorEntityDescription,
+        entity_description: MTSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
         self.entity_description = entity_description
-        self._attr_unique_id = f"{self._device['serial']}_{self.entity_description.key}"
-        self._attr_name = f"{self._device['name']} {self.entity_description.name}"
+
+        self._attr_unique_id = f"{self._device['serial']}_{entity_description.key}"
+        self._attr_name = f"{self._device['name']} {entity_description.name}"
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._device["serial"])},
-            name=format_device_name(
-                self._device, self.coordinator.config_entry.options
-            ),
+            name=format_device_name(self._device, self.coordinator.config_entry),
             model=self._device["model"],
             manufacturer="Cisco Meraki",
         )
@@ -46,41 +60,29 @@ class MerakiMtSensor(CoordinatorEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        for device in self.coordinator.data.get("devices", []):
-            if device["serial"] == self._device["serial"]:
-                self._device = device
-                self.async_write_ha_state()
-                return
+        if self.coordinator.data and (
+            device := self.coordinator.data.devices.get(self._device["serial"])
+        ):
+            self._device = device
+            self.async_write_ha_state()
 
     @property
     def native_value(self) -> float | bool | None:
         """Return the state of the sensor."""
-        readings = self._device.get("readings")
-        if not readings or not isinstance(readings, list):
+        if (
+            not self.entity_description.value_key
+            or not (readings := self._device.get("readings"))
+            or not isinstance(readings, list)
+        ):
             return None
 
         for reading in readings:
             if reading.get("metric") == self.entity_description.key:
-                metric_data = reading.get(self.entity_description.key)
-                if isinstance(metric_data, dict):
-                    # Map metric to the key holding its value
-                    key_map = {
-                        "temperature": "celsius",
-                        "humidity": "relativePercentage",
-                        "pm25": "concentration",
-                        "tvoc": "concentration",
-                        "co2": "concentration",
-                        "noise": "ambient",
-                        "water": "present",
-                        "power": "draw",
-                        "voltage": "level",
-                        "current": "draw",
-                    }
-                    value_key = key_map.get(self.entity_description.key)
-                    if value_key:
-                        if value_key == "ambient":
+                if metric_data := reading.get(self.entity_description.key):
+                    if isinstance(metric_data, dict):
+                        if self.entity_description.value_key == "ambient":
                             return metric_data.get("ambient", {}).get("level")
-                        return metric_data.get(value_key)
+                        return metric_data.get(self.entity_description.value_key)
         return None
 
     @property

--- a/custom_components/meraki_ha/sensor/setup_mt_sensors.py
+++ b/custom_components/meraki_ha/sensor/setup_mt_sensors.py
@@ -1,6 +1,9 @@
 """Setup helper for Meraki MT sensors."""
 
+from __future__ import annotations
+
 import logging
+from typing import Final
 
 from homeassistant.helpers.entity import Entity
 
@@ -8,7 +11,7 @@ from ..meraki_data_coordinator import MerakiDataCoordinator
 from ..sensor_defs.mt_sensors import MT_SENSOR_MODELS
 from .device.meraki_mt_base import MerakiMtSensor
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: Final = logging.getLogger(__name__)
 
 
 def async_setup_mt_sensors(
@@ -17,8 +20,8 @@ def async_setup_mt_sensors(
 ) -> list[Entity]:
     """Set up Meraki MT sensor entities for a given device."""
     entities: list[Entity] = []
-    model = device_info.get("model")
 
+    model = device_info.get("model")
     if not model or not model.startswith("MT"):
         return []
 
@@ -41,5 +44,4 @@ def async_setup_mt_sensors(
 
     for description in sensor_descriptions:
         entities.append(MerakiMtSensor(coordinator, device_info, description))
-
     return entities

--- a/custom_components/meraki_ha/sensor_defs/mt_sensors.py
+++ b/custom_components/meraki_ha/sensor_defs/mt_sensors.py
@@ -2,7 +2,6 @@
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
-    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.const import (
@@ -16,84 +15,96 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 
+from ..sensor.device.meraki_mt_base import MTSensorEntityDescription
+
 # Descriptions for individual sensor metrics
-MT_TEMPERATURE_DESCRIPTION = SensorEntityDescription(
+MT_TEMPERATURE_DESCRIPTION = MTSensorEntityDescription(
     key="temperature",
     name="Temperature",
     device_class=SensorDeviceClass.TEMPERATURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    value_key="celsius",
 )
 
-MT_HUMIDITY_DESCRIPTION = SensorEntityDescription(
+MT_HUMIDITY_DESCRIPTION = MTSensorEntityDescription(
     key="humidity",
     name="Humidity",
     device_class=SensorDeviceClass.HUMIDITY,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=PERCENTAGE,
+    value_key="relativePercentage",
 )
 
-MT_WATER_DESCRIPTION = SensorEntityDescription(
+MT_WATER_DESCRIPTION = MTSensorEntityDescription(
     key="water",
     name="Water Detection",
     device_class=SensorDeviceClass.MOISTURE,
+    value_key="present",
 )
 
-MT_PM25_DESCRIPTION = SensorEntityDescription(
+MT_PM25_DESCRIPTION = MTSensorEntityDescription(
     key="pm25",
     name="PM2.5",
     device_class=SensorDeviceClass.PM25,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    value_key="concentration",
 )
 
-MT_TVOC_DESCRIPTION = SensorEntityDescription(
+MT_TVOC_DESCRIPTION = MTSensorEntityDescription(
     key="tvoc",
     name="TVOC",
     device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    value_key="concentration",
 )
 
-MT_CO2_DESCRIPTION = SensorEntityDescription(
+MT_CO2_DESCRIPTION = MTSensorEntityDescription(
     key="co2",
     name="CO2",
     device_class=SensorDeviceClass.CO2,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+    value_key="concentration",
 )
 
-MT_NOISE_DESCRIPTION = SensorEntityDescription(
+MT_NOISE_DESCRIPTION = MTSensorEntityDescription(
     key="noise",
     name="Ambient Noise",
     device_class=SensorDeviceClass.SOUND_PRESSURE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfSoundPressure.WEIGHTED_DECIBEL_A,
+    value_key="ambient",
 )
 
 
-MT_POWER_DESCRIPTION = SensorEntityDescription(
+MT_POWER_DESCRIPTION = MTSensorEntityDescription(
     key="power",
     name="Power",
     device_class=SensorDeviceClass.POWER,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfPower.WATT,
+    value_key="draw",
 )
 
-MT_VOLTAGE_DESCRIPTION = SensorEntityDescription(
+MT_VOLTAGE_DESCRIPTION = MTSensorEntityDescription(
     key="voltage",
     name="Voltage",
     device_class=SensorDeviceClass.VOLTAGE,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    value_key="level",
 )
 
-MT_CURRENT_DESCRIPTION = SensorEntityDescription(
+MT_CURRENT_DESCRIPTION = MTSensorEntityDescription(
     key="current",
     name="Current",
     device_class=SensorDeviceClass.CURRENT,
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+    value_key="draw",
 )
 
 


### PR DESCRIPTION
# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
