### PR TITLE
fix(vlan): Instantiate VlansListSensor and verify dependencies

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from ...const import (
     CONF_ENABLE_NETWORK_SENSORS,
+    CONF_ENABLE_VLAN_MANAGEMENT,
     CONF_ENABLE_VLAN_SENSORS,
 )
 from ...sensor.network.network_clients import MerakiNetworkClientsSensor
@@ -106,6 +107,18 @@ class NetworkHandler(BaseHandler):
                     )
 
             # VLAN Sensors
+            # VLANs List Sensor
+            if self._config_entry.options.get(CONF_ENABLE_VLAN_MANAGEMENT, False):
+                from ...sensor.network.vlans_list import VlansListSensor
+
+                entities.append(
+                    VlansListSensor(
+                        self._coordinator,
+                        self._config_entry,
+                        network,
+                    )
+                )
+
             if self._config_entry.options.get(CONF_ENABLE_VLAN_SENSORS, True):
                 vlans = self._coordinator.data.get("vlans", {}).get(network.id, [])
                 if vlans:


### PR DESCRIPTION
Fixed a regression where `VlansListSensor` was not being instantiated in `NetworkHandler`, causing test failures in `tests/sensor/network/test_vlans_list.py`.
Verified that `manifest.json` and `requirements_test.txt` contain the required dependencies (`aiodns==3.6.1`, `pycares==4.11.0`, `webrtc-models==0.3.0`) to resolve CI conflicts and crashes on Python 3.13.
Deleted accidental garbage file `=23.2.1`.

---
*PR created automatically by Jules for task [7547960421926209485](https://jules.google.com/task/7547960421926209485) started by @brewmarsh*