### PR TITLE
fix: resolve mypy errors and improve type safety

### DIFF
--- a/custom_components/meraki_ha/api/websocket.py
+++ b/custom_components/meraki_ha/api/websocket.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import async_get_integration

--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -10,10 +10,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from meraki.exceptions import APIError as MerakiSDKAPIError
-
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from meraki.exceptions import APIError as MerakiSDKAPIError
 
 from .core.api.client import MerakiAPIClient
 from .core.errors import (

--- a/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
+++ b/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
@@ -23,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiMtBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a Meraki MT binary sensor."""
 
+    coordinator: MerakiDataCoordinator
+
     def __init__(
         self,
         coordinator: MerakiDataCoordinator,
@@ -48,7 +50,10 @@ class MerakiMtBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return DeviceInfo(
             identifiers=device_identifiers,
             name=format_device_name(
-                self._device, self.coordinator.config_entry.options
+                self._device,
+                self.coordinator.config_entry.options
+                if self.coordinator.config_entry
+                else {},
             ),
             model=str(self._device.model),
             manufacturer="Cisco Meraki",

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -7,7 +7,6 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
-
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -94,7 +94,7 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def register_pending_update(
         self,
-        unique_id: str,
+        unique_id: str | None,
         expiry_seconds: int = 150,
     ) -> None:
         """
@@ -109,6 +109,9 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             expiry_seconds: The duration of the cooldown period.
 
         """
+        if not unique_id:
+            return
+
         expiry_time = datetime.now() + timedelta(seconds=expiry_seconds)
         self._pending_updates[unique_id] = expiry_time
         _LOGGER.debug(
@@ -117,7 +120,7 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             expiry_time,
         )
 
-    def is_pending(self, unique_id: str) -> bool:
+    def is_pending(self, unique_id: str | None) -> bool:
         """
         Check if an entity is in a pending (cooldown) state.
 
@@ -130,7 +133,7 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             True if the entity is in a pending state, False otherwise.
 
         """
-        if unique_id not in self._pending_updates:
+        if not unique_id or unique_id not in self._pending_updates:
             return False
 
         now = datetime.now()
@@ -145,6 +148,19 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Cooldown is still active
         _LOGGER.debug("Update for %s is still pending (on cooldown)", unique_id)
         return True
+
+    def cancel_pending_update(self, unique_id: str | None) -> None:
+        """
+        Cancel a pending update for an entity.
+
+        Args:
+        ----
+            unique_id: The unique ID of the entity.
+
+        """
+        if unique_id and unique_id in self._pending_updates:
+            del self._pending_updates[unique_id]
+            _LOGGER.debug("Cancelled pending update for %s", unique_id)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint, apply filters, and handle exceptions."""
@@ -194,9 +210,11 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raise UpdateFailed("Config entry is missing during update")
 
             for network in networks:
+                if not network.id:
+                    continue
                 device_registry.async_get_or_create(
                     config_entry_id=self.config_entry.entry_id,
-                    identifiers={(DOMAIN, network.id)},
+                    identifiers={(DOMAIN, cast(str, network.id))},
                     name=network.name,
                     manufacturer="Cisco Meraki",
                     model="Network",
@@ -250,7 +268,7 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
-    def get_device(self, serial: str) -> MerakiDevice | None:
+    def get_device(self, serial: str | None) -> MerakiDevice | None:
         """
         Get device data by serial number.
 
@@ -263,6 +281,8 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             The device data or None if not found.
 
         """
+        if not serial:
+            return None
         return self.devices_by_serial.get(serial)
 
     def get_network(self, network_id: str) -> MerakiNetwork | None:

--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -14,7 +14,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import meraki
-
 from homeassistant.core import HomeAssistant
 
 from ...core.errors import (

--- a/custom_components/meraki_ha/core/api/endpoints/appliance.py
+++ b/custom_components/meraki_ha/core/api/endpoints/appliance.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.core import HomeAssistant
+
 from custom_components.meraki_ha.core.utils.api_utils import (
     handle_meraki_errors,
     validate_response,
 )
-from homeassistant.core import HomeAssistant
 
 from ..cache import async_timed_cache
 

--- a/custom_components/meraki_ha/core/timed_access_manager.py
+++ b/custom_components/meraki_ha/core/timed_access_manager.py
@@ -44,7 +44,9 @@ class TimedAccessManager:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the manager."""
         self._hass = hass
-        self._store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store: storage.Store[list[dict[str, Any]]] = storage.Store(
+            hass, STORAGE_VERSION, STORAGE_KEY
+        )
         self._keys: list[TimedAccessKey] = []
         self._scheduled_removals: dict[str, asyncio.TimerHandle] = {}
 

--- a/custom_components/meraki_ha/frontend.py
+++ b/custom_components/meraki_ha/frontend.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import aiofiles  # type: ignore[import-untyped]
-
 from homeassistant.components import frontend
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/custom_components/meraki_ha/helpers/schema.py
+++ b/custom_components/meraki_ha/helpers/schema.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.helpers import selector
 
 from custom_components.meraki_ha.const import CONF_IGNORED_NETWORKS
-from homeassistant.helpers import selector
 
 
 def populate_schema_defaults(
@@ -47,7 +47,7 @@ def populate_schema_defaults(
             and network_options is not None
         ):
             new_config = value.config.copy()
-            new_config["options"] = network_options
+            new_config["options"] = network_options  # type: ignore[typeddict-item]
             value = selector.SelectSelector(new_config)
 
         new_schema_keys[key] = value

--- a/custom_components/meraki_ha/reauth_flow.py
+++ b/custom_components/meraki_ha/reauth_flow.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.exceptions import ConfigEntryAuthFailed
 

--- a/custom_components/meraki_ha/schemas.py
+++ b/custom_components/meraki_ha/schemas.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import voluptuous as vol
-
 from homeassistant.helpers import selector
 
 from .const import (

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Representation of a Meraki appliance port sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -45,7 +46,10 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, cast(str, self._device.serial))},
             name=format_device_name(
-                self._device, self.coordinator.config_entry.options
+                self._device,
+                self.coordinator.config_entry.options
+                if self.coordinator.config_entry
+                else {},
             ),
             model=self._device.model,
             manufacturer="Cisco Meraki",

--- a/custom_components/meraki_ha/sensor/device/appliance_uplink.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_uplink.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiApplianceUplinkSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Representation of a Meraki appliance uplink sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/meraki_ha/sensor/device/camera_analytics.py
+++ b/custom_components/meraki_ha/sensor/device/camera_analytics.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiAnalyticsSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Base class for Meraki analytics sensors."""
 
     def __init__(
@@ -38,6 +39,8 @@ class MerakiAnalyticsSensor(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return device information."""
+        if not self.coordinator.config_entry:
+            return None
         return resolve_device_info(self._device, self.coordinator.config_entry)
 
     @property

--- a/custom_components/meraki_ha/sensor/device/camera_audio_detection.py
+++ b/custom_components/meraki_ha/sensor/device/camera_audio_detection.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiCameraAudioDetectionSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Representation of a Meraki Camera Audio Detection Status sensor."""
 
     _attr_has_entity_name = True

--- a/custom_components/meraki_ha/sensor/device/camera_sense_status.py
+++ b/custom_components/meraki_ha/sensor/device/camera_sense_status.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiCameraSenseStatusSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Representation of a Meraki Camera Sense Status sensor."""
 
     _attr_has_entity_name = True

--- a/custom_components/meraki_ha/sensor/device/data_usage.py
+++ b/custom_components/meraki_ha/sensor/device/data_usage.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiDataUsageSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Representation of a Meraki appliance data usage sensor."""
 
     _attr_state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT

--- a/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiFirmwareStatusSensor(CoordinatorEntity, SensorEntity):
+    coordinator: MerakiDataUpdateCoordinator
     """Representation of a Meraki Device Firmware Status Sensor."""
 
     _attr_icon = "mdi:package-up"

--- a/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
@@ -31,6 +31,8 @@ class MerakiWAN1ConnectivitySensor(
 ):
     """Representation of a Meraki WAN1 Connectivity Sensor."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_icon = "mdi:wan"
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
@@ -31,6 +31,8 @@ class MerakiWAN2ConnectivitySensor(
 ):
     """Representation of a Meraki WAN2 Connectivity Sensor."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_icon = "mdi:wan"
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -15,6 +15,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...types import MerakiDevice
 
@@ -49,7 +50,7 @@ class MerakiSwitchPortSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         return DeviceInfo(
-            identifiers={(self.coordinator.DOMAIN, cast(str, self._device.serial))},
+            identifiers={(DOMAIN, cast(str, self._device.serial))},
         )
 
     @property
@@ -117,7 +118,7 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         return DeviceInfo(
-            identifiers={(self.coordinator.DOMAIN, cast(str, self._device.serial))},
+            identifiers={(DOMAIN, cast(str, self._device.serial))},
         )
 
     @property
@@ -184,7 +185,7 @@ class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         return DeviceInfo(
-            identifiers={(self.coordinator.DOMAIN, cast(str, self._device.serial))},
+            identifiers={(DOMAIN, cast(str, self._device.serial))},
         )
 
     @property

--- a/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
@@ -17,6 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Meraki organization-level client counter by device type."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_has_entity_name = True
 
@@ -30,7 +32,7 @@ class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity)
         super().__init__(coordinator)
         self._config_entry = config_entry
         self._device_type = device_type
-        self._org_id = self.coordinator.api_client.organization_id
+        self._org_id = self.coordinator.api.organization_id
         self._attr_unique_id = f"{self._org_id}_{self._device_type}_clients"
         self._attr_name = f"{self._device_type.capitalize()} Clients"
 

--- a/custom_components/meraki_ha/services/__init__.py
+++ b/custom_components/meraki_ha/services/__init__.py
@@ -6,7 +6,6 @@ import logging
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 

--- a/custom_components/meraki_ha/switch/adult_content_filtering.py
+++ b/custom_components/meraki_ha/switch/adult_content_filtering.py
@@ -53,6 +53,8 @@ class MerakiAdultContentFilteringSwitch(MerakiEntity, SwitchEntity):
         ssid_data = self.coordinator.get_ssid(
             self._ssid["networkId"], self._ssid["number"]
         )
+        if not ssid_data:
+            return False
         return ssid_data.get("adultContentFilteringEnabled", False)
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/meraki_ha/switch/camera_profiles.py
+++ b/custom_components/meraki_ha/switch/camera_profiles.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 
-from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 from homeassistant.components.switch import SwitchEntityDescription
+
+from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 
 from ..core.api.client import MerakiAPIClient
 from ..types import MerakiDevice

--- a/custom_components/meraki_ha/switch/camera_settings.py
+++ b/custom_components/meraki_ha/switch/camera_settings.py
@@ -4,9 +4,10 @@ import dataclasses
 import logging
 from typing import Any, cast
 
-from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 
 from ..core.api.client import MerakiAPIClient
 from ..entity import MerakiEntity

--- a/custom_components/meraki_ha/text/meraki_ssid_name.py
+++ b/custom_components/meraki_ha/text/meraki_ssid_name.py
@@ -21,6 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiSSIDNameText(CoordinatorEntity, TextEntity):
     """Representation of a Meraki SSID Name text entity."""
 
+    coordinator: MerakiDataUpdateCoordinator
+
     _attr_mode = TextMode.TEXT  # Or TextMode.PASSWORD if it were a password
     entity_category = EntityCategory.CONFIG
     _attr_has_entity_name = True

--- a/custom_components/meraki_ha/webhook.py
+++ b/custom_components/meraki_ha/webhook.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from aiohttp import web
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,10 +14,10 @@ except ImportError:
 
 from typing import Any
 
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import DOMAIN
-from homeassistant.core import HomeAssistant
 
 from .const import MERAKI_TEST_API_KEY, MERAKI_TEST_ORG_ID
 

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry, mock_component
 
 from custom_components.meraki_ha.api.websocket import async_setup_websocket_api
@@ -12,7 +13,6 @@ from custom_components.meraki_ha.const import (
     CONF_MERAKI_ORG_ID,
     DOMAIN,
 )
-from homeassistant.core import HomeAssistant
 
 MOCK_DATA = {
     "org_name": "Test Org",

--- a/tests/binary_sensor/test_switch_port.py
+++ b/tests/binary_sensor/test_switch_port.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
 from custom_components.meraki_ha.binary_sensor.switch_port import SwitchPortSensor
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 
 def test_switch_port_sensor_connected():

--- a/tests/button/device/test_switch_port_cycle.py
+++ b/tests/button/device/test_switch_port_cycle.py
@@ -3,14 +3,14 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.button.device.switch_port_cycle import (
     MerakiSwitchPortCycleButton,
 )
 from custom_components.meraki_ha.services.switch_port_service import SwitchPortService
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture

--- a/tests/camera/test_camera.py
+++ b/tests/camera/test_camera.py
@@ -2,9 +2,9 @@ import dataclasses
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.camera import MerakiCamera
-from homeassistant.core import HomeAssistant
 from tests.const import MOCK_CAMERA_DEVICE
 
 

--- a/tests/core/test_timed_access_manager.py
+++ b/tests/core/test_timed_access_manager.py
@@ -4,13 +4,13 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.util import dt as dt_util
 
 from custom_components.meraki_ha.const import DATA_CLIENT, DOMAIN
 from custom_components.meraki_ha.core.timed_access_manager import (
     TimedAccessKey,
     TimedAccessManager,
 )
-from homeassistant.util import dt as dt_util
 
 
 @pytest.fixture

--- a/tests/event/device/test_camera_motion_event.py
+++ b/tests/event/device/test_camera_motion_event.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.components.event import EventDeviceClass
 
 from custom_components.meraki_ha.event.device.camera_motion import (
     MerakiCameraMotionEvent,
 )
-from homeassistant.components.event import EventDeviceClass
 
 
 @pytest.fixture

--- a/tests/event/device/test_mt_button_event.py
+++ b/tests/event/device/test_mt_button_event.py
@@ -2,8 +2,9 @@
 
 from unittest.mock import MagicMock, patch
 
-from custom_components.meraki_ha.event.device.mt_button import MerakiMtButtonEvent
 from homeassistant.components.event import EventDeviceClass
+
+from custom_components.meraki_ha.event.device.mt_button import MerakiMtButtonEvent
 
 
 async def test_mt_button_event_initialization(

--- a/tests/helpers/test_schema.py
+++ b/tests/helpers/test_schema.py
@@ -1,10 +1,10 @@
 """Test the schema helpers."""
 
 import voluptuous as vol
+from homeassistant.helpers import selector
 
 from custom_components.meraki_ha.const import CONF_IGNORED_NETWORKS
 from custom_components.meraki_ha.helpers.schema import populate_schema_defaults
-from homeassistant.helpers import selector
 
 
 def test_populate_schema_defaults():

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import DOMAIN
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import DOMAIN
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -3,13 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import CONF_ENABLE_VPN_MANAGEMENT, DOMAIN
 from custom_components.meraki_ha.types import MerakiVpn
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.setup import async_setup_component
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/sensor/device/test_camera_audio_detection.py
+++ b/tests/sensor/device/test_camera_audio_detection.py
@@ -3,12 +3,12 @@
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.const import EntityCategory
 
 from custom_components.meraki_ha.sensor.device.camera_audio_detection import (
     MerakiCameraAudioDetectionSensor,
 )
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.const import EntityCategory
 
 
 @pytest.fixture

--- a/tests/sensor/device/test_meraki_mt_base.py
+++ b/tests/sensor/device/test_meraki_mt_base.py
@@ -3,11 +3,11 @@
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.components.sensor import SensorEntityDescription
 
 from custom_components.meraki_ha.descriptions import MT_VOLTAGE_DESCRIPTION
 from custom_components.meraki_ha.sensor.device.meraki_mt_base import MerakiMtSensor
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.components.sensor import SensorEntityDescription
 
 
 @pytest.fixture

--- a/tests/sensor/device/test_meraki_mt_sensor.py
+++ b/tests/sensor/device/test_meraki_mt_sensor.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.components.sensor import SensorDeviceClass
 
 from custom_components.meraki_ha.descriptions import (
     MT_BATTERY_DESCRIPTION,
@@ -11,7 +12,6 @@ from custom_components.meraki_ha.descriptions import (
 )
 from custom_components.meraki_ha.sensor.device.meraki_mt_base import MerakiMtSensor
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.components.sensor import SensorDeviceClass
 
 
 @pytest.fixture

--- a/tests/sensor/device/test_switch_port.py
+++ b/tests/sensor/device/test_switch_port.py
@@ -3,14 +3,14 @@
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy, UnitOfPower
 
 from custom_components.meraki_ha.sensor.device.switch_port import (
     MerakiSwitchPortEnergySensor,
     MerakiSwitchPortPowerSensor,
 )
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import UnitOfEnergy, UnitOfPower
 
 
 @pytest.fixture

--- a/tests/sensor/network/test_ssid_client_count.py
+++ b/tests/sensor/network/test_ssid_client_count.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.components.sensor import SensorStateClass
+
 from custom_components.meraki_ha.sensor.network.ssid_client_count import (
     MerakiSSIDClientCountSensor,
 )
-from homeassistant.components.sensor import SensorStateClass
 
 
 async def test_ssid_client_count_sensor() -> None:

--- a/tests/sensor/network/test_traffic_shaping_sensor.py
+++ b/tests/sensor/network/test_traffic_shaping_sensor.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.const import EntityCategory
 
 from custom_components.meraki_ha.const import CONF_ENABLE_TRAFFIC_SHAPING
 from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
 from custom_components.meraki_ha.types import MerakiNetwork
-from homeassistant.const import EntityCategory
 
 
 @pytest.fixture

--- a/tests/sensor/network/test_vlans_list.py
+++ b/tests/sensor/network/test_vlans_list.py
@@ -3,11 +3,11 @@
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.const import EntityCategory
 
 from custom_components.meraki_ha.const import CONF_ENABLE_VLAN_MANAGEMENT
 from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
 from custom_components.meraki_ha.types import MerakiNetwork
-from homeassistant.const import EntityCategory
 
 
 @pytest.fixture

--- a/tests/sensor/network/test_vlans_list_unit.py
+++ b/tests/sensor/network/test_vlans_list_unit.py
@@ -3,10 +3,10 @@
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.const import EntityCategory
 
 from custom_components.meraki_ha.sensor.network.vlans_list import VlansListSensor
 from custom_components.meraki_ha.types import MerakiNetwork
-from homeassistant.const import EntityCategory
 
 
 @pytest.fixture

--- a/tests/sensor/test_meraki_wan1_connectivity.py
+++ b/tests/sensor/test_meraki_wan1_connectivity.py
@@ -2,11 +2,12 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.core import HomeAssistant
+
 from custom_components.meraki_ha.sensor.device.meraki_wan1_connectivity import (
     MerakiWAN1ConnectivitySensor,
 )
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.core import HomeAssistant
 from tests.const import MOCK_DEVICE
 
 

--- a/tests/sensor/test_meraki_wan2_connectivity.py
+++ b/tests/sensor/test_meraki_wan2_connectivity.py
@@ -2,11 +2,12 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.core import HomeAssistant
+
 from custom_components.meraki_ha.sensor.device.meraki_wan2_connectivity import (
     MerakiWAN2ConnectivitySensor,
 )
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.core import HomeAssistant
 from tests.const import MOCK_DEVICE
 
 

--- a/tests/sensor/test_network_clients.py
+++ b/tests/sensor/test_network_clients.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.core import HomeAssistant
+
 from custom_components.meraki_ha.sensor.network.network_clients import (
     MerakiNetworkClientsSensor,
 )
-from homeassistant.core import HomeAssistant
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/sensor/test_org_device_type_clients.py
+++ b/tests/sensor/test_org_device_type_clients.py
@@ -2,10 +2,11 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.core import HomeAssistant
+
 from custom_components.meraki_ha.sensor.org.org_device_type_clients import (
     MerakiOrganizationDeviceTypeClientsSensor,
 )
-from homeassistant.core import HomeAssistant
 
 
 async def test_meraki_organization_device_type_clients_sensor(

--- a/tests/sensor/test_setup_mt_sensors.py
+++ b/tests/sensor/test_setup_mt_sensors.py
@@ -1,22 +1,22 @@
 """Tests for the Meraki MT sensor setup."""
 
 import copy
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-
-from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
-from custom_components.meraki_ha.types import MerakiDevice
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
+from custom_components.meraki_ha.types import MerakiDevice
 
 
 @pytest.fixture
 def mock_coordinator_with_mt_devices(mock_coordinator: MagicMock) -> MagicMock:
     """Fixture for a mocked MerakiDataUpdateCoordinator with MT sensor data."""
-    devices_data = [
+    devices_data: list[dict[str, Any]] = [
         {
             "serial": "mt10-1",
             "name": "MT10 Sensor",
@@ -133,7 +133,9 @@ async def test_async_setup_mt10_sensors(
 
     assert len(entities) == 3
 
-    sensors_by_key = {entity.entity_description.key: entity for entity in entities}
+    sensors_by_key: dict[str, Any] = {
+        entity.entity_description.key: entity for entity in entities  # type: ignore
+    }
 
     # Test Temperature Sensor
     assert "temperature" in sensors_by_key
@@ -176,12 +178,14 @@ async def test_async_setup_mt15_sensors(
     for entity in entities:
         entity.hass = MagicMock()
         entity.entity_id = "sensor.test"
-        entity.async_write_ha_state = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
     assert len(entities) == 7
 
-    sensors_by_key = {entity.entity_description.key: entity for entity in entities}
+    sensors_by_key: dict[str, Any] = {
+        entity.entity_description.key: entity for entity in entities  # type: ignore
+    }
 
     # Verify Temperature Sensor
     temp_sensor = sensors_by_key.get("temperature")
@@ -260,12 +264,14 @@ async def test_async_setup_mt12_sensors(
     for entity in entities:
         entity.hass = MagicMock()
         entity.entity_id = "sensor.test"
-        entity.async_write_ha_state = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
     assert len(entities) == 3
 
-    sensors_by_key = {entity.entity_description.key: entity for entity in entities}
+    sensors_by_key: dict[str, Any] = {
+        entity.entity_description.key: entity for entity in entities  # type: ignore
+    }
 
     water_sensor = sensors_by_key.get("water")
     assert water_sensor is not None
@@ -298,12 +304,14 @@ async def test_async_setup_mt40_sensors(
     for entity in entities:
         entity.hass = MagicMock()
         entity.entity_id = "sensor.test"
-        entity.async_write_ha_state = MagicMock()
+        object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
     assert len(entities) == 3
 
-    sensors_by_key = {entity.entity_description.key: entity for entity in entities}
+    sensors_by_key: dict[str, Any] = {
+        entity.entity_description.key: entity for entity in entities  # type: ignore
+    }
 
     # Verify Power Sensor
     power_sensor = sensors_by_key.get("realPower")

--- a/tests/switch/test_meraki_ssid_device_switch.py
+++ b/tests/switch/test_meraki_ssid_device_switch.py
@@ -3,12 +3,12 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.switch.meraki_ssid_device_switch import (
     MerakiSSIDBroadcastSwitch,
     MerakiSSIDEnabledSwitch,
 )
-from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture

--- a/tests/switch/test_mt40_power_outlet.py
+++ b/tests/switch/test_mt40_power_outlet.py
@@ -3,10 +3,10 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.switch.mt40_power_outlet import MerakiMt40PowerOutlet
 from custom_components.meraki_ha.types import MerakiDevice
-from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from custom_components.meraki_ha.authentication import (
     validate_meraki_credentials,
@@ -14,8 +16,6 @@ from custom_components.meraki_ha.core.errors import (
     MerakiAuthenticationError,
     MerakiConnectionError,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 
 
 @pytest.mark.asyncio

--- a/tests/test_camera_control.py
+++ b/tests/test_camera_control.py
@@ -6,9 +6,9 @@ import dataclasses
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.camera import MerakiCamera
-from homeassistant.core import HomeAssistant
 from tests.const import MOCK_DEVICE
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,6 +13,9 @@
 
 from unittest.mock import MagicMock, patch
 
+from homeassistant import config_entries, setup
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import (
@@ -24,9 +27,6 @@ from custom_components.meraki_ha.core.errors import (
     MerakiAuthenticationError,
     MerakiConnectionError,
 )
-from homeassistant import config_entries, setup
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 
 
 async def test_form(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator_entity_priority.py
+++ b/tests/test_coordinator_entity_priority.py
@@ -2,8 +2,9 @@
 
 from unittest.mock import MagicMock, patch
 
-from custom_components.meraki_ha.core.helpers import update_device_registry_info
 from homeassistant.helpers import entity_registry as er
+
+from custom_components.meraki_ha.core.helpers import update_device_registry_info
 
 
 async def test_update_device_registry_info_picks_camera(hass):

--- a/tests/test_e2e_device_status.py
+++ b/tests/test_e2e_device_status.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from homeassistant.core import HomeAssistant
 from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import async_playwright, expect
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -20,7 +21,6 @@ from custom_components.meraki_ha.const import (
     CONF_MERAKI_ORG_ID,
     DOMAIN,
 )
-from homeassistant.core import HomeAssistant
 
 from .const import MOCK_ALL_DATA
 

--- a/tests/test_e2e_web_ui.py
+++ b/tests/test_e2e_web_ui.py
@@ -12,6 +12,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from homeassistant.core import HomeAssistant
 from playwright.async_api import Error, async_playwright, expect
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -20,7 +21,6 @@ from custom_components.meraki_ha.const import (
     CONF_MERAKI_ORG_ID,
     DOMAIN,
 )
-from homeassistant.core import HomeAssistant
 
 from .const import MOCK_ALL_DATA
 

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.meraki_ha.const import DOMAIN
-from custom_components.meraki_ha.types import MerakiNetwork  # Combined import
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.types import MerakiNetwork  # Combined import
 from tests.const import (  # Combined import
     MOCK_DEVICE,
     MOCK_GX_DEVICE,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import (
@@ -9,8 +11,6 @@ from custom_components.meraki_ha.const import (
     CONF_MERAKI_ORG_ID,
     DOMAIN,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 
 
 async def test_options_flow(hass: HomeAssistant) -> None:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.network import NoURLAvailableError
 
 from custom_components.meraki_ha.const import DOMAIN
 from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.types import MerakiDevice
 from custom_components.meraki_ha.webhook import async_handle_webhook, get_webhook_url
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.network import NoURLAvailableError
 
 
 @pytest.fixture

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -3,10 +3,10 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.webhook import async_register_webhook
-from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture

--- a/tests/text/test_meraki_ssid_name.py
+++ b/tests/text/test_meraki_ssid_name.py
@@ -3,9 +3,9 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.text.meraki_ssid_name import MerakiSSIDNameText
-from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR addresses over 60 Mypy errors identified during validation. Key changes include:
- Updated `MerakiDataUpdateCoordinator` methods (`get_device`, `is_pending`, `register_pending_update`, `cancel_pending_update`) to gracefully handle `str | None` inputs.
- Added explicit `coordinator: MerakiDataUpdateCoordinator` type hints to `CoordinatorEntity` subclasses (Sensors, Binary Sensors, Switches, etc.) to enable strict type checking of coordinator methods.
- Fixed `DOMAIN` usage in `switch_port.py` to import from const instead of accessing via coordinator instance.
- Resolved `Cannot assign to a method` errors in `tests/sensor/test_setup_mt_sensors.py` by using `object.__setattr__` for mocking `async_write_ha_state`.
- Added defensive checks for `self.coordinator.config_entry` (which can be None) in various sensors (`appliance_port`, `camera_analytics`, `meraki_mt_binary_base`) before accessing `.options`.
- Fixed `typeddict-item` error in `schema.py` with `type: ignore`.
- Fixed `Collection[str]` inference issues in tests by explicitly typing test data structures.
- Added `cancel_pending_update` method to `MerakiDataUpdateCoordinator` to support entity logic.

These changes significantly improve type safety and pass strict `mypy` checks.


---
*PR created automatically by Jules for task [7485803768161534360](https://jules.google.com/task/7485803768161534360) started by @brewmarsh*