### PR TITLE
fix: resolve aiodns conflict and clean up CI workflow

### DIFF
--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -67,14 +67,10 @@ jobs:
           uv pip install --system --prerelease=allow -r requirements_dev.txt
           uv pip install --system --prerelease=allow pytest-homeassistant-custom-component>=0.13.205
 
-      - name: Install HA Custom Component
-        # Note: This may temporarily downgrade aiodns, but the next step enforces strict versions.
-        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205"
-
       - name: Force Clean DNS Stack
         run: |
-          # FIX: removed -y flag which uv does not support
-          uv pip uninstall --system pycares aiodns
+          # FIX: use pip uninstall -y for forced removal
+          python -m pip uninstall -y pycares aiodns
           uv pip install --system --no-cache-dir pycares==4.11.0 aiodns==3.6.1
 
       - name: Install mypy
@@ -110,8 +106,8 @@ jobs:
 
       - name: Force Clean DNS Stack
         run: |
-          # FIX: removed -y flag which uv does not support
-          uv pip uninstall --system pycares aiodns
+          # FIX: use pip uninstall -y for forced removal
+          python -m pip uninstall -y pycares aiodns
           uv pip install --system --no-cache-dir pycares==4.11.0 aiodns==3.6.1
 
       - name: Install tools
@@ -153,14 +149,10 @@ jobs:
           uv pip install --system --prerelease=allow -r requirements_dev.txt
           uv pip install --system --prerelease=allow pytest-homeassistant-custom-component>=0.13.205
 
-      - name: Install HA Custom Component
-        # Note: This may temporarily downgrade aiodns, but the next step enforces strict versions.
-        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205"
-
       - name: Force Clean DNS Stack
         run: |
-          # FIX: removed -y flag which uv does not support
-          uv pip uninstall --system pycares aiodns
+          # FIX: use pip uninstall -y for forced removal
+          python -m pip uninstall -y pycares aiodns
           uv pip install --system --no-cache-dir pycares==4.11.0 aiodns==3.6.1
 
       - name: Run Tests


### PR DESCRIPTION
- Replaced `uv pip uninstall --system pycares aiodns` with `python -m pip uninstall -y pycares aiodns` to ensure reliable forced removal of conflicting packages in CI.
- Removed redundant `pytest-homeassistant-custom-component` installation steps in `type-check` and `test` jobs in `.github/workflows/reusable-quality-checks.yaml`.
- Verified `aiodns==3.6.1` and `pycares==4.11.0` hard lock to prevent Python 3.13 crashes.
- Verified `webrtc-models==0.3.0` requirement.
- Verified linting and tests pass.

---
*PR created automatically by Jules for task [2593777259169627503](https://jules.google.com/task/2593777259169627503) started by @brewmarsh*