### PR TITLE
fix(camera): Adopt has_entity_name convention for MerakiCamera

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -58,6 +58,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
     """
 
     _attr_brand = "Cisco Meraki"
+    _attr_has_entity_name = True
 
     coordinator: MerakiDataUpdateCoordinator
 
@@ -76,9 +77,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
         self._device_serial = device.serial or ""
         self._camera_service = camera_service
         self._attr_unique_id = f"{self._device_serial}-camera"
-        self._attr_name = format_device_name(
-            device, self.coordinator.config_entry.options
-        )
+        self._attr_name = None
         self._attr_model = self.device_data.model
 
     @property


### PR DESCRIPTION
This PR updates the `MerakiCamera` entity to use the modern `has_entity_name` convention.

- Set `_attr_has_entity_name = True`.
- Set `_attr_name = None` in `__init__` so that the entity name defaults to the device name.
- This fixes the `tests/test_naming_conventions.py` failure which explicitly asserts `camera.has_entity_name is True`.

Verification:
- Ran `tests/test_naming_conventions.py` and it passed.
- Ran all tests (`pytest`) and they passed.


---
*PR created automatically by Jules for task [18314608041554532299](https://jules.google.com/task/18314608041554532299) started by @brewmarsh*