### PR TITLE
ci: move PAT_TOKEN to checkout step to enable admin bypass

### DIFF
--- a/.github/workflows/deploy-hacs.yml
+++ b/.github/workflows/deploy-hacs.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.base_ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up Python and Node.js
         uses: actions/setup-python@v6
@@ -72,7 +73,6 @@ jobs:
           commit_user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
           branch: ${{ github.base_ref }}
-          token: ${{ secrets.PAT_TOKEN }}
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change fixes the failing release workflow by moving the Personal Access Token to the `actions/checkout` step. This grants the entire job the necessary permissions to bypass branch protection rules and push version commits to the `beta` branch. The invalid `token` parameter was also removed from the `git-auto-commit-action` step.

Fixes #1333

---
*PR created automatically by Jules for task [2194186058243649847](https://jules.google.com/task/2194186058243649847) started by @brewmarsh*