### PR TITLE
Fix ignored_networks handling

### DIFF
--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -50,7 +50,7 @@ CONF_ENABLE_VLAN_MANAGEMENT: Final = "enable_vlan_management"
 """Configuration key for enabling vlan management."""
 
 
-DEFAULT_IGNORED_NETWORKS: Final = ""
+DEFAULT_IGNORED_NETWORKS: Final[list[str]] = []
 """Default value for the ignored networks list."""
 
 DEFAULT_ENABLE_VLAN_MANAGEMENT: Final = False

--- a/custom_components/meraki_ha/options_flow.py
+++ b/custom_components/meraki_ha/options_flow.py
@@ -96,11 +96,19 @@ class MerakiOptionsFlowHandler(config_entries.OptionsFlow):
         for key, value in schema.schema.items():
             key_name = key.schema
             # 'key.schema' is the name of the option (e.g., 'scan_interval')
-            if key_name in defaults:
-                # Create a new voluptuous key (e.g., vol.Required) with the
-                # default value set to the existing option value.
-                key = type(key)(key.schema, default=defaults[key.schema])
+            if key_name == CONF_IGNORED_NETWORKS:
+                current = defaults.get(CONF_IGNORED_NETWORKS, [])
 
+                # Normalize to a list
+                if current is None:
+                    current = []
+                elif isinstance(current, str):
+                    current = [x.strip() for x in current.split(",") if x.strip()]
+
+                key = type(key)(key.schema, default=current)
+
+            elif key_name in defaults:
+                key = type(key)(key.schema, default=defaults[key.schema])
             if key_name == CONF_IGNORED_NETWORKS and isinstance(
                 value, selector.SelectSelector
             ):

--- a/custom_components/meraki_ha/schemas.py
+++ b/custom_components/meraki_ha/schemas.py
@@ -47,7 +47,7 @@ OPTIONS_SCHEMA = vol.Schema(
             selector.SelectSelectorConfig(
                 options=[],
                 multiple=True,
-                custom_value=False,
+                custom_value=True,
                 mode=selector.SelectSelectorMode.DROPDOWN,
             )
         ),


### PR DESCRIPTION
This PR fixes multiple issues with the ignored_networks option in the Meraki HA integration.
Previously, ignored_networks behaved inconsistently depending on whether it was set via the config flow, options flow, or YAML import, leading to crashes and mis-parsing.

What Was Broken

- DEFAULT_IGNORED_NETWORKS was defined as an empty string (""), but the options schema defined ignored_networks as a list selector (multiple=True).

This mismatch caused the options flow to receive the wrong type.

- When existing configs contained a comma-separated string (e.g. "10.1.1.0/24,10.1.2.0/24"), the options flow did not normalize it into a list, which produced crashes when reconfiguring the integration.

- The selector did not allow custom entries, making it impossible to enter arbitrary networks unless they were pre-populated.

What This PR Changes

- DEFAULT_IGNORED_NETWORKS is now correctly typed as an empty list ([]).
- The options flow now normalizes values:
- None → []
- "a,b,c" → ["a", "b", "c"]
- Already-correct lists pass through unchanged.
- The selector in schemas.py now uses custom_value=True, allowing users to enter arbitrary networks rather than only predefined ones.
- The resulting options flow now behaves consistently and does not error when re-entering configuration.

Why This Fix Is Required
Home Assistant expects config flows and options flows to supply the correct type for selectors.
Providing the wrong type (string vs list) results in:

- AttributeError during reconfiguration
- Blocked config reloads
- Integration stuck in FAILED_UNLOAD or FAILED_SETUP states

This PR aligns the integration with HA’s expectations for multi-select list fields and prevents future type-related breakage.

Files Updated

- custom_components/meraki_ha/const.py
- custom_components/meraki_ha/schemas.py
- custom_components/meraki_ha/options_flow.py