### PR TITLE
fix: Update VPN switch test to match spoke mode implementation

### DIFF
--- a/tests/switch/test_vpn_switch.py
+++ b/tests/switch/test_vpn_switch.py
@@ -138,7 +138,7 @@ async def test_vpn_turn_on_off(
     assert switch.is_on is True
     mock_api.appliance.update_vpn_status.assert_called_with(
         network_id="net1",
-        mode="hub",
+        mode="spoke",
     )
 
     await switch.async_turn_off()


### PR DESCRIPTION
Updated `tests/switch/test_vpn_switch.py` to expect `mode="spoke"` instead of `"hub"` when verifying the `async_turn_on` behavior of `MerakiVPNSwitch`. This aligns the test with the actual implementation which uses "spoke" mode for site-to-site VPN activation.

Also successfully verified that all tests pass in the local environment after resolving dependency issues.

---
*PR created automatically by Jules for task [9629207485078696524](https://jules.google.com/task/9629207485078696524) started by @brewmarsh*