### PR TITLE
fix: Raise InvalidOrgID in authentication for specific error message

### DIFF
--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -91,7 +91,7 @@ class MerakiAuthentication:
                     "Organization ID %s not found in accessible organizations.",
                     self.organization_id,
                 )
-                raise ValueError(
+                raise InvalidOrgID(
                     f"Org ID {self.organization_id} not accessible with this API key.",
                 )
 
@@ -146,6 +146,8 @@ class MerakiAuthentication:
                 self.organization_id,
                 e,
             )
+            raise
+        except InvalidOrgID:
             raise
         except Exception as e:
             _LOGGER.error(

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -11,7 +11,10 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from custom_components.meraki_ha.authentication import (
     validate_meraki_credentials,
 )
-from custom_components.meraki_ha.core.errors import MerakiAuthenticationError
+from custom_components.meraki_ha.core.errors import (
+    InvalidOrgID,
+    MerakiAuthenticationError,
+)
 
 
 @pytest.mark.asyncio
@@ -48,7 +51,7 @@ async def test_validate_meraki_credentials_invalid_org(hass: HomeAssistant) -> N
         patch(
             "custom_components.meraki_ha.authentication.MerakiAPIClient",
         ) as mock_client,
-        pytest.raises(ValueError),
+        pytest.raises(InvalidOrgID),
     ):
         mock_client.return_value.organization.get_organizations = AsyncMock(
             return_value=[{"id": "other-org-id", "name": "Other Org"}],


### PR DESCRIPTION
Previously, when an Organization ID was not found in the list of accessible organizations, `ValueError` was raised. This caused the config flow to catch it as a generic `Exception` and display an "unknown" error. This change ensures `InvalidOrgID` is raised, which is correctly mapped to the "invalid_org_id" error message in the config flow.

---
*PR created automatically by Jules for task [6373037768591311147](https://jules.google.com/task/6373037768591311147) started by @brewmarsh*