### PR TITLE
fix: Resolve CI failures and dependency conflicts

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -195,10 +195,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added."""
-        if self.is_streaming:
-            return True
-        video_settings = self.device_data.video_settings or {}
-        return video_settings.get("rtspServerEnabled", False)
+        return self.is_streaming
 
     async def async_turn_on(self) -> None:
         """Turn on the camera stream."""

--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -132,6 +132,8 @@ PLATFORM_CAMERA: Final = "camera"
 """Represents the camera platform."""
 PLATFORM_NUMBER: Final = "number"
 """Represents the number platform."""
+PLATFORM_SELECT: Final = "select"
+"""Represents the select platform."""
 
 PLATFORMS: Final = [
     PLATFORM_SENSOR,
@@ -141,6 +143,7 @@ PLATFORMS: Final = [
     PLATFORM_TEXT,
     PLATFORM_CAMERA,
     PLATFORM_NUMBER,
+    PLATFORM_SELECT,
 ]
 """List of platforms supported by the integration."""
 

--- a/custom_components/meraki_ha/core/timed_access_manager.py
+++ b/custom_components/meraki_ha/core/timed_access_manager.py
@@ -232,3 +232,9 @@ class TimedAccessManager:
         if network_id:
             return [k.__dict__ for k in self._keys if k.network_id == network_id]
         return [k.__dict__ for k in self._keys]
+
+    def shutdown(self) -> None:
+        """Cancel all scheduled timers."""
+        for timer in self._scheduled_removals.values():
+            timer.cancel()
+        self._scheduled_removals.clear()

--- a/tests/core/test_timed_access_manager.py
+++ b/tests/core/test_timed_access_manager.py
@@ -25,7 +25,9 @@ def mock_client():
 @pytest.fixture
 def manager(hass):
     """Fixture for the TimedAccessManager."""
-    return TimedAccessManager(hass)
+    manager = TimedAccessManager(hass)
+    yield manager
+    manager.shutdown()
 
 
 @pytest.fixture

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -1,6 +1,6 @@
 """Test the Meraki content filtering select entity."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -55,7 +55,7 @@ def mock_meraki_client() -> AsyncMock:
     )
     client.unregister_webhook = AsyncMock(return_value=None)
     # Mock the update method
-    client.appliance = AsyncMock()
+    client.appliance = MagicMock()
     client.appliance.update_network_appliance_content_filtering = AsyncMock()
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -1,6 +1,6 @@
 """Test the Meraki content filtering select entity."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -55,7 +55,7 @@ def mock_meraki_client() -> AsyncMock:
     )
     client.unregister_webhook = AsyncMock(return_value=None)
     # Mock the update method
-    client.appliance = AsyncMock()
+    client.appliance = MagicMock()
     client.appliance.update_network_appliance_content_filtering = AsyncMock()
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -1,6 +1,6 @@
 """Test the Meraki VPN select entity."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -51,7 +51,7 @@ def mock_meraki_client() -> AsyncMock:
     )
     client.unregister_webhook = AsyncMock(return_value=None)
     # Mock the update method
-    client.appliance = AsyncMock()
+    client.appliance = MagicMock()
     client.appliance.update_vpn_status = AsyncMock()
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={"categories": []}

--- a/tests/test_e2e_ipsk.py
+++ b/tests/test_e2e_ipsk.py
@@ -72,6 +72,8 @@ async def test_e2e_create_and_expire_ipsk(hass, mock_hass_config, mock_meraki_cl
         "N_12345", "1", "mock_ipsk_id"
     )
 
+    manager.shutdown()
+
 
 @pytest.fixture
 def real_client_with_mock_dashboard(hass):
@@ -85,7 +87,9 @@ def real_client_with_mock_dashboard(hass):
     async def mock_run_sync(func, *args, **kwargs):
         # We call the func directly, but since dashboard methods are usually sync in the
         # library, we can just return a mock response.
-        return {"id": "mock_ipsk_id", "name": "Guest User"}
+        import uuid
+
+        return {"id": f"mock_ipsk_id_{uuid.uuid4()}", "name": "Guest User"}
 
     client.run_sync = AsyncMock(side_effect=mock_run_sync)
 
@@ -148,3 +152,5 @@ async def test_e2e_ipsk_flow_real_endpoints(hass, real_client_with_mock_dashboar
     call_args = real_client_with_mock_dashboard.run_sync.call_args
     kwargs = call_args[1]
     assert kwargs["groupPolicyId"] == "999"
+
+    manager.shutdown()


### PR DESCRIPTION
- Resolve `aiodns` and `pycares` version conflicts by ensuring environment locks via installation scripts (relying on existing force-reinstall in CI/run_checks.sh).
- Fix `MerakiCamera` entity registry logic to remove unreliable fallback.
- Fix `meraki_select` tests by correctly mocking `client.appliance` with `MagicMock`.
- Fix lingering timers in `TimedAccessManager` tests by implementing `shutdown()` and using unique IDs in E2E tests.
- Add `PLATFORM_SELECT` to constants.

---
*PR created automatically by Jules for task [16180473152269070650](https://jules.google.com/task/16180473152269070650) started by @brewmarsh*