### PR TITLE
fix: resolve pycares/aiodns conflicts and linting errors

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -18,6 +19,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-mock

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9
@@ -14,6 +15,7 @@ pip-audit==2.7.3
 playwright>=1.48.0
 psutil-home-assistant==0.0.1
 py==1.11.0
+pycares==4.11.0
 pytest-asyncio
 pytest-cov
 pytest-mock

--- a/tests/event/device/test_mt_button_event.py
+++ b/tests/event/device/test_mt_button_event.py
@@ -2,13 +2,14 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from homeassistant.components.event import EventDeviceClass
 
 from custom_components.meraki_ha.event.device.mt_button import MerakiMtButtonEvent
 
 
-async def test_mt_button_event_initialization(hass, mock_coordinator, mock_config_entry):
+async def test_mt_button_event_initialization(
+    hass, mock_coordinator, mock_config_entry
+):
     """Test the initialization of the MT button event entity."""
     device = MagicMock()
     device.serial = "Q2XX-XXXX-XXXX"


### PR DESCRIPTION
Hard locked aiodns==3.6.1 and pycares==4.11.0 in requirements_dev.txt and requirements_test.txt to prevent conflicts on Python 3.13.
Fixed linting error in tests/event/device/test_mt_button_event.py.
Verified webrtc-models==0.3.0 is present in manifest.json.
Verified all tests pass locally.

---
*PR created automatically by Jules for task [15058941021282228696](https://jules.google.com/task/15058941021282228696) started by @brewmarsh*