### PR TITLE
feat: Improve switch port power calculation using scan interval

### DIFF
--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -203,7 +203,14 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Fetch data from API endpoint, apply filters, and handle exceptions."""
         try:
             # Pass the last known successful data to the API client
-            data = await self.api.get_all_data(self.last_successful_data)
+            timespan = (
+                int(self.update_interval.total_seconds())
+                if self.update_interval
+                else None
+            )
+            data = await self.api.get_all_data(
+                self.last_successful_data, timespan=timespan
+            )
 
             if not data:
                 _LOGGER.warning("API call to get_all_data returned no data.")

--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -264,6 +264,7 @@ class MerakiAPIClient:
         self,
         networks: list[MerakiNetwork],
         devices: list[MerakiDevice],
+        timespan: int | None = None,
     ) -> dict[str, asyncio.Task[Any]]:
         """
         Build a dictionary of tasks to fetch detailed data.
@@ -271,6 +272,7 @@ class MerakiAPIClient:
         Args:
             networks: A list of networks.
             devices: A list of devices.
+            timespan: The timespan to use for switch port statuses.
 
         Returns
         -------
@@ -357,7 +359,9 @@ class MerakiAPIClient:
             elif device.product_type == "switch":
                 detail_tasks[f"ports_statuses_{device.serial}"] = asyncio.create_task(
                     self._run_with_semaphore(
-                        self.switch.get_device_switch_ports_statuses(device.serial),
+                        self.switch.get_device_switch_ports_statuses(
+                            device.serial, timespan=timespan
+                        ),
                     )
                 )
             elif device.product_type == "appliance" and device.network_id:
@@ -375,12 +379,14 @@ class MerakiAPIClient:
     async def get_all_data(
         self,
         previous_data: dict[str, Any] | None = None,
+        timespan: int | None = None,
     ) -> dict[str, Any]:
         """
         Fetch all data from the Meraki API concurrently, with caching.
 
         Args:
             previous_data: The previous data from the coordinator.
+            timespan: The timespan to use for switch port statuses.
 
         Returns
         -------
@@ -430,7 +436,9 @@ class MerakiAPIClient:
         parse_appliance_data(devices_list, appliance_uplink_statuses)
         parse_sensor_data(devices_list, sensor_readings, battery_readings)
 
-        detail_tasks = self._build_detail_tasks(networks_list, devices_list)
+        detail_tasks = self._build_detail_tasks(
+            networks_list, devices_list, timespan=timespan
+        )
         detail_results = await asyncio.gather(
             *detail_tasks.values(),
             return_exceptions=True,

--- a/custom_components/meraki_ha/core/api/endpoints/switch.py
+++ b/custom_components/meraki_ha/core/api/endpoints/switch.py
@@ -37,7 +37,9 @@ class SwitchEndpoints:
     @handle_meraki_errors
     @async_timed_cache(timeout=60)
     async def get_device_switch_ports_statuses(
-        self, serial: str
+        self,
+        serial: str,
+        timespan: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get statuses for all ports of a switch.
@@ -45,14 +47,19 @@ class SwitchEndpoints:
         Args:
         ----
             serial: The serial number of the switch.
+            timespan: The timespan for which the information will be fetched.
 
         Returns
         -------
             A list of port statuses.
 
         """
+        kwargs: dict[str, Any] = {"serial": serial}
+        if timespan:
+            kwargs["timespan"] = timespan
+
         statuses = await self._api_client.run_sync(
-            self._dashboard.switch.getDeviceSwitchPortsStatuses, serial=serial
+            self._dashboard.switch.getDeviceSwitchPortsStatuses, **kwargs
         )
         validated = validate_response(statuses)
         if not isinstance(validated, list):

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -139,12 +139,26 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
         """Return the state of the sensor."""
         power_usage_wh = self._port.get("powerUsageInWh", 0) or 0
         if power_usage_wh > 0:
-            return round(power_usage_wh / 24, 2)
+            timespan = (
+                self.coordinator.update_interval.total_seconds()
+                if self.coordinator.update_interval
+                else 86400
+            )
+            # Avoid division by zero
+            if timespan <= 0:
+                timespan = 86400
+
+            # Power (W) = Energy (Wh) * 3600 (s/h) / Timespan (s)
+            return round(power_usage_wh * 3600 / timespan, 2)
         return 0.0
 
 
 class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
-    """Representation of a Meraki switch port energy sensor."""
+    """
+    Representation of a Meraki switch port energy sensor.
+
+    This sensor reports the energy consumed during the last scan interval.
+    """
 
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR

--- a/tests/core/api/test_client.py
+++ b/tests/core/api/test_client.py
@@ -180,6 +180,51 @@ async def test_build_detail_tasks_for_wireless_device(api_client):
 
 
 @pytest.mark.asyncio
+async def test_build_detail_tasks_propagates_timespan(api_client):
+    """Test that _build_detail_tasks passes timespan to switch endpoint."""
+    # Arrange
+    api_client.switch.get_device_switch_ports_statuses = AsyncMock()
+
+    # Mock _run_with_semaphore to return the task directly
+    async def side_effect(coro):
+        return await coro
+
+    api_client._run_with_semaphore = MagicMock(side_effect=side_effect)
+
+    device = MerakiDevice(
+        serial="Q123", product_type="switch", model="MS120", name="Switch"
+    )
+
+    # Act
+    tasks = api_client._build_detail_tasks([], [device], timespan=300)
+
+    # Cleanup
+    for task in tasks.values():
+        await task
+
+    # Assert
+    api_client.switch.get_device_switch_ports_statuses.assert_called_with(
+        "Q123", timespan=300
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_all_data_propagates_timespan(api_client):
+    """Test that get_all_data passes timespan to _build_detail_tasks."""
+    # Arrange
+    api_client._async_fetch_initial_data = AsyncMock(return_value={})
+    api_client._build_detail_tasks = MagicMock(return_value={})
+    api_client._async_fetch_network_clients = AsyncMock(return_value=[])
+    api_client._async_fetch_device_clients = AsyncMock(return_value={})
+
+    # Act
+    await api_client.get_all_data(timespan=300)
+
+    # Assert
+    api_client._build_detail_tasks.assert_called_with([], [], timespan=300)
+
+
+@pytest.mark.asyncio
 async def test_get_all_data_includes_switch_ports(api_client):
     """Test that get_all_data returns switch ports statuses."""
     # Arrange


### PR DESCRIPTION
This PR improves the accuracy of Meraki switch port power sensors by calculating power based on the actual scan interval rather than a fixed 24-hour window.

Changes:
- Modified `getDeviceSwitchPortsStatuses` API call to accept a `timespan` parameter.
- The `MerakiDataUpdateCoordinator` now passes the configured `scan_interval` (default 300s) as the `timespan` for fetching switch port statuses.
- `MerakiSwitchPortPowerSensor` now calculates Watts as `Energy (Wh) * 3600 / Timespan (s)`.
- `MerakiSwitchPortEnergySensor` now reports the energy consumed during the last scan interval (e.g., 5 minutes), instead of the last 24 hours.

This addresses the roadmap item: "Add real-time Power (W) sensors for MS Switches".

---
*PR created automatically by Jules for task [5048263718840477314](https://jules.google.com/task/5048263718840477314) started by @brewmarsh*