### PR TITLE
Fix: Add Missing InvalidOrgID Exception Class

### DIFF
--- a/custom_components/meraki_ha/core/errors.py
+++ b/custom_components/meraki_ha/core/errors.py
@@ -39,3 +39,7 @@ class MerakiNetworkError(MerakiHAException):
 
 class MerakiVlansDisabledError(MerakiInformationalError):
     """Error to indicate that VLANs are not enabled for a network."""
+
+
+class InvalidOrgID(MerakiHAException):
+    """Error to indicate the Organization ID is invalid."""


### PR DESCRIPTION
This change adds the `InvalidOrgID` exception class to `custom_components/meraki_ha/core/errors.py` to fix an `ImportError` that was causing the integration to crash. The `DhcpServiceInfo` deprecation warning was not addressed as the import could not be found.

Fixes #1407

---
*PR created automatically by Jules for task [10035057236159577969](https://jules.google.com/task/10035057236159577969) started by @brewmarsh*