### PR TITLE
fix(ci): Resolve dependency conflicts and fix static analysis errors

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -604,7 +604,7 @@ class MerakiAPIClient:
         sensor_readings = initial_results.get("sensor_readings")
 
         if sensor_readings and not isinstance(sensor_readings, Exception):
-            parse_sensor_data(devices_list, sensor_readings)
+            parse_sensor_data(devices_list, sensor_readings, None)
 
         if uplink_statuses and not isinstance(uplink_statuses, Exception):
             parse_appliance_data(devices_list, uplink_statuses)

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -41,7 +41,7 @@
     "aiofiles>=24.1.0",
     "aiohttp>=3.8.1",
     "diskcache==5.6.3",
-    "meraki>=1.53.0",
+    "meraki==1.54.0",
     "orjson>=3.9.0",
     "pycares==4.11.0",
     "urllib3>=1.26.5",

--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,7 +1,7 @@
 aiodns==3.6.1
 aiofiles>=24.1.0
 aiohttp>=3.8.1
-meraki>=1.53.0
+meraki==1.54.0
 orjson>=3.9.0
 pycares==4.11.0
 urllib3>=1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.54.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -9,7 +9,7 @@ diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.54.0
 mypy==1.11.0
 numpy>=1.26.0
 orjson>=3.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-acme==5.1.0
 aiofiles==23.2.1
 aiohappyeyeballs
 aiohasupervisor
@@ -69,7 +68,7 @@ markdown-it-py==4.0.0
 MarkupSafe
 mashumaro==3.17
 mdurl==0.1.2
-meraki>=1.53.0
+meraki==1.54.0
 mock-open==1.4.0
 msgpack
 multidict
@@ -159,5 +158,3 @@ webrtc-models==0.3.0
 wheel==0.45.1
 yarl
 zeroconf==0.148.0
-aiodns==3.6.1
-pycares==4.11.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ diskcache==5.6.3
 greenlet==3.3.0
 homeassistant==2026.1.0b4
 janus==1.0.0
-meraki>=1.53.0
+meraki==1.54.0
 numpy==2.3.2
 orjson==3.11.3
 pillow==12.0.0

--- a/requirements_test_isolated.txt
+++ b/requirements_test_isolated.txt
@@ -1,6 +1,6 @@
 aiodns==3.6.1
 aiortc
-meraki
+meraki==1.54.0
 pycares==4.11.0
 pytest
 pytest-asyncio

--- a/requirements_test_minimal.txt
+++ b/requirements_test_minimal.txt
@@ -1,6 +1,6 @@
 aiodns==3.6.1
 bandit==1.7.9
-meraki>=1.53.0
+meraki==1.54.0
 pycares==4.11.0
 pytest-cov
 pytest-homeassistant-custom-component

--- a/tests/core/api/test_client.py
+++ b/tests/core/api/test_client.py
@@ -6,7 +6,6 @@ import pytest
 
 from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.core.api.client import MerakiAPIClient
-from custom_components.meraki_ha.core.errors import MerakiInformationalError
 from custom_components.meraki_ha.types import MerakiDevice, MerakiNetwork
 from tests.const import MOCK_DEVICE, MOCK_DEVICE_INIT, MOCK_NETWORK, MOCK_NETWORK_INIT
 


### PR DESCRIPTION
Resolved CI failures by pinning dependencies and fixing static analysis errors.

Key changes:
- **Dependency Pinning**: Pinned `meraki` to `1.54.0` across all requirements files to prevent conflicts with `pytest-homeassistant-custom-component` introduced in newer Meraki SDK versions.
- **Python 3.13 Compatibility**: Enforced `aiodns==3.6.1` and `pycares==4.11.0` locks while removing them from `requirements_dev.txt` to resolve install-time conflicts with Home Assistant 2024.12.0 (the forced upgrade happens in `run_checks.sh`).
- **Conflict Resolution**: Removed `acme==5.1.0` from `requirements_dev.txt` as it conflicted with `homeassistant`'s `pyopenssl` requirements.
- **Bug Fix**: Fixed a `TypeError` in `custom_components/meraki_ha/core/api/client.py` where `parse_sensor_data` was called with missing arguments.

Verified using static analysis (`ruff`, `mypy`) as local environment restrictions prevented full test suite execution.

---
*PR created automatically by Jules for task [337032712637932967](https://jules.google.com/task/337032712637932967) started by @brewmarsh*