### PR TITLE
Silence "400 Bad Request" Logs for Optional Features

### DIFF
--- a/custom_components/meraki_ha/core/utils/api_utils.py
+++ b/custom_components/meraki_ha/core/utils/api_utils.py
@@ -52,13 +52,21 @@ def handle_meraki_errors(
             # Inspect return type to provide a safe empty value
             sig = inspect.signature(func)
             return_type = sig.return_annotation
-            if return_type is list or getattr(return_type, "__origin__", None) in (
-                list,
-                list,
-            ):
+            if return_type is list or getattr(return_type, "__origin__", None) is list:
                 return cast(T, [])
             return cast(T, {})
         except APIError as err:
+            error_msg = str(err)
+            if getattr(err, "status", None) == 400 and (
+                "Traffic Analysis with Hostname Visibility must be enabled" in error_msg
+                or "VLANs are not enabled" in error_msg
+            ):
+                _LOGGER.info("Meraki feature disabled (skipping): %s", error_msg)
+                sig = inspect.signature(func)
+                return_type = sig.return_annotation
+                if return_type is list or getattr(return_type, "__origin__", None) is list:
+                    return cast(T, [])
+                return cast(T, {})
             if _is_informational_error(err):
                 raise MerakiInformationalError(f"Informational error: {err}") from err
 


### PR DESCRIPTION
This change downgrades specific '400 Bad Request' errors for disabled features (VLANs, Traffic Analysis) to INFO logs, preventing log spam. Instead of returning `None` which could cause `TypeError` exceptions, the decorated function now returns a type-safe empty value (either `[]` or `{}`).

Fixes #1564

---
*PR created automatically by Jules for task [14966618814768709708](https://jules.google.com/task/14966618814768709708) started by @brewmarsh*