### PR TITLE
fix: CI dependency conflicts and linting errors

### DIFF
--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Force Clean DNS Stack
         run: |
           # FIX: removed -y flag which uv does not support
-          uv pip uninstall --system pycares aiodns
+          python -m pip uninstall -y pycares aiodns
           uv pip install --system --no-cache-dir pycares==4.11.0 aiodns==3.6.1
 
       - run: mypy --ignore-missing-imports custom_components/meraki_ha/ tests/
@@ -157,7 +157,7 @@ jobs:
       - name: Force Clean DNS Stack
         run: |
           # FIX: removed -y flag which uv does not support
-          uv pip uninstall --system pycares aiodns
+          python -m pip uninstall -y pycares aiodns
           uv pip install --system --no-cache-dir pycares==4.11.0 aiodns==3.6.1
 
       - name: Run Tests

--- a/custom_components/meraki_ha/core/coordinator_helpers/device_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/device_fetcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ...core.parsers.devices import parse_device_data
 from ...types import MerakiDevice
@@ -56,11 +56,12 @@ class DeviceFetcher:
                 "Could not fetch devices, device data will be unavailable: %s",
                 devices_res,
             )
-            devices_list = []
-            devices_raw = []
+            devices_list: list[MerakiDevice] = []
+            devices_raw: list[dict[str, Any]] = []
         else:
-            devices_list = [MerakiDevice.from_dict(d) for d in devices_res]
-            devices_raw = devices_res
+            devices_res_list = cast(list[dict[str, Any]], devices_res)
+            devices_list = [MerakiDevice.from_dict(d) for d in devices_res_list]
+            devices_raw = devices_res_list
 
         device_statuses = data.get("device_statuses", [])
         if isinstance(device_statuses, Exception):
@@ -70,6 +71,8 @@ class DeviceFetcher:
                 device_statuses,
             )
             device_statuses = []
+        else:
+            device_statuses = cast(list[dict[str, Any]], device_statuses)
 
         parse_device_data(devices_list, device_statuses)
 

--- a/tests/core/api/test_client_vpn_gate.py
+++ b/tests/core/api/test_client_vpn_gate.py
@@ -94,7 +94,6 @@ async def test_vpn_status_fetched_when_enabled(mock_hass, mock_coordinator):
             "custom_components.meraki_ha.core.api.client.parse_wireless_data",
             return_value={},
         ),
-        patch("custom_components.meraki_ha.core.api.client.parse_device_data"),
         patch("custom_components.meraki_ha.core.api.client.parse_appliance_data"),
         patch("custom_components.meraki_ha.core.api.client.parse_sensor_data"),
         patch("custom_components.meraki_ha.core.api.client.parse_camera_data"),


### PR DESCRIPTION
Resolved pycares/aiodns conflicts in CI by using 'python -m pip uninstall' and hard-locking versions. Fixed mypy errors in device fetcher and removed invalid test patch.

---
*PR created automatically by Jules for task [16783237731255005445](https://jules.google.com/task/16783237731255005445) started by @brewmarsh*