### PR TITLE
fix: resolve aiodns and pycares conflicts for Python 3.13

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,6 @@
 aiodhcpwatcher
 aiodiscover
-# aiodns and pycares are unpinned here to allow installation of pytest-homeassistant-custom-component.
-# They are forced to 3.6.1/4.11.0 by the CI workflow (Force Clean DNS Stack).
-aiodns
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -21,7 +19,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
-pycares
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,6 @@
 aiodhcpwatcher
 aiodiscover
-# aiodns and pycares are unpinned here to allow installation of pytest-homeassistant-custom-component.
-# They are forced to 3.6.1/4.11.0 by the CI workflow (Force Clean DNS Stack).
-aiodns
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -17,7 +15,7 @@ pip-audit==2.7.3
 playwright>=1.48.0
 psutil-home-assistant==0.0.1
 py==1.11.0
-pycares
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component>=0.13.205


### PR DESCRIPTION
Hard-locked aiodns==3.6.1 and pycares==4.11.0 in requirements_dev.txt and requirements_test.txt to prevent crashes on Python 3.13. Removed comments about unpinning them. Verified webrtc-models==0.3.0 in manifest.json.

---
*PR created automatically by Jules for task [8950873892142715041](https://jules.google.com/task/8950873892142715041) started by @brewmarsh*