### PR TITLE
fix: Update camera naming test to reflect entity naming convention

### DIFF
--- a/tests/core/test_entity_naming.py
+++ b/tests/core/test_entity_naming.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.meraki_ha.core.entities.meraki_vlan_entity import MerakiVLANEntity
+from custom_components.meraki_ha.core.entities.meraki_vlan_entity import (
+    MerakiVLANEntity,
+)
 from custom_components.meraki_ha.types import MerakiNetwork
 
 
@@ -51,6 +53,7 @@ def test_camera_naming(mock_coordinator):
 
     config_entry = MagicMock()
     config_entry.options = {}
+    mock_coordinator.config_entry = config_entry
 
     device = MerakiDevice(
         serial="Q2XX-YYYY-YYYY",
@@ -66,7 +69,9 @@ def test_camera_naming(mock_coordinator):
 
     entity = MerakiCamera(mock_coordinator, config_entry, device, camera_service)
 
-    assert entity.name.startswith("Front Door")
+    assert entity.has_entity_name is True
+    assert entity.name is None
+    assert entity.device_info["name"] == "Front Door"
 
 
 def test_network_status_naming(mock_coordinator):

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import DOMAIN
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import DOMAIN
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -3,13 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import CONF_ENABLE_VPN_MANAGEMENT, DOMAIN
 from custom_components.meraki_ha.types import MerakiVpn
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
-from homeassistant.setup import async_setup_component
 from tests.const import MOCK_NETWORK
 
 

--- a/tests/test_coordinator_entity_priority.py
+++ b/tests/test_coordinator_entity_priority.py
@@ -2,8 +2,9 @@
 
 from unittest.mock import MagicMock, patch
 
-from custom_components.meraki_ha.core.helpers import update_device_registry_info
 from homeassistant.helpers import entity_registry as er
+
+from custom_components.meraki_ha.core.helpers import update_device_registry_info
 
 
 async def test_update_device_registry_info_picks_camera(hass):


### PR DESCRIPTION
Updates tests/core/test_entity_naming.py to correctly assert that MerakiCamera entity uses has_entity_name=True and name=None, effectively inheriting the device name. This fixes the regression test failure caused by the recent adoption of the entity naming convention.

---
*PR created automatically by Jules for task [15469623441860867025](https://jules.google.com/task/15469623441860867025) started by @brewmarsh*