### PR TITLE
Fix Webhook Logging to Reveal the Real Error

### DIFF
--- a/custom_components/meraki_ha/webhook.py
+++ b/custom_components/meraki_ha/webhook.py
@@ -112,8 +112,8 @@ async def async_register_webhook(
         webhook_url = get_webhook_url(hass, webhook_id, webhook_url_from_entry)
         if config_entry_id:
             await api_client.register_webhook(webhook_url, secret, config_entry_id)
-    except Exception as err:
-        _LOGGER.error("Failed to register webhook: %s", err)
+    except Exception:
+        _LOGGER.error("Failed to register webhook", exc_info=True)
 
 
 async def async_unregister_webhook(


### PR DESCRIPTION
This pull request improves the error logging for webhook registration failures in `custom_components/meraki_ha/webhook.py`. The previous implementation did not log the exception details, making it difficult to diagnose the root cause of registration failures. This change ensures the full traceback is logged, providing developers with the necessary context to debug the issue.

Fixes #1481

---
*PR created automatically by Jules for task [16465058384514662964](https://jules.google.com/task/16465058384514662964) started by @brewmarsh*