### PR TITLE
fix(vlan): Correct attribute access error in MerakiVLANEntity

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -29,7 +29,7 @@ class MerakiVLANEntity(BaseMerakiEntity):
         if self._network_id is None:
             raise ValueError("Network ID cannot be None for a VLAN entity")
 
-        vlan_id = vlan.id
+        vlan_id = vlan["id"]
 
         if not vlan_id:
             raise ValueError("VLAN ID not found in VLAN data")


### PR DESCRIPTION
Fixed `AttributeError` in `MerakiVLANEntity` by changing `vlan.id` to `vlan['id']` to correctly access dictionary data. Verified that `webrtc-models`, `aiodns`, and `pycares` are correctly pinned in requirement files.

---
*PR created automatically by Jules for task [9492714735904251105](https://jules.google.com/task/9492714735904251105) started by @brewmarsh*