### PR TITLE
fix(vlan): Resolve AttributeError in VLAN entity and cleanup dependencies

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -29,7 +29,7 @@ class MerakiVLANEntity(BaseMerakiEntity):
         if self._network_id is None:
             raise ValueError("Network ID cannot be None for a VLAN entity")
 
-        vlan_id = vlan.id
+        vlan_id = vlan["id"]
 
         if not vlan_id:
             raise ValueError("VLAN ID not found in VLAN data")

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -40,5 +40,4 @@ janus
 psutil-home-assistant
 pillow
 fnv-hash-fast
-flake8
 urllib3


### PR DESCRIPTION
Resolved CI failures by fixing a regression in `MerakiVLANEntity` where `vlan` data (now a dictionary) was being accessed as an object. Also cleaned up `requirements_test_unpinned.txt` by removing the deprecated `flake8` dependency. Verified that `webrtc-models` is correctly listed in `manifest.json` and strict version pins for `aiodns`/`pycares` are in place (from previous commits).

---
*PR created automatically by Jules for task [619946607352849792](https://jules.google.com/task/619946607352849792) started by @brewmarsh*