### PR TITLE
fix: Hard lock aiodns and pycares versions for Python 3.13 CI

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 acme
 aiodhcpwatcher
 aiodiscover
+aiodns==3.6.1
 aiofiles==24.1.0
 aiohappyeyeballs
 aiohasupervisor
@@ -93,6 +94,7 @@ propcache
 psutil
 psutil-home-assistant
 py-serializable==1.1.2
+pycares==4.11.0
 pycognito==2024.5.1
 pycparser
 pydantic


### PR DESCRIPTION
Hard locks aiodns==3.6.1 and pycares==4.11.0 in requirements_dev.txt to prevent CI failures on Python 3.13 due to incompatible older versions.

---
*PR created automatically by Jules for task [11259745852418029461](https://jules.google.com/task/11259745852418029461) started by @brewmarsh*