### PR TITLE
fix(security): Cleanup bandit config and suppress warnings in dev tools

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,17 +1,3 @@
-skips:
-  - 'B101' # assert_used
-  - 'B104' # hardcoded_bind_all_interfaces
-  - 'B105' # hardcoded_password_string
-  - 'B106' # hardcoded_password_funcarg
-  - 'B107' # hardcoded_password_default
-  - 'B110' # try_except_pass
-  - 'B112' # try_except_continue
-  - 'B311' # aandr_random
-  - 'B404' # import_subprocess
-  - 'B603' # subprocess_without_shell_equals_true
-  - 'B607' # start_process_with_partial_path
-
 exclude_dirs:
   - 'tests'
   - 'node_modules'
-  - 'custom_components/meraki_ha/core/utils'

--- a/tools/auditor/health_auditor.py
+++ b/tools/auditor/health_auditor.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os
 import re
-import subprocess
+import subprocess  # nosec
 from typing import Any
 
 import aiohttp
@@ -63,7 +63,7 @@ def run_gh_command(command: list[str]) -> str:
         return ""
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec
             ["gh"] + command,
             capture_output=True,
             text=True,

--- a/tools/check_artifacts.py
+++ b/tools/check_artifacts.py
@@ -5,7 +5,7 @@ Used by pre-commit as a local hook to prevent committing agent/debug artifacts.
 """
 
 import re
-import subprocess
+import subprocess  # nosec
 import sys
 
 FORBIDDEN_PATTERNS = [
@@ -26,7 +26,7 @@ def get_staged_files():
     Returns an empty list if the git command fails.
     """
     try:
-        out = subprocess.check_output(
+        out = subprocess.check_output(  # nosec
             ["git", "diff", "--cached", "--name-only"], text=True
         )
     except subprocess.CalledProcessError:

--- a/tools/resolve_conflicts.py
+++ b/tools/resolve_conflicts.py
@@ -22,7 +22,7 @@ for dirpath, _dirnames, filenames in os.walk(root):
         try:
             with open(path, encoding="utf-8") as f:
                 text = f.read()
-        except Exception:
+        except Exception:  # nosec
             continue
         if "<<<<<<<" not in text:
             continue

--- a/verify_ui.py
+++ b/verify_ui.py
@@ -2,7 +2,7 @@ import asyncio
 import http.server
 import os
 import socketserver
-import subprocess
+import subprocess  # nosec
 import sys
 import threading
 
@@ -17,7 +17,7 @@ async def main():
     os.chdir("custom_components/meraki_ha/www")
 
     Handler = http.server.SimpleHTTPRequestHandler
-    httpd = socketserver.TCPServer(("", PORT), Handler)
+    httpd = socketserver.TCPServer(("", PORT), Handler)  # nosec
     server_thread = threading.Thread(target=httpd.serve_forever)
     server_thread.daemon = True
 


### PR DESCRIPTION
This PR hardens the security linting process by removing global suppressions in `.bandit.yaml`. It ensures that the main integration code (`custom_components/meraki_ha`) is scanned for all standard bandit security issues (including B101, B311, etc.). To accommodate this, explicit `# nosec` suppressions were added to development scripts in `tools/` and `verify_ui.py` where `subprocess` or insecure bindings are necessary and safe. This change aligns with the recent fixes for B311 and B101.

---
*PR created automatically by Jules for task [5362534592680958134](https://jules.google.com/task/5362534592680958134) started by @brewmarsh*