### PR TITLE
feat: add translation keys for event entities

### DIFF
--- a/custom_components/meraki_ha/event/device/camera_motion.py
+++ b/custom_components/meraki_ha/event/device/camera_motion.py
@@ -29,6 +29,7 @@ class MerakiCameraMotionEvent(MerakiEntity, EventEntity):
 
     _attr_device_class = EventDeviceClass.MOTION
     _attr_event_types = ["motion", "person", "vehicle"]
+    _attr_translation_key = "motion_event"
 
     def __init__(
         self,
@@ -43,7 +44,6 @@ class MerakiCameraMotionEvent(MerakiEntity, EventEntity):
         self._camera_service = camera_service
         self._config_entry = config_entry
         self._attr_unique_id = f"{device.serial}-motion-event"
-        self._attr_name = "Motion Event"
         self._last_timestamp: float = 0
         self._is_first_update = True
 

--- a/custom_components/meraki_ha/event/device/mt_button.py
+++ b/custom_components/meraki_ha/event/device/mt_button.py
@@ -28,6 +28,7 @@ class MerakiMtButtonEvent(MerakiEntity, EventEntity):
 
     _attr_device_class = EventDeviceClass.BUTTON
     _attr_event_types = ["short_press", "long_press"]
+    _attr_translation_key = "button_press"
 
     def __init__(
         self,
@@ -40,7 +41,6 @@ class MerakiMtButtonEvent(MerakiEntity, EventEntity):
         self._device = device
         self._config_entry = config_entry
         self._attr_unique_id = f"{device.serial}-button-event"
-        self._attr_name = "Button Press"
         self._last_ts: str = ""
 
     @property

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -112,6 +112,14 @@
       "meraki_ssid_name": {
         "name": "SSID Name"
       }
+    },
+    "event": {
+      "motion_event": {
+        "name": "Motion Event"
+      },
+      "button_press": {
+        "name": "Button Press"
+      }
     }
   }
 }

--- a/tests/event/device/test_camera_motion_event.py
+++ b/tests/event/device/test_camera_motion_event.py
@@ -36,7 +36,7 @@ async def test_camera_motion_event_initialization(
         )
 
         assert entity.unique_id == "Q2XX-XXXX-XXXX-motion-event"
-        assert entity.name == "Motion Event"
+        assert entity.translation_key == "motion_event"
         assert entity.device_class == EventDeviceClass.MOTION
         assert entity.event_types == ["motion", "person", "vehicle"]
     assert entity.should_poll is True

--- a/tests/event/device/test_mt_button_event.py
+++ b/tests/event/device/test_mt_button_event.py
@@ -24,7 +24,7 @@ async def test_mt_button_event_initialization(
         entity = MerakiMtButtonEvent(mock_coordinator, device, mock_config_entry)
 
         assert entity.unique_id == "Q2XX-XXXX-XXXX-button-event"
-        assert entity.name == "Button Press"
+        assert entity.translation_key == "button_press"
         assert entity.device_class == EventDeviceClass.BUTTON
         assert entity.event_types == ["short_press", "long_press"]
         assert entity._last_ts == ""


### PR DESCRIPTION
Refactors MerakiCameraMotionEvent and MerakiMtButtonEvent to use `translation_key` instead of hardcoded `name` attributes. Updates `strings.json` with the corresponding keys. This aligns with Home Assistant best practices for entity naming and localization.

---
*PR created automatically by Jules for task [12729034447064775398](https://jules.google.com/task/12729034447064775398) started by @brewmarsh*