### PR TITLE
fix(ci): Resolve dependency conflicts and update test requirements

### DIFF
--- a/requirements_test_minimal.txt
+++ b/requirements_test_minimal.txt
@@ -8,4 +8,5 @@ pytest-cov
 pytest-homeassistant-custom-component
 pytest-mock==3.12.0
 ruff==0.5.5
+types-aiofiles>=24.1.0
 webrtc-models==0.3.0

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -40,5 +40,4 @@ janus
 psutil-home-assistant
 pillow
 fnv-hash-fast
-flake8
 urllib3


### PR DESCRIPTION
Resolved CI failures by addressing dependency conflicts and static analysis errors.

-   **Dependencies**: Verified `aiodns==3.6.1` and `pycares==4.11.0` are hard-locked across all requirement files to prevent crashes on Python 3.13. Verified `webrtc-models==0.3.0` is in manifest.
-   **Static Analysis**: Added `types-aiofiles>=24.1.0` to `requirements_test_minimal.txt` to satisfy Mypy checks. Removed deprecated `flake8` from `requirements_test_unpinned.txt`.
-   **Cleanup**: Removed an accidental garbage file created during testing.
-   **Verification**: Ran `ruff`, `bandit`, and `mypy` locally; all checks passed. Full test suite execution was skipped due to Python version mismatch (local 3.12 vs required 3.13), but dependency fixes should resolve CI failures.

---
*PR created automatically by Jules for task [15342568710568373608](https://jules.google.com/task/15342568710568373608) started by @brewmarsh*