### PR TITLE
fix: resolve CI dependency conflicts and pin meraki

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -30,7 +30,7 @@
     "aiofiles>=24.1.0",
     "aiodns==3.6.1",
     "aiohttp>=3.8.1",
-    "meraki>=1.53.0",
+    "meraki==1.53.0",
     "orjson>=3.9.0",
     "pycares==4.11.0",
     "urllib3>=1.26.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.53.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.53.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ bandit==1.7.9
 diskcache==5.6.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.53.0
 numpy>=1.26.0
 orjson>=3.9.0
 pillow>=11.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.53.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0


### PR DESCRIPTION
This PR resolves the CI validation failure by addressing dependency conflicts.
1.  **Pin Meraki Library:** The `meraki` library is pinned to `1.53.0`. The newer version 2.1.0 introduces strict requirements for `pytest>=8.3.5` and `aiohttp>=3.11.18`, which conflict with `pytest-homeassistant-custom-component` (which requires older versions).
2.  **Hard Lock aiodns/pycares:** `aiodns` is locked to `3.6.1` and `pycares` to `4.11.0` to ensure stability and compatibility with Python 3.13.
3.  **Cleanup:** Removed garbage files created by accidental shell redirection.
4.  **Verification:** Validated that all tests pass with the pinned versions.

---
*PR created automatically by Jules for task [18028278844146648147](https://jules.google.com/task/18028278844146648147) started by @brewmarsh*