### PR TITLE
Fix Ambiguous VLAN Device Names

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -33,9 +33,10 @@ class MerakiVLANEntity(BaseMerakiEntity):
         vlan_id = vlan.id
         if not vlan_id:
             raise ValueError("VLAN ID not found in VLAN data")
+        self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             identifiers={(self._config_entry.domain, f"vlan_{network_id}_{vlan_id}")},
-            name=vlan.name,
+            name=f"VLAN {vlan.id} - {vlan.name}",
             manufacturer="Cisco Meraki",
             model="VLAN",
             via_device=(self._config_entry.domain, f"network_{network_id}"),

--- a/custom_components/meraki_ha/sensor/network/vlan.py
+++ b/custom_components/meraki_ha/sensor/network/vlan.py
@@ -36,7 +36,7 @@ class MerakiVLANIDSensor(MerakiVLANEntity, SensorEntity):
         if not vlan_id:
             raise ValueError("VLAN ID should not be None here")
         self._attr_unique_id = get_vlan_entity_id(self._network_id, vlan_id, "vlan_id")
-        self._attr_name = "VLAN ID"
+        self._attr_translation_key = "vlan_id"
 
     @property
     def native_value(self) -> str | None:
@@ -66,7 +66,7 @@ class MerakiVLANIPv4EnabledSensor(MerakiVLANEntity, SensorEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "ipv4_enabled"
         )
-        self._attr_name = "IPv4 Enabled"
+        self._attr_translation_key = "ipv4_enabled"
 
     @property
     def native_value(self) -> bool:
@@ -96,7 +96,7 @@ class MerakiVLANIPv4InterfaceSensor(MerakiVLANEntity, SensorEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "ipv4_interface_ip"
         )
-        self._attr_name = "IPv4 Interface IP"
+        self._attr_translation_key = "ipv4_interface_ip"
 
     @property
     def native_value(self) -> str | None:
@@ -126,7 +126,7 @@ class MerakiVLANIPv4UplinkSensor(MerakiVLANEntity, SensorEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "ipv4_uplink"
         )
-        self._attr_name = "IPv4 Uplink"
+        self._attr_translation_key = "ipv4_uplink"
 
     @property
     def native_value(self) -> str | None:
@@ -157,7 +157,7 @@ class MerakiVLANIPv6EnabledSensor(MerakiVLANEntity, SensorEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "ipv6_enabled"
         )
-        self._attr_name = "IPv6 Enabled"
+        self._attr_translation_key = "ipv6_enabled"
 
     @property
     def native_value(self) -> bool:
@@ -190,7 +190,7 @@ class MerakiVLANIPv6InterfaceSensor(MerakiVLANEntity, SensorEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "ipv6_interface_ip"
         )
-        self._attr_name = "IPv6 Interface IP"
+        self._attr_translation_key = "ipv6_interface_ip"
 
     @property
     def native_value(self) -> str | None:
@@ -223,7 +223,7 @@ class MerakiVLANIPv6UplinkSensor(MerakiVLANEntity, SensorEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "ipv6_uplink"
         )
-        self._attr_name = "IPv6 Uplink"
+        self._attr_translation_key = "ipv6_uplink"
 
     @property
     def native_value(self) -> str | None:

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -85,52 +85,66 @@ def test_vlan_sensor_creation(mock_coordinator):
     assert len(vlan_sensors) == 14
 
     # Filter for sensors of the first VLAN
-    vlan1_sensors = [s for s in vlan_sensors if s.device_info["name"] == "VLAN 1"]
+    vlan1_sensors = [
+        s for s in vlan_sensors if s.device_info["name"] == "VLAN 1 - VLAN 1"
+    ]
     assert len(vlan1_sensors) == 7
 
     # Find the specific sensors for VLAN 1
-    id_sensor = next(s for s in vlan1_sensors if s.name == "VLAN ID")
-    ipv4_enabled_sensor = next(s for s in vlan1_sensors if s.name == "IPv4 Enabled")
-    ipv4_ip_sensor = next(s for s in vlan1_sensors if s.name == "IPv4 Interface IP")
-    ipv4_uplink_sensor = next(s for s in vlan1_sensors if s.name == "IPv4 Uplink")
-    ipv6_enabled_sensor = next(s for s in vlan1_sensors if s.name == "IPv6 Enabled")
-    ipv6_ip_sensor = next(s for s in vlan1_sensors if s.name == "IPv6 Interface IP")
-    ipv6_uplink_sensor = next(s for s in vlan1_sensors if s.name == "IPv6 Uplink")
+    id_sensor = next(s for s in vlan1_sensors if s.translation_key == "vlan_id")
+    ipv4_enabled_sensor = next(
+        s for s in vlan1_sensors if s.translation_key == "ipv4_enabled"
+    )
+    ipv4_ip_sensor = next(
+        s for s in vlan1_sensors if s.translation_key == "ipv4_interface_ip"
+    )
+    ipv4_uplink_sensor = next(
+        s for s in vlan1_sensors if s.translation_key == "ipv4_uplink"
+    )
+    ipv6_enabled_sensor = next(
+        s for s in vlan1_sensors if s.translation_key == "ipv6_enabled"
+    )
+    ipv6_ip_sensor = next(
+        s for s in vlan1_sensors if s.translation_key == "ipv6_interface_ip"
+    )
+    ipv6_uplink_sensor = next(
+        s for s in vlan1_sensors if s.translation_key == "ipv6_uplink"
+    )
 
     # Assertions for VLAN ID Sensor
     assert id_sensor.unique_id == "meraki_vlan_net1_1_vlan_id"
-    assert id_sensor.name == "VLAN ID"
+    assert id_sensor.translation_key == "vlan_id"
     assert id_sensor.native_value == 1
-    assert id_sensor.device_info["name"] == "VLAN 1"
+    assert id_sensor.device_info["name"] == "VLAN 1 - VLAN 1"
 
     # Assertions for IPv4 Enabled Sensor
     assert ipv4_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv4_enabled"
-    assert ipv4_enabled_sensor.name == "IPv4 Enabled"
+    assert ipv4_enabled_sensor.translation_key == "ipv4_enabled"
     assert ipv4_enabled_sensor.native_value is True
     # Logic for IPv4 Enabled: return self._vlan.appliance_ip is not None
     # vlan1 has appliance_ip, so True.
 
     # Assertions for IPv4 Interface IP Sensor
     assert ipv4_ip_sensor.unique_id == "meraki_vlan_net1_1_ipv4_interface_ip"
-    assert ipv4_ip_sensor.name == "IPv4 Interface IP"
+    assert ipv4_ip_sensor.translation_key == "ipv4_interface_ip"
     assert ipv4_ip_sensor.native_value == "192.168.1.1"
 
     # Assertions for IPv4 Uplink Sensor
     assert ipv4_uplink_sensor.unique_id == "meraki_vlan_net1_1_ipv4_uplink"
-    assert ipv4_uplink_sensor.name == "IPv4 Uplink"
+    assert ipv4_uplink_sensor.translation_key == "ipv4_uplink"
     assert ipv4_uplink_sensor.native_value == "Any"
 
     # Assertions for IPv6 Enabled Sensor
     assert ipv6_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv6_enabled"
-    assert ipv6_enabled_sensor.name == "IPv6 Enabled"
+    assert ipv6_enabled_sensor.translation_key == "ipv6_enabled"
     assert ipv6_enabled_sensor.native_value is True
 
     # Assertions for IPv6 Interface IP Sensor
     assert ipv6_ip_sensor.unique_id == "meraki_vlan_net1_1_ipv6_interface_ip"
-    assert ipv6_ip_sensor.name == "IPv6 Interface IP"
+    assert ipv6_ip_sensor.translation_key == "ipv6_interface_ip"
     assert ipv6_ip_sensor.native_value == "2001:db8:1::/64"
 
     # Assertions for IPv6 Uplink Sensor
     assert ipv6_uplink_sensor.unique_id == "meraki_vlan_net1_1_ipv6_uplink"
-    assert ipv6_uplink_sensor.name == "IPv6 Uplink"
+    assert ipv6_uplink_sensor.translation_key == "ipv6_uplink"
     assert ipv6_uplink_sensor.native_value == "WAN 1, WAN 2"


### PR DESCRIPTION
This commit resolves ambiguous VLAN device names by updating the naming scheme to `f"VLAN {vlan['id']} - {vlan['name']}"`. It also sets `_attr_has_entity_name = True` in the base entity class and updates relevant tests to ensure proper UI display and prevent regressions.

Fixes #1323

---
*PR created automatically by Jules for task [12157874274080569790](https://jules.google.com/task/12157874274080569790) started by @brewmarsh*