### PR TITLE
Standardize VLAN and Network Device Naming Prefixes

### DIFF
--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -229,7 +229,6 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 device_registry.async_get_or_create(
                     config_entry_id=self.config_entry.entry_id,
                     identifiers={(DOMAIN, network.id)},
-                    # AGENT RULE: Apply standardized [Network] prefix
                     name=f"[Network] {network.name}",
                     manufacturer="Cisco Meraki",
                     model="Network",

--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -36,7 +36,7 @@ class MerakiVLANEntity(BaseMerakiEntity):
         self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(
             identifiers={(self._config_entry.domain, f"vlan_{network_id}_{vlan_id}")},
-            name=f"VLAN {vlan.id} - {vlan.name}",
+            name=f"[VLAN] {vlan.id} - {vlan.name}",
             manufacturer="Cisco Meraki",
             model="VLAN",
             via_device=(self._config_entry.domain, f"network_{network_id}"),

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -86,7 +86,7 @@ def test_vlan_sensor_creation(mock_coordinator):
 
     # Filter for sensors of the first VLAN
     vlan1_sensors = [
-        s for s in vlan_sensors if s.device_info["name"] == "VLAN 1 - VLAN 1"
+        s for s in vlan_sensors if s.device_info["name"] == "[VLAN] 1 - VLAN 1"
     ]
     assert len(vlan1_sensors) == 7
 
@@ -115,7 +115,7 @@ def test_vlan_sensor_creation(mock_coordinator):
     assert id_sensor.unique_id == "meraki_vlan_net1_1_vlan_id"
     assert id_sensor.translation_key == "vlan_id"
     assert id_sensor.native_value == 1
-    assert id_sensor.device_info["name"] == "VLAN 1 - VLAN 1"
+    assert id_sensor.device_info["name"] == "[VLAN] 1 - VLAN 1"
 
     # Assertions for IPv4 Enabled Sensor
     assert ipv4_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv4_enabled"


### PR DESCRIPTION
This commit standardizes the naming convention for "Network" and "VLAN" devices by prepending `[Network]` and `[VLAN]` to their names, respectively. This improves clarity and prevents naming collisions in the Device Registry. The changes have been tested and verified.

Fixes #1327

---
*PR created automatically by Jules for task [10178124832618213096](https://jules.google.com/task/10178124832618213096) started by @brewmarsh*