### PR TITLE
fix(ci): Resolve install conflicts and ensure dependency hard-locks

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -14,7 +14,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import meraki
-
 from homeassistant.core import HomeAssistant
 
 from ...core.errors import (

--- a/custom_components/meraki_ha/reauth_flow.py
+++ b/custom_components/meraki_ha/reauth_flow.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 import voluptuous as vol
-
 from homeassistant import data_entry_flow
 from homeassistant.exceptions import ConfigEntryAuthFailed
 

--- a/custom_components/meraki_ha/webhook.py
+++ b/custom_components/meraki_ha/webhook.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from aiohttp import web
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
-acme==5.1.0
-aiodns==3.6.1
 aiofiles==24.1.0
 aiohappyeyeballs
 aiohasupervisor

--- a/requirements_test_unpinned.txt
+++ b/requirements_test_unpinned.txt
@@ -5,8 +5,6 @@ aiodns==3.6.1
 pycares==4.11.0
 
 # Test-specific dependencies
-aiodns==3.6.1
-pycares==4.11.0
 pytest-homeassistant-custom-component
 pytest
 pytest-cov

--- a/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
+++ b/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
@@ -7,11 +7,11 @@ import pytest
 from custom_components.meraki_ha.binary_sensor.device.meraki_mt_binary_base import (
     MerakiMtBinarySensor,
 )
-from custom_components.meraki_ha.types import MerakiDevice
 from custom_components.meraki_ha.descriptions import (
     MT_DOOR_DESCRIPTION,
     MT_WATER_DESCRIPTION,
 )
+from custom_components.meraki_ha.types import MerakiDevice
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,6 +13,9 @@
 
 from unittest.mock import MagicMock, patch
 
+from homeassistant import config_entries, setup
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import (
@@ -24,9 +27,6 @@ from custom_components.meraki_ha.core.errors import (
     MerakiAuthenticationError,
     MerakiConnectionError,
 )
-from homeassistant import config_entries, setup
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 
 
 async def test_form(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Resolves CI dependency conflicts by cleaning up `requirements_dev.txt` to allow `homeassistant` installation, while relying on existing CI/script mechanisms to enforce strict `aiodns`/`pycares` versions for Python 3.13 compatibility. Also tidies up test requirements.

---
*PR created automatically by Jules for task [6426719677312114364](https://jules.google.com/task/6426719677312114364) started by @brewmarsh*