### PR TITLE
fix(ci): Enforce aiodns/pycares hard lock and pin meraki version

### DIFF
--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,7 +1,7 @@
 aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
-meraki>=1.53.0
+meraki==1.54.0
 orjson>=3.9.0
 pycares==4.11.0
 urllib3>=1.26.5

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -1,5 +1,9 @@
 -r requirements_dev.txt
 
+# Hard lock specific dependencies for Python 3.13 compatibility
+aiodns==3.6.1
+pycares==4.11.0
+
 # Test-specific dependencies
 pytest-homeassistant-custom-component
 pytest


### PR DESCRIPTION
Resolved CI dependency conflicts and enforced Python 3.13 compatibility by:
- Explicitly adding 'aiodns==3.6.1' and 'pycares==4.11.0' to 'requirements_test_unpinned.txt' to prevent upgrading to incompatible versions during unpinned tests.
- Pinning 'meraki==1.54.0' in 'custom_components/meraki_ha/requirements.txt' to match 'manifest.json' and prevent resolution of unstable versions.
- Verified 'webrtc-models==0.3.0' is present in 'manifest.json'.
- Verified static analysis (Ruff, Bandit, Mypy) passes.

---
*PR created automatically by Jules for task [6022876328570511437](https://jules.google.com/task/6022876328570511437) started by @brewmarsh*