### PR TITLE
Add Debug Logging to Investigate Entity Naming Issues

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -80,6 +80,14 @@ class MerakiCamera(CoordinatorEntity, Camera):
         self._attr_unique_id = f"{self._device_serial}-camera"
         self._attr_name = None
         self._attr_model = self.device_data.model
+        _LOGGER.debug(
+            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
+            self.entity_id if hasattr(self, "entity_id") else "New Entity",
+            self.__class__.__name__,
+            getattr(self, "_attr_has_entity_name", "Not Set"),
+            getattr(self, "_attr_name", "None"),
+            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
+        )
 
     @property
     def device_data(self) -> MerakiDevice:

--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -1,5 +1,6 @@
 """Base entity classes for the Meraki integration."""
 
+import logging
 from abc import ABC
 
 from homeassistant.config_entries import ConfigEntry
@@ -13,6 +14,8 @@ from ...const import (
     MANUFACTURER,
 )
 from ...coordinator import MerakiDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
@@ -51,6 +54,14 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
         self._network_id = network_id
         self._attr_has_entity_name = True
         self._network = self.coordinator.get_network(network_id) if network_id else None
+        _LOGGER.debug(
+            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
+            self.entity_id if hasattr(self, "entity_id") else "New Entity",
+            self.__class__.__name__,
+            getattr(self, "_attr_has_entity_name", "Not Set"),
+            getattr(self, "_attr_name", "None"),
+            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
+        )
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -1,6 +1,7 @@
 """Base entity for Meraki Networks."""
 
 from __future__ import annotations
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import DeviceInfo
@@ -8,6 +9,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...types import MerakiNetwork
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class MerakiNetworkEntity(CoordinatorEntity):
@@ -35,6 +38,14 @@ class MerakiNetworkEntity(CoordinatorEntity):
             name=network.name,
             manufacturer="Cisco Meraki",
             model="Network",
+        )
+        _LOGGER.debug(
+            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
+            self.entity_id if hasattr(self, "entity_id") else "New Entity",
+            self.__class__.__name__,
+            getattr(self, "_attr_has_entity_name", "Not Set"),
+            getattr(self, "_attr_name", "None"),
+            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
         )
 
     @property


### PR DESCRIPTION
This pull request adds debug logging to the `__init__` method of `BaseMerakiEntity`, `MerakiCamera`, and `MerakiNetworkEntity` to help diagnose entity naming problems. This logging will provide information about the entity's class, `has_entity_name` attribute, `_attr_name`, and device identifiers.

Fixes #1600

---
*PR created automatically by Jules for task [18278245786352333944](https://jules.google.com/task/18278245786352333944) started by @brewmarsh*