### PR TITLE
fix(ci): Resolve pycares/aiodns conflicts and fix dependencies

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -39,12 +39,10 @@
   "requirements": [
     "aiodns==3.6.1",
     "aiofiles>=24.1.0",
-    "aiohttp>=3.8.1",
     "diskcache==5.6.3",
     "meraki>=1.53.0",
     "orjson>=3.9.0",
     "pycares==4.11.0",
-    "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
   "version": "2.2.1-beta.34"

--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,8 +1,6 @@
 aiodns==3.6.1
 aiofiles>=24.1.0
-aiohttp>=3.8.1
 meraki>=1.53.0
 orjson>=3.9.0
 pycares==4.11.0
-urllib3>=1.26.5
 webrtc-models==0.3.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,6 @@ aiofiles==23.2.1
 aiohttp==3.13.3
 bandit==1.7.9
 diskcache==5.6.3
-flake8==7.0.0
 greenlet==3.3.0
 homeassistant==2026.1.0b4
 janus==1.0.0

--- a/tests/sensor/ssid/test_ssid_connected_clients.py
+++ b/tests/sensor/ssid/test_ssid_connected_clients.py
@@ -3,11 +3,11 @@
 from unittest.mock import MagicMock
 
 import pytest
+
+from custom_components.meraki_ha.const import DOMAIN
 from custom_components.meraki_ha.sensor.ssid.connected_clients import (
     MerakiSsidConnectedClientsSensor,
 )
-
-from custom_components.meraki_ha.const import DOMAIN
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolved dependency conflicts and linting errors to fix CI failures.
- Removed `aiohttp` and `urllib3` from `manifest.json` and `requirements.txt` to avoid conflicts with Home Assistant Core.
- Removed deprecated `flake8` from `requirements_test.txt`.
- Ensured `aiodns==3.6.1` and `pycares==4.11.0` are pinned.
- Ensured `webrtc-models==0.3.0` is present.
- Fixed import sorting in `tests/sensor/ssid/test_ssid_connected_clients.py` using Ruff.

---
*PR created automatically by Jules for task [13973466516206252733](https://jules.google.com/task/13973466516206252733) started by @brewmarsh*