### PR TITLE
fix(ci): Resolve pycares/aiodns conflicts and pin meraki

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -41,7 +41,7 @@
     "aiofiles>=24.1.0",
     "aiohttp>=3.8.1",
     "diskcache==5.6.3",
-    "meraki>=1.53.0",
+    "meraki==1.54.0",
     "orjson>=3.9.0",
     "pycares==4.11.0",
     "urllib3>=1.26.5",

--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,7 +1,7 @@
 aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
-meraki>=1.53.0
+meraki==1.54.0
 orjson>=3.9.0
 pycares==4.11.0
 urllib3>=1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.54.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.54.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -70,7 +70,7 @@ markdown-it-py==4.0.0
 MarkupSafe
 mashumaro==3.17
 mdurl==0.1.2
-meraki>=1.53.0
+meraki==1.54.0
 mock-open==1.4.0
 msgpack
 multidict

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ diskcache==5.6.3
 greenlet==3.3.0
 homeassistant==2026.1.0b4
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.54.0
 numpy==2.3.2
 orjson==3.11.3
 pillow==12.0.0

--- a/requirements_test_isolated.txt
+++ b/requirements_test_isolated.txt
@@ -1,6 +1,6 @@
 aiodns==3.6.1
 aiortc
-meraki
+meraki==1.54.0
 pycares==4.11.0
 pytest
 pytest-asyncio

--- a/requirements_test_minimal.txt
+++ b/requirements_test_minimal.txt
@@ -1,7 +1,7 @@
 aiodns==3.6.1
 aiofiles>=24.1.0
 bandit==1.7.9
-meraki>=1.53.0
+meraki==1.54.0
 mypy
 pycares==4.11.0
 pytest-cov

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -41,3 +41,6 @@ psutil-home-assistant
 pillow
 fnv-hash-fast
 urllib3
+aiodns==3.6.1
+pycares==4.11.0
+meraki==1.54.0


### PR DESCRIPTION
Resolved CI dependency conflicts and enforced Python 3.13 compatibility by:
- Explicitly pinning `meraki` to `1.54.0` across all requirements files and `manifest.json` to avoid upstream `pytest` conflicts.
- Hard-locking `aiodns` to `3.6.1` and `pycares` to `4.11.0` to prevent crashes on Python 3.13, specifically adding them to `requirements_test_unpinned.txt`.
- Verifying `webrtc-models` version in manifest.
- Validating changes with static analysis tools.

---
*PR created automatically by Jules for task [11447516560714272564](https://jules.google.com/task/11447516560714272564) started by @brewmarsh*