### PR TITLE
fix: resolve CI dependency order and verify locks

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -27,8 +27,8 @@
   "loggers": ["meraki_ha"],
   "quality_scale": "platinum",
   "requirements": [
-    "aiofiles>=24.1.0",
     "aiodns==3.6.1",
+    "aiofiles>=24.1.0",
     "aiohttp>=3.8.1",
     "meraki==1.53.0",
     "orjson>=3.9.0",


### PR DESCRIPTION
Resolved CI failure by enforcing strict alphabetical order in `manifest.json` requirements. Verified that critical dependency locks (`aiodns`, `pycares`) and `webrtc-models` are present and correct. Ran `ruff` and `pytest` to ensure no regressions.

---
*PR created automatically by Jules for task [8601133990187500792](https://jules.google.com/task/8601133990187500792) started by @brewmarsh*