### PR TITLE
fix: hard lock aiodns and pycares versions for Python 3.13

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -18,6 +19,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -14,6 +15,7 @@ pip-audit==2.7.3
 playwright>=1.48.0
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205


### PR DESCRIPTION
Hard locks `aiodns==3.6.1` and `pycares==4.11.0` in `requirements_dev.txt` and `requirements_test.txt` to prevent crashes on Python 3.13. This resolves dependency conflicts and ensures the test environment is stable.

Also verified that `webrtc-models==0.3.0` is present in `manifest.json`.

---
*PR created automatically by Jules for task [11266992634999995256](https://jules.google.com/task/11266992634999995256) started by @brewmarsh*