### PR TITLE
fix: resolve aiodns/pycares conflicts and fix linting

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -27,8 +27,8 @@
   "loggers": ["meraki_ha"],
   "quality_scale": "platinum",
   "requirements": [
-    "aiofiles>=24.1.0",
     "aiodns==3.6.1",
+    "aiofiles>=24.1.0",
     "aiohttp>=3.8.1",
     "meraki>=1.53.0",
     "orjson>=3.9.0",

--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,5 +1,5 @@
-aiofiles>=24.1.0
 aiodns==3.6.1
+aiofiles>=24.1.0
 aiohttp>=3.8.1
 meraki>=1.53.0
 orjson>=3.9.0

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -103,7 +103,9 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
         self._config_entry = config_entry
 
         self._attr_has_entity_name = True
-        self._attr_unique_id = f"{self._device.serial}_port_{self._port['portId']}_power"
+        self._attr_unique_id = (
+            f"{self._device.serial}_port_{self._port['portId']}_power"
+        )
         self._attr_name = f"Port {self._port['portId']} Power"
 
     @property
@@ -162,7 +164,9 @@ class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
         self._config_entry = config_entry
 
         self._attr_has_entity_name = True
-        self._attr_unique_id = f"{self._device.serial}_port_{self._port['portId']}_energy"
+        self._attr_unique_id = (
+            f"{self._device.serial}_port_{self._port['portId']}_energy"
+        )
         self._attr_name = f"Port {self._port['portId']} Energy"
 
     @property

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -18,6 +19,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -14,6 +15,7 @@ pip-audit==2.7.3
 playwright>=1.48.0
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205


### PR DESCRIPTION
Resolved dependency conflicts causing CI failures.
- Hard locked `aiodns` and `pycares` to stable versions compatible with Python 3.13.
- Enforced strict alphabetical sorting of dependencies in `manifest.json` and `requirements.txt`.
- Fixed linting errors.
- Verified all tests pass.

---
*PR created automatically by Jules for task [17256258503550078354](https://jules.google.com/task/17256258503550078354) started by @brewmarsh*