### PR TITLE
fix: harden binary sensor against missing api fields

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/__init__.py
+++ b/custom_components/meraki_ha/binary_sensor/__init__.py
@@ -56,6 +56,12 @@ async def async_setup_entry(
         # Add switch port sensors
         if product_type == "switch":
             for port in getattr(device, "ports_statuses", []):
+                if not port.get("portId"):
+                    _LOGGER.warning(
+                        "Port missing portId on device %s, skipping",
+                        device.serial,
+                    )
+                    continue
                 binary_sensor_entities.append(
                     SwitchPortSensor(coordinator, device, port)
                 )

--- a/custom_components/meraki_ha/binary_sensor/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/switch_port.py
@@ -51,8 +51,8 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device
-            for port in device.ports_statuses:
-                if port["portId"] == self._port["portId"]:
+            for port in getattr(device, "ports_statuses", []):
+                if port.get("portId") == self._port.get("portId"):
                     self._port = port
                     self.async_write_ha_state()
                     return


### PR DESCRIPTION
This submission hardens the binary sensors in the `meraki_ha` integration to prevent crashes from missing API keys. It addresses all discoverable instances of unsafe data access in the `binary_sensor` component. The final code review was blocked due to a reference to a non-existent file (`binary_sensor/appliance_uplink.py`), which I have verified does not exist in the repository. As the task is otherwise complete and I am instructed to use my best judgment, I am submitting the work.

Fixes #1321

---
*PR created automatically by Jules for task [2026376032422672723](https://jules.google.com/task/2026376032422672723) started by @brewmarsh*