### PR TITLE
Fix CI dependencies and conflicts

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -20,7 +20,7 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 pytest>=8.3.4
-PyTurboJPEG
+PyTurboJPEG==1.8.2
 ruff
 setuptools==78.1.1
 types-aiofiles==25.1.0.20251011

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -6,6 +6,7 @@ pip install uv
 
 echo "Installing dependencies..."
 uv pip install --system --prerelease=allow -r requirements_dev.txt
+uv pip install --system --prerelease=allow pytest-homeassistant-custom-component>=0.13.205
 
 # Force reinstall aiodns and pycares to match Python 3.13 compatibility requirements
 # even if Home Assistant pins older versions.


### PR DESCRIPTION
This PR addresses CI failures by ensuring `pytest-homeassistant-custom-component` is correctly installed in the local check script and pinning `PyTurboJPEG` in test requirements. It also cleans up a garbage file and verifies critical dependencies for Python 3.13 support.

---
*PR created automatically by Jules for task [8845839373271303314](https://jules.google.com/task/8845839373271303314) started by @brewmarsh*