### PR TITLE
fix(test): Update camera naming test for has_entity_name convention

### DIFF
--- a/tests/core/test_entity_naming.py
+++ b/tests/core/test_entity_naming.py
@@ -66,7 +66,9 @@ def test_camera_naming(mock_coordinator):
 
     entity = MerakiCamera(mock_coordinator, config_entry, device, camera_service)
 
-    assert entity.name.startswith("Front Door")
+    assert entity.has_entity_name is True
+    assert entity.name is None
+    assert entity.device_info["name"] == "Front Door"
 
 
 def test_network_status_naming(mock_coordinator):


### PR DESCRIPTION
Updated `tests/core/test_entity_naming.py` to correctly verify `MerakiCamera` naming behavior after the adoption of `has_entity_name = True`. The test now asserts that `entity.name` is `None` (as expected) and that `entity.device_info["name"]` is correct.

---
*PR created automatically by Jules for task [4651139666085820416](https://jules.google.com/task/4651139666085820416) started by @brewmarsh*