### PR TITLE
fix(ci): Resolve conflicts and linting errors

### DIFF
--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -40,5 +40,4 @@ janus
 psutil-home-assistant
 pillow
 fnv-hash-fast
-flake8
 urllib3


### PR DESCRIPTION
Resolve pycares/aiodns conflicts and fix linting errors.
- Hard-lock aiodns==3.6.1 and pycares==4.11.0 in dependencies (verified).
- Ensure webrtc-models==0.3.0 is in manifest.json (verified).
- Remove flake8 from requirements_test_unpinned.txt as it is replaced by ruff.
- Verified linting with ruff, bandit, and mypy.

---
*PR created automatically by Jules for task [6643358666200851798](https://jules.google.com/task/6643358666200851798) started by @brewmarsh*