### PR TITLE
Fix: Populate sensor readings and appliance uplink statuses in MerakiDevice

### DIFF
--- a/custom_components/meraki_ha/core/parsers/sensors.py
+++ b/custom_components/meraki_ha/core/parsers/sensors.py
@@ -74,5 +74,7 @@ def parse_sensor_data(
                     device.voltage = reading.get("voltage", {}).get("level")
                 elif metric == "door":
                     device.door_open = reading.get("door", {}).get("open")
+                elif metric == "water":
+                    device.water_present = reading.get("water", {}).get("present")
                 elif metric == "button":
                     device.button_press = reading.get("button")


### PR DESCRIPTION
- Updated `custom_components/meraki_ha/core/parsers/sensors.py` to parse `water` metric and populate `water_present` on `MerakiDevice`.
- Updated `custom_components/meraki_ha/core/api/client.py` to call `parse_sensor_data` and `parse_appliance_data` in `get_all_data`, ensuring that fetched sensor readings and appliance statuses are actually merged into device objects.
- Added error handling for `device_fetcher_result` and `sensor_readings` in `client.py` to prevent crashes when partial data fetch fails.
- Verified changes using static analysis (`ruff`, `bandit`, `mypy`).

---
*PR created automatically by Jules for task [14353786827441130380](https://jules.google.com/task/14353786827441130380) started by @brewmarsh*