### PR TITLE
fix: CI conflicts and linting errors

### DIFF
--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -56,6 +56,8 @@ class MerakiPoeUsageSensor(
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
+        self._last_update_timestamp: float | None = None
+        self._duration_seconds: float = 300.0
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -78,7 +80,7 @@ class MerakiPoeUsageSensor(
             self._device = device
 
             now = time.time()
-            if hasattr(self, "_last_update_timestamp"):
+            if self._last_update_timestamp is not None:
                 self._duration_seconds = now - self._last_update_timestamp
             else:
                 self._duration_seconds = (
@@ -104,7 +106,7 @@ class MerakiPoeUsageSensor(
         if total_poe_usage_wh <= 0:
             return 0.0
 
-        duration_hours = getattr(self, "_duration_seconds", 300) / 3600
+        duration_hours = self._duration_seconds / 3600
         if duration_hours <= 0:
             return 0.0
 

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -110,6 +110,8 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
             f"{self._device.serial}_port_{self._port['portId']}_power"
         )
         self._attr_name = f"Port {self._port['portId']} Power"
+        self._last_update_timestamp: float | None = None
+        self._duration_seconds: float = 300.0
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -136,7 +138,7 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
                 break
 
         now = time.time()
-        if hasattr(self, "_last_update_timestamp"):
+        if self._last_update_timestamp is not None:
             self._duration_seconds = now - self._last_update_timestamp
         else:
             self._duration_seconds = (
@@ -155,7 +157,7 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
         if power_usage_wh <= 0:
             return 0.0
 
-        duration_hours = getattr(self, "_duration_seconds", 300) / 3600
+        duration_hours = self._duration_seconds / 3600
         if duration_hours <= 0:
             return 0.0
 

--- a/requirements_test_isolated.txt
+++ b/requirements_test_isolated.txt
@@ -6,4 +6,6 @@ pytest-socket
 pytest-mock
 aiortc
 meraki
-webrtc-models
+webrtc-models==0.3.0
+aiodns==3.6.1
+pycares==4.11.0


### PR DESCRIPTION
- Resolved `pycares`/`aiodns` conflicts by hard-locking versions in `requirements_test_isolated.txt` to prevent Python 3.13 crashes.
- Pinned `webrtc-models==0.3.0` in `requirements_test_isolated.txt` for consistency with `manifest.json`.
- Fixed `mypy` errors in `MerakiSwitchPortPowerSensor` and `MerakiPoeUsageSensor` by initializing `_last_update_timestamp` and `_duration_seconds` in `__init__`.
- Verified code quality with `ruff`, `bandit`, and `mypy`.
- Verified tests with `pytest`.

---
*PR created automatically by Jules for task [12175439662340657638](https://jules.google.com/task/12175439662340657638) started by @brewmarsh*