### PR TITLE
fix: Resolve linting errors and CI dependency conflicts

### DIFF
--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -221,6 +221,9 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Pre-register network devices to avoid "referencing a non existing
             # via_device" warnings when downstream entities (like VLANs) initialize.
             device_registry = dr.async_get(self.hass)
+
+            assert self.config_entry is not None
+
             for network in data.get("networks", []):
                 device_registry.async_get_or_create(
                     config_entry_id=self.config_entry.entry_id,


### PR DESCRIPTION
- Fixed a mypy error in `custom_components/meraki_ha/coordinator.py` by adding an assertion check for `self.config_entry`.
- Verified hard-locked dependencies for `aiodns==3.6.1` and `pycares==4.11.0` to resolve CI conflicts on Python 3.13.
- Verified `webrtc-models==0.3.0` requirement in manifest.
- Validated all tests and linting checks pass.

---
*PR created automatically by Jules for task [15066105947522749978](https://jules.google.com/task/15066105947522749978) started by @brewmarsh*