### PR TITLE
fix: resolve linting errors and verify requirements

### DIFF
--- a/custom_components/meraki_ha/core/utils/api_utils.py
+++ b/custom_components/meraki_ha/core/utils/api_utils.py
@@ -53,7 +53,8 @@ def handle_meraki_errors(
                     func.__name__,
                     err,
                 )
-                # Inspect the wrapped function's return type to return a safe empty value
+                # Inspect the wrapped function's return type
+                # to return a safe empty value
                 sig = inspect.signature(func)
                 return_type = sig.return_annotation
                 if return_type is list or getattr(
@@ -106,7 +107,9 @@ def handle_meraki_errors(
                 _LOGGER.error("Unexpected error: %s", err)
                 raise MerakiConnectionError(f"Unexpected error: {err}") from err
 
-        raise MerakiConnectionError("API call failed after multiple retries") from last_err
+        raise MerakiConnectionError(
+            "API call failed after multiple retries"
+        ) from last_err
 
     return cast(Callable[..., Awaitable[T]], wrapper)
 

--- a/tests/core/test_api_utils.py
+++ b/tests/core/test_api_utils.py
@@ -1,5 +1,4 @@
 """Test the API utility functions."""
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Fixed linting errors in `custom_components/meraki_ha/core/utils/api_utils.py` which were causing CI failures. Also verified that all dependency requirements (aiodns, pycares, webrtc-models) are correctly pinned as requested.

---
*PR created automatically by Jules for task [15070255488239987421](https://jules.google.com/task/15070255488239987421) started by @brewmarsh*