### PR TITLE
fix(ci): Resolve pycares/aiodns conflicts and enforce pins

### DIFF
--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -41,3 +41,5 @@ psutil-home-assistant
 pillow
 fnv-hash-fast
 urllib3
+aiodns==3.6.1
+pycares==4.11.0


### PR DESCRIPTION
Resolved CI failures by strictly pinning `aiodns` and `pycares` in test requirements to versions compatible with Python 3.13. Verified `webrtc-models` requirement and ran static analysis.

---
*PR created automatically by Jules for task [11940270907686608985](https://jules.google.com/task/11940270907686608985) started by @brewmarsh*