### PR TITLE
[Jules]: Add MT40 Power Monitoring Support to Sensor Entities

### DIFF
--- a/custom_components/meraki_ha/descriptions.py
+++ b/custom_components/meraki_ha/descriptions.py
@@ -15,10 +15,37 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfPower,
     UnitOfSoundPressure,
     UnitOfTemperature,
 )
+
+MT_POWER_FACTOR_DESCRIPTION = SensorEntityDescription(
+    key="powerFactor",
+    name="Power Factor",
+    device_class=SensorDeviceClass.POWER_FACTOR,
+    state_class=SensorStateClass.MEASUREMENT,
+    native_unit_of_measurement=PERCENTAGE,
+)
+
+MT_FREQUENCY_DESCRIPTION = SensorEntityDescription(
+    key="frequency",
+    name="Frequency",
+    device_class=SensorDeviceClass.FREQUENCY,
+    state_class=SensorStateClass.MEASUREMENT,
+    native_unit_of_measurement=UnitOfFrequency.HERTZ,
+)
+
+MT_ENERGY_DESCRIPTION = SensorEntityDescription(
+    key="energy",
+    name="Energy",
+    device_class=SensorDeviceClass.ENERGY,
+    state_class=SensorStateClass.TOTAL_INCREASING,
+    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+)
+
 
 # Descriptions for individual sensor metrics
 MT_TEMPERATURE_DESCRIPTION = SensorEntityDescription(
@@ -157,6 +184,9 @@ MT_SENSOR_MODELS = {
         MT_POWER_DESCRIPTION,
         MT_VOLTAGE_DESCRIPTION,
         MT_CURRENT_DESCRIPTION,
+        MT_POWER_FACTOR_DESCRIPTION,
+        MT_FREQUENCY_DESCRIPTION,
+        MT_ENERGY_DESCRIPTION,
     ],
 }
 

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -72,45 +72,51 @@ class MerakiMtSensor(CoordinatorEntity, RestoreSensor):
         self._attr_native_value = None
         key = self.entity_description.key
 
-        if key == "noise":
-            self._attr_native_value = self._maybe_get_value(self._device.ambient_noise)
-        elif key == "pm25":
-            self._attr_native_value = self._maybe_get_value(self._device.pm25)
-        elif key in ("power", "realPower"):
-            self._attr_native_value = self._maybe_get_value(self._device.real_power)
-        elif key == "power_factor":
-            self._attr_native_value = self._maybe_get_value(self._device.power_factor)
-        elif key == "current":
-            self._attr_native_value = self._maybe_get_value(self._device.current)
-        elif key == "voltage":
-            self._attr_native_value = self._maybe_get_value(self._device.voltage)
-        elif key == "door":
-            self._attr_native_value = self._maybe_get_value(self._device.door_open)
-        else:
-            readings = self._device.readings
-            if not readings or not isinstance(readings, list):
-                return
+        readings = self._device.readings
+        if not readings or not isinstance(readings, list):
+            # Fallback for older MT devices that don't use the readings structure
+            if key == "noise":
+                self._attr_native_value = self._maybe_get_value(
+                    self._device.ambient_noise
+                )
+            elif key == "pm25":
+                self._attr_native_value = self._maybe_get_value(self._device.pm25)
+            elif key == "door":
+                self._attr_native_value = self._maybe_get_value(self._device.door_open)
+            return
 
-            for reading in readings:
-                if reading.get("metric") == key:
-                    metric_data = reading.get(key)
-                    if isinstance(metric_data, dict):
-                        key_map = {
-                            "battery": "percentage",
-                            "temperature": "celsius",
-                            "humidity": "relativePercentage",
-                            "tvoc": "concentration",
-                            "co2": "concentration",
-                            "water": "present",
-                            "voltage": "level",
-                            "button": "pressType",
-                        }
-                        value_key = key_map.get(key)
-                        if value_key:
+        for reading in readings:
+            if reading.get("metric") == key:
+                metric_data = reading.get(key)
+                if isinstance(metric_data, dict):
+                    # Map metric keys to the nested dictionary key that holds the value
+                    key_map = {
+                        "battery": "percentage",
+                        "temperature": "celsius",
+                        "humidity": "relativePercentage",
+                        "tvoc": "concentration",
+                        "co2": "concentration",
+                        "water": "present",
+                        "button": "pressType",
+                        # MT40 Power Monitoring
+                        "realPower": "draw",
+                        "current": "draw",
+                        "voltage": "level",  # fallback to draw if level is missing
+                        "powerFactor": "percentage",
+                        "frequency": "level",
+                        "energy": "draw",
+                    }
+                    value_key = key_map.get(key)
+                    if value_key:
+                        self._attr_native_value = self._maybe_get_value(
+                            metric_data.get(value_key)
+                        )
+                        # Special case for voltage fallback
+                        if key == "voltage" and self._attr_native_value is None:
                             self._attr_native_value = self._maybe_get_value(
-                                metric_data.get(value_key)
+                                metric_data.get("draw")
                             )
-                            return
+                        return
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
This submission adds support for the MT40 Smart Power Controller by creating new sensor entities for power-related metrics. It includes updates to the sensor descriptions, enhancements to the base MT sensor class to handle nested data, and a new test file for validation. Additionally, it contains fixes for several issues in the existing test suite that were uncovered during development.

Fixes #1588

---
*PR created automatically by Jules for task [11301047843119352083](https://jules.google.com/task/11301047843119352083) started by @brewmarsh*