### PR TITLE
Disable Switch Port Sensors by Default

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/switch_port.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a Meraki switch port sensor."""
 
+    _attr_entity_registry_enabled_default = False
     _attr_state_color = True
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -18,6 +18,7 @@ from ...types import MerakiDevice
 class MerakiSwitchPortSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Meraki switch port sensor."""
 
+    _attr_entity_registry_enabled_default = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(


### PR DESCRIPTION
This pull request disables the switch port status and connectivity sensors by default to prevent a "thundering herd" of updates that can cause WebSocket client disconnections. This is achieved by setting `_attr_entity_registry_enabled_default = False` in the sensor and binary_sensor classes, allowing users to enable only the specific ports they need to monitor.

Fixes #1311

---
*PR created automatically by Jules for task [7058546892944092695](https://jules.google.com/task/7058546892944092695) started by @brewmarsh*