### PR TITLE
fix(ci): Lock aiodns and pycares in unpinned test requirements

### DIFF
--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -41,3 +41,5 @@ psutil-home-assistant
 pillow
 fnv-hash-fast
 urllib3
+aiodns==3.6.1
+pycares==4.11.0


### PR DESCRIPTION
This PR resolves CI failures caused by incompatible versions of `aiodns` and `pycares` on Python 3.13.

**Changes:**
- Appended `aiodns==3.6.1` and `pycares==4.11.0` to `requirements_test_unpinned.txt` to enforce strict version locking during unpinned test runs.
- Verified that `webrtc-models==0.3.0` is present in `manifest.json`.
- Confirmed that static analysis (Ruff, MyPy, Bandit) passes locally.

This ensures a stable CI environment and prevents regressions related to these low-level dependencies.

---
*PR created automatically by Jules for task [7208906914371390290](https://jules.google.com/task/7208906914371390290) started by @brewmarsh*