### PR TITLE
fix: Resolve CI MyPy failures and verify dependencies

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
+++ b/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
@@ -33,7 +33,7 @@ class MerakiMtBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.entity_description = entity_description
         self._attr_unique_id = f"{self._device.serial}_{self.entity_description.key}"
         self._attr_has_entity_name = True
-        self._attr_name = self.entity_description.name
+        self._attr_name = self.entity_description.name  # type: ignore[assignment]
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -212,16 +212,18 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.data[key] = value.strip()
 
             for network in networks:
+                if not network.id:
+                    continue
                 device_registry.async_get_or_create(
                     config_entry_id=self.config_entry.entry_id,
-                    identifiers={(DOMAIN, network.id)},
+                    identifiers={(DOMAIN, cast(str, network.id))},
                     name=network.name,
                     manufacturer="Cisco Meraki",
                     model="Network",
                 )
 
             self.ssids_by_network_and_number = {
-                (s.get("networkId"), str(s.get("number"))): s
+                (cast(str, s.get("networkId")), int(s.get("number"))): s
                 for s in data.get("ssids", [])
                 if s.get("networkId") and s.get("number") is not None
             }

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -60,6 +60,8 @@ class MerakiAppliancePortSensor(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self._device.serial:
+            return
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device


### PR DESCRIPTION
This PR addresses CI failures by fixing MyPy type checking errors and verifying that the required dependencies are correctly specified.

Changes:
- **`custom_components/meraki_ha/coordinator.py`**: Added explicit casting and null checks for network IDs to satisfy strict typing for device registry identifiers. Fixed dictionary key typing for SSIDs.
- **`custom_components/meraki_ha/sensor/device/appliance_port.py`**: Added a guard clause to handle cases where `device.serial` might be `None` before attempting to fetch the device from the coordinator.
- **`custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py`**: Added a type ignore directive for the `_attr_name` assignment to resolve a conflict between `Entity` attributes and `EntityDescription` types.

Dependency Verification:
- Confirmed `aiodns==3.6.1` and `pycares==4.11.0` are present in `requirements_dev.txt` and `custom_components/meraki_ha/manifest.json`.
- Confirmed `webrtc-models==0.3.0` is present in `custom_components/meraki_ha/manifest.json` and `requirements_dev.txt`.

All local checks (`run_checks.sh`) passed, including strict MyPy validation.

---
*PR created automatically by Jules for task [14638164992235286351](https://jules.google.com/task/14638164992235286351) started by @brewmarsh*