### PR TITLE
Fix CI dependencies and sensor mapping

### DIFF
--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -100,6 +100,7 @@ class MerakiMtSensor(CoordinatorEntity, RestoreSensor):
                             "co2": "concentration",
                             "water": "present",
                             "voltage": "level",
+                            "button": "pressType",
                         }
                         value_key = key_map.get(key)
                         if value_key:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 acme==5.1.0
 aiodns==3.6.1
-aiofiles==23.2.1
+aiofiles==24.1.0
 aiohappyeyeballs
 aiohasupervisor
 aiohttp

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 aiodns==3.6.1
-aiofiles==23.2.1
+aiofiles==24.1.0
 aiohttp==3.13.3
 bandit==1.7.9
 diskcache==5.6.3

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -40,5 +40,4 @@ janus
 psutil-home-assistant
 pillow
 fnv-hash-fast
-flake8
 urllib3


### PR DESCRIPTION
Resolved CI failures by updating dependencies and fixing a sensor logic omission.

- **Dependencies**: Updated `aiofiles` to `24.1.0` for Python 3.13 compatibility. Removed deprecated `flake8`. Confirmed `aiodns`, `pycares`, and `webrtc-models` versions are correct.
- **Code**: Added missing `button` key mapping in `MerakiMtSensor`.
- **Verification**: Validated with `ruff`, `bandit`, and `mypy`.

---
*PR created automatically by Jules for task [14818978733722279874](https://jules.google.com/task/14818978733722279874) started by @brewmarsh*