### PR TITLE
Resolve CI dependency conflicts and linting errors

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -38,7 +38,7 @@
   "quality_scale": "platinum",
   "requirements": [
     "aiodns==3.6.1",
-    "aiofiles>=24.1.0",
+    "aiofiles>=23.2.1",
     "aiohttp>=3.8.1",
     "diskcache==5.6.3",
     "meraki>=1.53.0",

--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,5 +1,5 @@
 aiodns==3.6.1
-aiofiles>=24.1.0
+aiofiles>=23.2.1
 aiohttp>=3.8.1
 meraki>=1.53.0
 orjson>=3.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiodhcpwatcher
 aiodiscover
 aiodns==3.6.1
-aiofiles>=24.1.0
+aiofiles>=23.2.1
 aiohttp>=3.8.1
 bandit==1.7.9
 codecov

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,6 @@ aiofiles==23.2.1
 aiohttp==3.13.3
 bandit==1.7.9
 diskcache==5.6.3
-flake8==7.0.0
 greenlet==3.3.0
 homeassistant==2026.1.0b4
 janus==1.0.0

--- a/requirements_test_minimal.txt
+++ b/requirements_test_minimal.txt
@@ -1,7 +1,10 @@
+aiodns==3.6.1
+aiofiles>=23.2.1
 bandit==1.7.9
-flake8==7.0.0
 meraki>=1.53.0
+pycares==4.11.0
 pytest-cov
 pytest-homeassistant-custom-component
 pytest-mock==3.12.0
 ruff==0.5.5
+webrtc-models==0.3.0

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -40,5 +40,4 @@ janus
 psutil-home-assistant
 pillow
 fnv-hash-fast
-flake8
 urllib3


### PR DESCRIPTION
Hard lock `aiodns==3.6.1` and `pycares==4.11.0` in `requirements_test_minimal.txt` to prevent crashes on Python 3.13.
Update `aiofiles` version to `>=23.2.1` in `manifest.json`, `requirements.txt`, and `custom_components/meraki_ha/requirements.txt` to resolve version conflicts with dev dependencies.
Remove `flake8` from `requirements_test.txt`, `requirements_test_minimal.txt`, and `requirements_test_unpinned.txt` as it has been replaced by `ruff`.
Add `webrtc-models==0.3.0` to `requirements_test_minimal.txt`.
Verified `manifest.json` correctly lists `aiodns`, `pycares`, and `webrtc-models`.
Verified `ruff` passes locally.
Note: Local tests fail due to Python 3.12 environment incompatibility with Python 3.13-only test dependencies (Home Assistant 2026.1.0b4), but dependency files are now correct for CI environments.

---
*PR created automatically by Jules for task [17782944604931974558](https://jules.google.com/task/17782944604931974558) started by @brewmarsh*