### PR TITLE
fix(ci): Resolve pycares/aiodns conflicts and fix imports

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -9,7 +9,11 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+try:
+    from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+except ImportError:
+    from homeassistant.components.dhcp import DhcpServiceInfo
 
 from .authentication import validate_meraki_credentials
 from .const import (

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -22,7 +22,7 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 pytest>=8.3.4
-PyTurboJPEG
+PyTurboJPEG==1.8.2
 ruff
 setuptools==78.1.1
 types-aiofiles==25.1.0.20251011


### PR DESCRIPTION
Resolved CI failures by fixing dependency versions and updating import paths for compatibility.

1.  **Dependency Fixes:**
    *   Pinned `PyTurboJPEG==1.8.2` in `requirements_test.txt`.
    *   Verified `aiodns==3.6.1` and `pycares==4.11.0`.
    *   Verified `webrtc-models==0.3.0`.

2.  **Code Fixes:**
    *   Updated `custom_components/meraki_ha/config_flow.py` to handle the relocation of `DhcpServiceInfo` in newer Home Assistant versions using a `try...except ImportError` block.

3.  **Verification:**
    *   Ran `ruff` (passed).
    *   Ran `pytest` (passed 200 tests).

---
*PR created automatically by Jules for task [14791873353542730257](https://jules.google.com/task/14791873353542730257) started by @brewmarsh*