### PR TITLE
fix: CI dependency conflicts and resolve test failures

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -194,10 +194,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added."""
-        if self.is_streaming:
-            return True
-        video_settings = self.device_data.video_settings or {}
-        return video_settings.get("rtspServerEnabled", False)
+        return self.is_streaming
 
     async def async_turn_on(self) -> None:
         """Turn on the camera stream."""

--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -132,6 +132,8 @@ PLATFORM_CAMERA: Final = "camera"
 """Represents the camera platform."""
 PLATFORM_NUMBER: Final = "number"
 """Represents the number platform."""
+PLATFORM_SELECT: Final = "select"
+"""Represents the select platform."""
 
 PLATFORMS: Final = [
     PLATFORM_SENSOR,
@@ -141,6 +143,7 @@ PLATFORMS: Final = [
     PLATFORM_TEXT,
     PLATFORM_CAMERA,
     PLATFORM_NUMBER,
+    PLATFORM_SELECT,
 ]
 """List of platforms supported by the integration."""
 

--- a/custom_components/meraki_ha/core/timed_access_manager.py
+++ b/custom_components/meraki_ha/core/timed_access_manager.py
@@ -83,6 +83,10 @@ class TimedAccessManager:
 
     def _schedule_removal(self, key: TimedAccessKey, expires_at: datetime) -> None:
         """Schedule removal of a key."""
+        # Cancel any existing timer for this key to prevent collisions
+        if key.identity_psk_id in self._scheduled_removals:
+            self._scheduled_removals[key.identity_psk_id].cancel()
+
         delay = (expires_at - dt_util.utcnow()).total_seconds()
 
         # Avoid scheduling if already passed or very close
@@ -232,3 +236,9 @@ class TimedAccessManager:
         if network_id:
             return [k.__dict__ for k in self._keys if k.network_id == network_id]
         return [k.__dict__ for k in self._keys]
+
+    def shutdown(self) -> None:
+        """Cancel all scheduled timers."""
+        for timer in self._scheduled_removals.values():
+            timer.cancel()
+        self._scheduled_removals.clear()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,6 @@
 aiodhcpwatcher
 aiodiscover
 aiofiles==24.1.0
-aiodns==3.6.1
 aiohappyeyeballs
 aiohasupervisor
 aiohttp

--- a/tests/core/test_timed_access_manager.py
+++ b/tests/core/test_timed_access_manager.py
@@ -25,7 +25,9 @@ def mock_client():
 @pytest.fixture
 def manager(hass):
     """Fixture for the TimedAccessManager."""
-    return TimedAccessManager(hass)
+    mgr = TimedAccessManager(hass)
+    yield mgr
+    mgr.shutdown()
 
 
 @pytest.fixture

--- a/tests/test_coordinator_entity_priority.py
+++ b/tests/test_coordinator_entity_priority.py
@@ -57,6 +57,10 @@ async def test_update_device_registry_info_picks_camera(hass):
 
     with (
         patch(
+            "custom_components.meraki_ha.core.helpers.dr.async_get",
+            return_value=mock_dr,
+        ),
+        patch(
             "custom_components.meraki_ha.core.helpers.er.async_get",
             return_value=mock_er,
         ),

--- a/tests/test_e2e_ipsk.py
+++ b/tests/test_e2e_ipsk.py
@@ -41,36 +41,38 @@ async def test_e2e_create_and_expire_ipsk(hass, mock_hass_config, mock_meraki_cl
     """
     manager = TimedAccessManager(hass)
     await manager.async_setup()
+    try:
+        # 1. Create a Key
+        # Verify that calling create_key propagates to the client correctly
+        key = await manager.create_key(
+            config_entry_id="test_entry_id",
+            network_id="N_12345",
+            ssid_number="1",
+            duration_minutes=60,
+            name="Guest User",
+            group_policy_id="101",
+        )
 
-    # 1. Create a Key
-    # Verify that calling create_key propagates to the client correctly
-    key = await manager.create_key(
-        config_entry_id="test_entry_id",
-        network_id="N_12345",
-        ssid_number="1",
-        duration_minutes=60,
-        name="Guest User",
-        group_policy_id="101",
-    )
+        # Assertions on the returned key object
+        assert key.identity_psk_id == "mock_ipsk_id"
+        assert key.name == "Guest User"
+        assert key.network_id == "N_12345"
 
-    # Assertions on the returned key object
-    assert key.identity_psk_id == "mock_ipsk_id"
-    assert key.name == "Guest User"
-    assert key.network_id == "N_12345"
+        # Assert that the API client was called with the correct arguments
+        # Crucially, we are checking that '101' was passed for group_policy_id
+        mock_meraki_client.wireless.create_identity_psk.assert_called_once_with(
+            "N_12345", "1", "Guest User", "101", key.passphrase
+        )
 
-    # Assert that the API client was called with the correct arguments
-    # Crucially, we are checking that '101' was passed for group_policy_id
-    mock_meraki_client.wireless.create_identity_psk.assert_called_once_with(
-        "N_12345", "1", "Guest User", "101", key.passphrase
-    )
+        # 2. Verify deletion logic
+        # We simulate deletion to ensure the ID is correctly passed down
+        await manager.delete_key(key.identity_psk_id)
 
-    # 2. Verify deletion logic
-    # We simulate deletion to ensure the ID is correctly passed down
-    await manager.delete_key(key.identity_psk_id)
-
-    mock_meraki_client.wireless.delete_identity_psk.assert_called_once_with(
-        "N_12345", "1", "mock_ipsk_id"
-    )
+        mock_meraki_client.wireless.delete_identity_psk.assert_called_once_with(
+            "N_12345", "1", "mock_ipsk_id"
+        )
+    finally:
+        manager.shutdown()
 
 
 @pytest.fixture
@@ -103,48 +105,51 @@ async def test_e2e_ipsk_flow_real_endpoints(hass, real_client_with_mock_dashboar
     manager = TimedAccessManager(hass)
     await manager.async_setup()
 
-    # 1. Create Key with NO Group Policy
-    await manager.create_key(
-        config_entry_id="test_entry_id",
-        network_id="N_12345",
-        ssid_number="1",
-        duration_minutes=60,
-        name="Guest Default",
-    )
+    try:
+        # 1. Create Key with NO Group Policy
+        await manager.create_key(
+            config_entry_id="test_entry_id",
+            network_id="N_12345",
+            ssid_number="1",
+            duration_minutes=60,
+            name="Guest Default",
+        )
 
-    # Now verify the call to the dashboard.wireless method
-    # This proves that WirelessEndpoints.create_identity_psk correctly omitted
-    # groupPolicyId instead of sending "Normal"
-    real_client_with_mock_dashboard.run_sync.assert_called()
+        # Now verify the call to the dashboard.wireless method
+        # This proves that WirelessEndpoints.create_identity_psk correctly omitted
+        # groupPolicyId instead of sending "Normal"
+        real_client_with_mock_dashboard.run_sync.assert_called()
 
-    # Get the arguments passed to run_sync.
-    # args[0] is the function
-    # (dashboard.wireless.createNetworkWirelessSsidIdentityPsk)
-    # kwargs should contain the API parameters
-    call_args = real_client_with_mock_dashboard.run_sync.call_args
+        # Get the arguments passed to run_sync.
+        # args[0] is the function
+        # (dashboard.wireless.createNetworkWirelessSsidIdentityPsk)
+        # kwargs should contain the API parameters
+        call_args = real_client_with_mock_dashboard.run_sync.call_args
 
-    wireless = real_client_with_mock_dashboard.dashboard.wireless
-    expected_func = wireless.createNetworkWirelessSsidIdentityPsk
-    assert call_args[0][0] == expected_func
+        wireless = real_client_with_mock_dashboard.dashboard.wireless
+        expected_func = wireless.createNetworkWirelessSsidIdentityPsk
+        assert call_args[0][0] == expected_func
 
-    # Check the keyword arguments passed to run_sync
-    kwargs = call_args[1]
-    assert kwargs["networkId"] == "N_12345"
-    assert kwargs["number"] == "1"
-    # CRITICAL: Confirm that 'groupPolicyId' IS present and set to "Normal"
-    # This prevents the TypeError because the API library requires this argument.
-    assert kwargs.get("groupPolicyId") == "Normal"
+        # Check the keyword arguments passed to run_sync
+        kwargs = call_args[1]
+        assert kwargs["networkId"] == "N_12345"
+        assert kwargs["number"] == "1"
+        # CRITICAL: Confirm that 'groupPolicyId' IS present and set to "Normal"
+        # This prevents the TypeError because the API library requires this argument.
+        assert kwargs.get("groupPolicyId") == "Normal"
 
-    # 2. Create Key WITH Group Policy
-    await manager.create_key(
-        config_entry_id="test_entry_id",
-        network_id="N_12345",
-        ssid_number="1",
-        duration_minutes=60,
-        name="Guest Policy",
-        group_policy_id="999",
-    )
+        # 2. Create Key WITH Group Policy
+        await manager.create_key(
+            config_entry_id="test_entry_id",
+            network_id="N_12345",
+            ssid_number="1",
+            duration_minutes=60,
+            name="Guest Policy",
+            group_policy_id="999",
+        )
 
-    call_args = real_client_with_mock_dashboard.run_sync.call_args
-    kwargs = call_args[1]
-    assert kwargs["groupPolicyId"] == "999"
+        call_args = real_client_with_mock_dashboard.run_sync.call_args
+        kwargs = call_args[1]
+        assert kwargs["groupPolicyId"] == "999"
+    finally:
+        manager.shutdown()


### PR DESCRIPTION
This PR addresses CI dependency conflicts by removing the conflicting `aiodns` pin from `requirements_dev.txt`. It also resolves multiple test failures by:
1. Fixing mocking in `test_coordinator_entity_priority.py`.
2. Updating `MerakiCamera` logic to match test expectations.
3. Enabling the `select` platform in `const.py` which was preventing `meraki_select` entities from being created.
4. Implementing proper timer cleanup in `TimedAccessManager` to prevent lingering timers in tests.

---
*PR created automatically by Jules for task [16951804207603173094](https://jules.google.com/task/16951804207603173094) started by @brewmarsh*