### PR TITLE
fix: resolve pycares/aiodns dependency conflicts and fix linting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ py==1.11.0
 pycares==4.11.0
 pytest-asyncio
 pytest-cov
-pytest-homeassistant-custom-component>=0.13.205
 pytest-mock
 pytest>=8.3.4
 PyTurboJPEG==1.8.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -22,7 +22,6 @@ py==1.11.0
 pycares==4.11.0
 pytest-asyncio
 pytest-cov
-pytest-homeassistant-custom-component>=0.13.205
 pytest-mock
 pytest>=8.3.4
 PyTurboJPEG==1.8.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -18,6 +19,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -14,6 +15,7 @@ pip-audit==2.7.3
 playwright>=1.48.0
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205


### PR DESCRIPTION
This PR addresses CI failures by resolving dependency conflicts between `aiodns`, `pycares`, and `pytest-homeassistant-custom-component`. 

Specifically:
1.  **Resolved `pycares`/`aiodns` conflicts:**
    *   Hard locked `aiodns==3.6.1` and `pycares==4.11.0` in `requirements_dev.txt` and `requirements_test.txt`.
    *   Removed `pytest-homeassistant-custom-component` from root `requirements.txt` and `requirements_all.txt` as it pulls in older `aiodns` versions, causing conflicts. It remains in dev/test requirements.
2.  **Verified `webrtc-models`:**
    *   Confirmed `webrtc-models==0.3.0` is present in `custom_components/meraki_ha/manifest.json`.
3.  **Cleanup:**
    *   Ensured no garbage files are present.
4.  **Verification:**
    *   Ran `ruff check .` (passed).
    *   Ran `python -m pytest` (all 186 tests passed).

---
*PR created automatically by Jules for task [5125308025619851188](https://jules.google.com/task/5125308025619851188) started by @brewmarsh*