### PR TITLE
fix: resolve dependency conflicts for pycares/aiodns

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
 aiodhcpwatcher
 aiodiscover
-aiodns==3.6.1
+# aiodns and pycares are unpinned here to allow installation of pytest-homeassistant-custom-component.
+# They are forced to 3.6.1/4.11.0 by the CI workflow (Force Clean DNS Stack).
+aiodns
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -19,7 +21,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
-pycares==4.11.0
+pycares
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,8 @@
 aiodhcpwatcher
 aiodiscover
-aiodns==3.6.1
+# aiodns and pycares are unpinned here to allow installation of pytest-homeassistant-custom-component.
+# They are forced to 3.6.1/4.11.0 by the CI workflow (Force Clean DNS Stack).
+aiodns
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -15,7 +17,7 @@ pip-audit==2.7.3
 playwright>=1.48.0
 psutil-home-assistant==0.0.1
 py==1.11.0
-pycares==4.11.0
+pycares
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205


### PR DESCRIPTION
Resolved dependency conflicts between `pytest-homeassistant-custom-component` and hard-locked versions of `aiodns`/`pycares` by unpinning them in `requirements_dev.txt` and `requirements_test.txt`. The CI workflow (`reusable-quality-checks.yaml`) explicitly enforces the hard-locked versions (`aiodns==3.6.1`, `pycares==4.11.0`) via a "Force Clean DNS Stack" step, ensuring the final test environment is correct and crash-free on Python 3.13.

Also verified `webrtc-models==0.3.0` in `manifest.json`.

---
*PR created automatically by Jules for task [5177356876554102403](https://jules.google.com/task/5177356876554102403) started by @brewmarsh*