### PR TITLE
chore(release): rebuild frontend during release process

### DIFF
--- a/.github/workflows/beta-version-update.yaml
+++ b/.github/workflows/beta-version-update.yaml
@@ -49,6 +49,11 @@ jobs:
           echo "Synchronizing package.json version to: ${{ steps.increment.outputs.new_version }}"
           npm version ${{ steps.increment.outputs.new_version }} --no-git-tag-version --allow-same-version
 
+      - name: Build frontend
+        if: steps.increment.outputs.new_version != ''
+        run: |
+          npm run build --prefix custom_components/meraki_ha/www
+
       - name: Generate Changelog
         if: steps.increment.outputs.new_version != ''
         run: |
@@ -61,7 +66,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore(release): update version to ${{ steps.increment.outputs.new_version }} and CHANGELOG'
-          file_pattern: 'custom_components/meraki_ha/manifest.json CHANGELOG.md package.json .bumpversion.cfg package-lock.json'
+          file_pattern: 'custom_components/meraki_ha/manifest.json CHANGELOG.md package.json .bumpversion.cfg package-lock.json custom_components/meraki_ha/www/meraki-panel.js'
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/production-version-update.yaml
+++ b/.github/workflows/production-version-update.yaml
@@ -59,6 +59,11 @@ jobs:
           echo "Synchronizing package.json version to: ${{ steps.increment.outputs.new_version }}"
           npm version ${{ steps.increment.outputs.new_version }} --no-git-tag-version --allow-same-version
 
+      - name: Build frontend
+        if: steps.increment.outputs.new_version != ''
+        run: |
+          npm run build --prefix custom_components/meraki_ha/www
+
       - name: Generate Changelog
         if: steps.increment.outputs.new_version != ''
         run: |
@@ -71,7 +76,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore(release): update version to ${{ steps.increment.outputs.new_version }} and CHANGELOG'
-          file_pattern: 'custom_components/meraki_ha/manifest.json CHANGELOG.md package.json .bumpversion.cfg package-lock.json'
+          file_pattern: 'custom_components/meraki_ha/manifest.json CHANGELOG.md package.json .bumpversion.cfg package-lock.json custom_components/meraki_ha/www/meraki-panel.js'
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"
           commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
Adds a step to the production and beta release workflows to rebuild the frontend after the version has been updated. This ensures that the compiled frontend artifact (`meraki-panel.js`) reflects the new version number.

# Type of Change

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

**Remember to include `[major]`, `[minor]`, or `[patch]` in your PR title based**
**on the type of change.** **Example:** `[minor] Add support for new sensor type`

## Description

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate)

## Types of changes

-Bug fix (non-breaking change which fixes an issue)
-New feature (non-breaking change which adds functionality)
-Breaking change (fix or feature that would cause existing functionality to not
work as expected)

## Checklist

-My code follows the style guidelines of this project
-I have performed a self-review of my own code
-I have commented my code, particularly in hard-to-understand areas
-I have made corresponding changes to the documentation
-My changes generate no new warnings
-I have added tests that prove my fix is effective or that my feature works
-New and existing unit tests pass locally with my changes
-Any dependent changes have been merged and published in downstream modules
