### PR TITLE
Implement cumulative energy sensor for switch ports

### DIFF
--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, cast
 
 from homeassistant.components.sensor import (
@@ -13,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfPower
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinator import MerakiDataUpdateCoordinator
@@ -153,16 +155,16 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
         return 0.0
 
 
-class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
+class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity, RestoreEntity):
     """
     Representation of a Meraki switch port energy sensor.
 
-    This sensor reports the energy consumed during the last scan interval.
+    This sensor accumulates the incremental energy reported by the API.
     """
 
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_translation_key = "energy"
 
     def __init__(
@@ -184,6 +186,9 @@ class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
         )
         self._attr_name = f"Port {self._port['portId']} Energy"
 
+        self._total_energy: float = 0.0
+        self._last_update_timestamp: datetime | None = None
+
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
@@ -196,15 +201,37 @@ class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
         """Return if the entity is available."""
         return self._device.status == "online"
 
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in ("unknown", "unavailable"):
+            try:
+                self._total_energy = float(last_state.state)
+            except ValueError:
+                self._total_energy = 0.0
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        # Only process if we have a new update
+        if (
+            self.coordinator.last_successful_update is None
+            or self.coordinator.last_successful_update == self._last_update_timestamp
+        ):
+            return
+
+        self._last_update_timestamp = self.coordinator.last_successful_update
+
         for device in self.coordinator.data.get("devices", []):
             if device.serial == self._device.serial:
                 self._device = device
                 for port in self._device.ports_statuses:
                     if port["portId"] == self._port["portId"]:
                         self._port = port
+                        # Add incremental energy
+                        increment = self._port.get("powerUsageInWh", 0) or 0
+                        self._total_energy += increment
                         break
                 break
         self.async_write_ha_state()
@@ -212,4 +239,4 @@ class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         """Return the state of the sensor."""
-        return self._port.get("powerUsageInWh", 0) or 0
+        return round(self._total_energy, 2)

--- a/tests/sensor/device/test_switch_port.py
+++ b/tests/sensor/device/test_switch_port.py
@@ -1,10 +1,12 @@
 """Tests for the Switch Port Power and Energy sensors."""
 
-from unittest.mock import MagicMock
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.core import State
 
 from custom_components.meraki_ha.sensor.device.switch_port import (
     MerakiSwitchPortEnergySensor,
@@ -30,6 +32,7 @@ def mock_coordinator_and_device():
     )
     coordinator.data = {"devices": [device]}
     coordinator.get_device.return_value = device
+    coordinator.last_successful_update = None
     return coordinator, device
 
 
@@ -79,20 +82,95 @@ def test_switch_port_power_sensor_invalid_interval(mock_coordinator_and_device):
 
 
 def test_switch_port_energy_sensor(mock_coordinator_and_device):
-    """Test the switch port energy sensor."""
+    """Test the switch port energy sensor initial state."""
     coordinator, device = mock_coordinator_and_device
     port = device.ports_statuses[0]
     config_entry = MagicMock()
 
     sensor = MerakiSwitchPortEnergySensor(coordinator, device, port, config_entry)
+    sensor.async_write_ha_state = MagicMock()
 
     assert sensor.unique_id == "Q234-ABCD-5678_port_1_energy"
     assert sensor.translation_key == "energy"
     assert sensor.device_class == SensorDeviceClass.ENERGY
     assert sensor.native_unit_of_measurement == UnitOfEnergy.WATT_HOUR
-    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    # Changed from MEASUREMENT to TOTAL_INCREASING
+    assert sensor.state_class == SensorStateClass.TOTAL_INCREASING
 
-    assert sensor.native_value == 240
+    # Initially 0 until update is processed
+    assert sensor.native_value == 0.0
+
+    # Trigger first update
+    coordinator.last_successful_update = datetime(2023, 1, 1, 12, 0, 0)
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == 240.0
+
+
+def test_switch_port_energy_sensor_accumulation(mock_coordinator_and_device):
+    """Test that the energy sensor accumulates value over multiple updates."""
+    coordinator, device = mock_coordinator_and_device
+    port = device.ports_statuses[0]  # Initially 240 Wh
+    config_entry = MagicMock()
+
+    sensor = MerakiSwitchPortEnergySensor(coordinator, device, port, config_entry)
+    sensor.async_write_ha_state = MagicMock()
+
+    # 1. First update
+    coordinator.last_successful_update = datetime(2023, 1, 1, 12, 0, 0)
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == 240.0
+
+    # 2. Second update with new data
+    # Simulate API returning new data (same object modified for simplicity in mock)
+    # Let's say next interval used 100 Wh
+    device.ports_statuses[0]["powerUsageInWh"] = 100
+    coordinator.last_successful_update = datetime(2023, 1, 1, 12, 5, 0)
+
+    sensor._handle_coordinator_update()
+    # Should be 240 + 100 = 340
+    assert sensor.native_value == 340.0
+
+    # 3. Duplicate update (same timestamp)
+    # Should NOT accumulate
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == 340.0
+
+
+async def test_switch_port_energy_sensor_restore():
+    """Test that the energy sensor restores state from registry."""
+    coordinator = MagicMock()
+    device = MerakiDevice(
+        serial="Q234-ABCD-5678",
+        name="Test Switch",
+        model="MS220-8P",
+        product_type="switch",
+        ports_statuses=[{"portId": "1", "powerUsageInWh": 50}],
+    )
+    coordinator.data = {"devices": [device]}
+    coordinator.get_device.return_value = device
+    coordinator.last_successful_update = None
+
+    port = device.ports_statuses[0]
+    config_entry = MagicMock()
+
+    sensor = MerakiSwitchPortEnergySensor(coordinator, device, port, config_entry)
+    sensor.hass = MagicMock()
+    sensor.async_write_ha_state = MagicMock()
+
+    # Mock async_get_last_state
+    mock_restore = AsyncMock(return_value=State("sensor.test", "1000.5"))
+    with patch.object(sensor, "async_get_last_state", mock_restore):
+        await sensor.async_added_to_hass()
+
+    # Should have restored 1000.5
+    assert sensor.native_value == 1000.5
+
+    # Now verify new update adds to restored value
+    coordinator.last_successful_update = datetime(2023, 1, 1, 12, 0, 0)
+    sensor._handle_coordinator_update()
+
+    # 1000.5 + 50 = 1050.5
+    assert sensor.native_value == 1050.5
 
 
 def test_switch_port_power_sensor_missing_data(mock_coordinator_and_device):
@@ -112,4 +190,9 @@ def test_switch_port_energy_sensor_missing_data(mock_coordinator_and_device):
     config_entry = MagicMock()
 
     sensor = MerakiSwitchPortEnergySensor(coordinator, device, port, config_entry)
-    assert sensor.native_value == 0
+    sensor.async_write_ha_state = MagicMock()
+
+    coordinator.last_successful_update = datetime(2023, 1, 1, 12, 0, 0)
+    sensor._handle_coordinator_update()
+
+    assert sensor.native_value == 0.0


### PR DESCRIPTION
Updated `MerakiSwitchPortEnergySensor` to use `TOTAL_INCREASING` state class and accumulate incremental energy usage reported by the API. Implemented state restoration to persist totals across restarts.

---
*PR created automatically by Jules for task [4440601947518594558](https://jules.google.com/task/4440601947518594558) started by @brewmarsh*