### PR TITLE
fix(deps): update manifest and requirements

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -13,8 +13,7 @@
   "quality_scale": "platinum",
   "requirements": [
     "aiofiles==23.2.1",
-    "aiohttp>=3.13.2",
-    "urllib3>=2.6.2"
+    "meraki==1.53.0"
   ],
   "version": "2.0.0-beta.70"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiodns==3.6.1
 aiofiles==23.2.1
 aiohttp>=3.13.2
 diskcache==5.6.3
-meraki==1.36.0
+meraki==1.53.0
 playwright
 protobuf==4.25.3
 pycares==4.11.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,6 @@ bandit==1.7.9
 filelock==3.20.3
 flake8==7.0.0
 meraki==1.53.0
-orjson>=3.10.7
 pip-audit==2.7.3
 playwright==1.39.0
 pytest-homeassistant-custom-component==0.13.205


### PR DESCRIPTION
This PR fixes the quality check failures by correcting the `manifest.json` and requirement files. 

- `meraki==1.53.0` was missing from `manifest.json` requirements, which is critical for the integration.
- `aiohttp` and `urllib3` were pinned in `manifest.json`, which is discouraged for Home Assistant custom components as they are provided by core.
- `requirements.txt` and `requirements_test.txt` were updated to match the correct versions and sorting rules.
- `orjson` pin was removed from `requirements_test.txt` to avoid potential build issues in CI environments, relying on Home Assistant or other packages to provide it if needed.

---
*PR created automatically by Jules for task [10995231385261070271](https://jules.google.com/task/10995231385261070271) started by @brewmarsh*