### PR TITLE
Fix Sensor Platform Crash (NoneType error)

### DIFF
--- a/custom_components/meraki_ha/sensor/__init__.py
+++ b/custom_components/meraki_ha/sensor/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -28,7 +29,7 @@ async def async_setup_entry(
     sensor_entities = [
         entity
         for entity in discovery_service.all_entities
-        if entity.platform.domain == "sensor"
+        if isinstance(entity, SensorEntity)
     ]
 
     # Filter out organization sensors if disabled


### PR DESCRIPTION
This pull request resolves a `NoneType` error that occurred during the sensor platform setup. The issue was caused by an incorrect entity filtering method, which has now been updated to use a more robust `isinstance` check. This change prevents the integration from crashing and aligns the code with Home Assistant's best practices. All relevant static analysis checks have passed, and a code review has confirmed the correctness of the fix.

Fixes #1480

---
*PR created automatically by Jules for task [12764045697750026385](https://jules.google.com/task/12764045697750026385) started by @brewmarsh*