### PR TITLE
fix: Resolve CI failures, dependency conflicts, and test errors

### DIFF
--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -63,7 +63,10 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system --prerelease=allow -r requirements_dev.txt
+        run: |
+          grep -vE "aiodns|pycares" requirements_dev.txt > requirements_dev_no_aiodns.txt
+          uv pip install --system --prerelease=allow -r requirements_dev_no_aiodns.txt
+          rm requirements_dev_no_aiodns.txt
 
       - name: Install HA Custom Component
         # Note: This may temporarily downgrade aiodns, but the next step enforces strict versions.
@@ -97,7 +100,10 @@ jobs:
         run: uv pip install --system --upgrade pip setuptools "wheel>=0.46.2"
 
       - name: Install dependencies
-        run: uv pip install --system --prerelease=allow -r requirements_dev.txt
+        run: |
+          grep -vE "aiodns|pycares" requirements_dev.txt > requirements_dev_no_aiodns.txt
+          uv pip install --system --prerelease=allow -r requirements_dev_no_aiodns.txt
+          rm requirements_dev_no_aiodns.txt
 
       - name: Install HA Custom Component
         # Note: This may temporarily downgrade aiodns, but the next step enforces strict versions.
@@ -149,7 +155,10 @@ jobs:
 
       # FIX: Allow pre-releases for Home Assistant deps
       - name: Install dependencies
-        run: uv pip install --system --prerelease=allow -r requirements_dev.txt
+        run: |
+          grep -vE "aiodns|pycares" requirements_dev.txt > requirements_dev_no_aiodns.txt
+          uv pip install --system --prerelease=allow -r requirements_dev_no_aiodns.txt
+          rm requirements_dev_no_aiodns.txt
 
       - name: Install HA Custom Component
         # Note: This may temporarily downgrade aiodns, but the next step enforces strict versions.
@@ -160,6 +169,9 @@ jobs:
           # FIX: removed -y flag which uv does not support
           uv pip uninstall --system pycares aiodns
           uv pip install --system --no-cache-dir pycares==4.11.0 aiodns==3.6.1
+
+      - name: Install Playwright Browsers
+        run: playwright install --with-deps
 
       - name: Run Tests
         run: pytest --cov=custom_components/meraki_ha --cov-report=xml tests/

--- a/custom_components/meraki_ha/binary_sensor/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/switch_port.py
@@ -50,6 +50,8 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self._device.serial:
+            return
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -194,10 +194,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added."""
-        if self.is_streaming:
-            return True
-        video_settings = self.device_data.video_settings or {}
-        return video_settings.get("rtspServerEnabled", False)
+        return self.is_streaming
 
     async def async_turn_on(self) -> None:
         """Turn on the camera stream."""

--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -132,6 +132,8 @@ PLATFORM_CAMERA: Final = "camera"
 """Represents the camera platform."""
 PLATFORM_NUMBER: Final = "number"
 """Represents the number platform."""
+PLATFORM_SELECT: Final = "select"
+"""Represents the select platform."""
 
 PLATFORMS: Final = [
     PLATFORM_SENSOR,
@@ -141,6 +143,7 @@ PLATFORMS: Final = [
     PLATFORM_TEXT,
     PLATFORM_CAMERA,
     PLATFORM_NUMBER,
+    PLATFORM_SELECT,
 ]
 """List of platforms supported by the integration."""
 

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -146,6 +146,19 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug("Update for %s is still pending (on cooldown)", unique_id)
         return True
 
+    def cancel_pending_update(self, unique_id: str) -> None:
+        """
+        Cancel a pending update for an entity.
+
+        Args:
+        ----
+            unique_id: The unique ID of the entity.
+
+        """
+        if unique_id in self._pending_updates:
+            del self._pending_updates[unique_id]
+            _LOGGER.debug("Cancelled pending update for %s", unique_id)
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint, apply filters, and handle exceptions."""
         try:

--- a/custom_components/meraki_ha/core/timed_access_manager.py
+++ b/custom_components/meraki_ha/core/timed_access_manager.py
@@ -44,7 +44,9 @@ class TimedAccessManager:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the manager."""
         self._hass = hass
-        self._store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store: storage.Store[list[dict[str, Any]]] = storage.Store(
+            hass, STORAGE_VERSION, STORAGE_KEY
+        )
         self._keys: list[TimedAccessKey] = []
         self._scheduled_removals: dict[str, asyncio.TimerHandle] = {}
 
@@ -232,3 +234,9 @@ class TimedAccessManager:
         if network_id:
             return [k.__dict__ for k in self._keys if k.network_id == network_id]
         return [k.__dict__ for k in self._keys]
+
+    def shutdown(self) -> None:
+        """Cancel all scheduled removals."""
+        for handle in self._scheduled_removals.values():
+            handle.cancel()
+        self._scheduled_removals.clear()

--- a/custom_components/meraki_ha/helpers/schema.py
+++ b/custom_components/meraki_ha/helpers/schema.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 from homeassistant.helpers import selector
+from homeassistant.helpers.selector import SelectOptionDict
 
 from custom_components.meraki_ha.const import CONF_IGNORED_NETWORKS
 
@@ -47,7 +48,7 @@ def populate_schema_defaults(
             and network_options is not None
         ):
             new_config = value.config.copy()
-            new_config["options"] = network_options
+            new_config["options"] = cast(list[SelectOptionDict], network_options)
             value = selector.SelectSelector(new_config)
 
         new_schema_keys[key] = value

--- a/custom_components/meraki_ha/sensor/device/data_usage.py
+++ b/custom_components/meraki_ha/sensor/device/data_usage.py
@@ -25,6 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiDataUsageSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Meraki appliance data usage sensor."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement: UnitOfInformation | None = (
         UnitOfInformation.MEGABYTES

--- a/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
@@ -24,6 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiFirmwareStatusSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Meraki Device Firmware Status Sensor."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_icon = "mdi:package-up"
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -114,6 +114,8 @@ class MerakiMtSensor(CoordinatorEntity, RestoreSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self._device.serial:
+            return
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device

--- a/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
@@ -31,6 +31,8 @@ class MerakiWAN1ConnectivitySensor(
 ):
     """Representation of a Meraki WAN1 Connectivity Sensor."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_icon = "mdi:wan"
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
@@ -31,6 +31,8 @@ class MerakiWAN2ConnectivitySensor(
 ):
     """Representation of a Meraki WAN2 Connectivity Sensor."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_icon = "mdi:wan"
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Meraki organization-level client counter by device type."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_has_entity_name = True
 
@@ -30,7 +32,7 @@ class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity)
         super().__init__(coordinator)
         self._config_entry = config_entry
         self._device_type = device_type
-        self._org_id = self.coordinator.api_client.organization_id
+        self._org_id = self.coordinator.api.organization_id
         self._attr_unique_id = f"{self._org_id}_{self._device_type}_clients"
         self._attr_name = f"{self._device_type.capitalize()} Clients"
 

--- a/custom_components/meraki_ha/switch/mt40_power_outlet.py
+++ b/custom_components/meraki_ha/switch/mt40_power_outlet.py
@@ -61,12 +61,14 @@ class MerakiMt40PowerOutlet(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self._device_info.serial:
+            return
         device: MerakiDevice | None = self.coordinator.get_device(
             serial=self._device_info.serial
         )
         if device:
             self._device_info = device
-            if not self.coordinator.is_pending(self.unique_id):
+            if self.unique_id and not self.coordinator.is_pending(self.unique_id):
                 self._attr_is_on = self._get_power_state()
             self.async_write_ha_state()
         else:
@@ -102,7 +104,8 @@ class MerakiMt40PowerOutlet(
         """
         self._attr_is_on = True
         self.async_write_ha_state()
-        self.coordinator.register_pending_update(self.unique_id)
+        if self.unique_id:
+            self.coordinator.register_pending_update(self.unique_id)
 
         try:
             if self._device_info.serial is None:
@@ -113,7 +116,8 @@ class MerakiMt40PowerOutlet(
             )
         except Exception as e:
             _LOGGER.error("Error turning on MT40 outlet %s: %s", self.unique_id, e)
-            self.coordinator.cancel_pending_update(self.unique_id)
+            if self.unique_id:
+                self.coordinator.cancel_pending_update(self.unique_id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """
@@ -126,7 +130,8 @@ class MerakiMt40PowerOutlet(
         """
         self._attr_is_on = False
         self.async_write_ha_state()
-        self.coordinator.register_pending_update(self.unique_id)
+        if self.unique_id:
+            self.coordinator.register_pending_update(self.unique_id)
 
         try:
             if self._device_info.serial is None:
@@ -137,7 +142,8 @@ class MerakiMt40PowerOutlet(
             )
         except Exception as e:
             _LOGGER.error("Error turning off MT40 outlet %s: %s", self.unique_id, e)
-            self.coordinator.cancel_pending_update(self.unique_id)
+            if self.unique_id:
+                self.coordinator.cancel_pending_update(self.unique_id)
 
     @property
     def available(self) -> bool:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -161,3 +161,4 @@ webrtc-models==0.3.0
 wheel==0.45.1
 yarl
 zeroconf==0.148.0
+pycares==4.11.0

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -5,7 +5,9 @@ echo "Installing uv..."
 pip install uv
 
 echo "Installing dependencies..."
-uv pip install --system --prerelease=allow -r requirements_dev.txt
+grep -vE "aiodns|pycares" requirements_dev.txt > requirements_dev_no_aiodns.txt
+uv pip install --system --prerelease=allow -r requirements_dev_no_aiodns.txt
+rm requirements_dev_no_aiodns.txt
 
 # Force reinstall aiodns and pycares to match Python 3.13 compatibility requirements
 # even if Home Assistant pins older versions.

--- a/tests/core/test_timed_access_manager.py
+++ b/tests/core/test_timed_access_manager.py
@@ -25,7 +25,9 @@ def mock_client():
 @pytest.fixture
 def manager(hass):
     """Fixture for the TimedAccessManager."""
-    return TimedAccessManager(hass)
+    manager = TimedAccessManager(hass)
+    yield manager
+    manager.shutdown()
 
 
 @pytest.fixture

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -1,6 +1,6 @@
 """Test the Meraki content filtering select entity."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -31,6 +31,10 @@ def mock_meraki_client() -> AsyncMock:
 
     from custom_components.meraki_ha.types import MerakiDevice
 
+    # Mock the appliance object (must be MagicMock for attribute access)
+    client.appliance = MagicMock()
+    client.appliance.update_network_appliance_content_filtering = AsyncMock()
+
     client.get_all_data = AsyncMock(
         return_value={
             "devices": [
@@ -54,9 +58,6 @@ def mock_meraki_client() -> AsyncMock:
         }
     )
     client.unregister_webhook = AsyncMock(return_value=None)
-    # Mock the update method
-    client.appliance = AsyncMock()
-    client.appliance.update_network_appliance_content_filtering = AsyncMock()
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={
             "categories": [

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -1,6 +1,6 @@
 """Test the Meraki content filtering select entity."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -31,6 +31,10 @@ def mock_meraki_client() -> AsyncMock:
 
     from custom_components.meraki_ha.types import MerakiDevice
 
+    # Mock the appliance object (must be MagicMock for attribute access)
+    client.appliance = MagicMock()
+    client.appliance.update_network_appliance_content_filtering = AsyncMock()
+
     client.get_all_data = AsyncMock(
         return_value={
             "devices": [
@@ -54,9 +58,6 @@ def mock_meraki_client() -> AsyncMock:
         }
     )
     client.unregister_webhook = AsyncMock(return_value=None)
-    # Mock the update method
-    client.appliance = AsyncMock()
-    client.appliance.update_network_appliance_content_filtering = AsyncMock()
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={
             "categories": [

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -1,6 +1,6 @@
 """Test the Meraki VPN select entity."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -33,6 +33,10 @@ def mock_meraki_client() -> AsyncMock:
 
     from custom_components.meraki_ha.types import MerakiDevice
 
+    # Mock the appliance object (must be MagicMock for attribute access)
+    client.appliance = MagicMock()
+    client.appliance.update_vpn_status = AsyncMock()
+
     client.get_all_data = AsyncMock(
         return_value={
             "devices": [
@@ -50,9 +54,6 @@ def mock_meraki_client() -> AsyncMock:
         }
     )
     client.unregister_webhook = AsyncMock(return_value=None)
-    # Mock the update method
-    client.appliance = AsyncMock()
-    client.appliance.update_vpn_status = AsyncMock()
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={"categories": []}
     )

--- a/tests/sensor/test_setup_mt_sensors.py
+++ b/tests/sensor/test_setup_mt_sensors.py
@@ -179,7 +179,7 @@ async def test_async_setup_mt15_sensors(
     for entity in entities:
         entity.hass = MagicMock()
         entity.entity_id = "sensor.test"
-        entity.async_write_ha_state = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
     assert len(entities) == 7
@@ -263,7 +263,7 @@ async def test_async_setup_mt12_sensors(
     for entity in entities:
         entity.hass = MagicMock()
         entity.entity_id = "sensor.test"
-        entity.async_write_ha_state = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
     assert len(entities) == 3
@@ -303,7 +303,7 @@ async def test_async_setup_mt40_sensors(
     for entity in entities:
         entity.hass = MagicMock()
         entity.entity_id = "sensor.test"
-        entity.async_write_ha_state = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
     assert len(entities) == 3

--- a/tests/test_coordinator_entity_priority.py
+++ b/tests/test_coordinator_entity_priority.py
@@ -64,6 +64,10 @@ async def test_update_device_registry_info_picks_camera(hass):
             "custom_components.meraki_ha.core.helpers.er.async_entries_for_device",
             return_value=mock_entries,
         ),
+        patch(
+            "custom_components.meraki_ha.core.helpers.dr.async_get",
+            return_value=mock_dr,
+        ),
     ):
         update_device_registry_info(hass, devices)
 

--- a/tests/test_e2e_ipsk.py
+++ b/tests/test_e2e_ipsk.py
@@ -1,6 +1,7 @@
 """End-to-end integration tests for IPSK functionality."""
 
 import logging
+import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -72,6 +73,8 @@ async def test_e2e_create_and_expire_ipsk(hass, mock_hass_config, mock_meraki_cl
         "N_12345", "1", "mock_ipsk_id"
     )
 
+    manager.shutdown()
+
 
 @pytest.fixture
 def real_client_with_mock_dashboard(hass):
@@ -85,7 +88,7 @@ def real_client_with_mock_dashboard(hass):
     async def mock_run_sync(func, *args, **kwargs):
         # We call the func directly, but since dashboard methods are usually sync in the
         # library, we can just return a mock response.
-        return {"id": "mock_ipsk_id", "name": "Guest User"}
+        return {"id": f"mock_ipsk_id_{uuid.uuid4()}", "name": "Guest User"}
 
     client.run_sync = AsyncMock(side_effect=mock_run_sync)
 
@@ -148,3 +151,5 @@ async def test_e2e_ipsk_flow_real_endpoints(hass, real_client_with_mock_dashboar
     call_args = real_client_with_mock_dashboard.run_sync.call_args
     kwargs = call_args[1]
     assert kwargs["groupPolicyId"] == "999"
+
+    manager.shutdown()


### PR DESCRIPTION
This PR addresses the "Pull Request Validation" CI failure by resolving dependency conflicts between `homeassistant`, `aiodns`, and `pycares`, particularly on Python 3.13. It also fixes multiple test failures including lingering timers, incorrect mocks, and logic errors in camera and select entities. Furthermore, it improves type safety and adds missing platform constants.

---
*PR created automatically by Jules for task [2563520320841020529](https://jules.google.com/task/2563520320841020529) started by @brewmarsh*