### PR TITLE
fix: Fix Switch Port logic and resolve linting issues

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/switch_port.py
@@ -58,7 +58,12 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
         if device:
             self._device = device
             ports = device.ports_statuses or device.appliance_ports or []
-            for port in ports:
+            for port_data in ports:
+                if hasattr(port_data, "to_dict"):
+                    port = port_data.to_dict()
+                else:
+                    port = port_data  # type: ignore[assignment]
+
                 port_id = self._port.get("portId") or self._port.get("number")
                 if port.get("portId") == port_id or port.get("number") == port_id:
                     self._port = port

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -80,12 +80,15 @@ class MerakiCamera(CoordinatorEntity, Camera):
         self._attr_name = None
         self._attr_model = self.device_data.model
         _LOGGER.debug(
-            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
+            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s "
+            "| _attr_name: %s | Device Identifiers: %s",
             self.entity_id if hasattr(self, "entity_id") else "New Entity",
             self.__class__.__name__,
             getattr(self, "_attr_has_entity_name", "Not Set"),
             getattr(self, "_attr_name", "None"),
-            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
+            self.device_info.get("identifiers")
+            if self.device_info
+            else "NO DEVICE INFO",
         )
 
     @property

--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -55,12 +55,15 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
         self._attr_has_entity_name = True
         self._network = self.coordinator.get_network(network_id) if network_id else None
         _LOGGER.debug(
-            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
+            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s "
+            "| _attr_name: %s | Device Identifiers: %s",
             self.entity_id if hasattr(self, "entity_id") else "New Entity",
             self.__class__.__name__,
             getattr(self, "_attr_has_entity_name", "Not Set"),
             getattr(self, "_attr_name", "None"),
-            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
+            self.device_info.get("identifiers")
+            if self.device_info
+            else "NO DEVICE INFO",
         )
 
     @property

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -41,12 +41,15 @@ class MerakiNetworkEntity(CoordinatorEntity):
             model="Network",
         )
         _LOGGER.debug(
-            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
+            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s "
+            "| _attr_name: %s | Device Identifiers: %s",
             self.entity_id if hasattr(self, "entity_id") else "New Entity",
             self.__class__.__name__,
             getattr(self, "_attr_has_entity_name", "Not Set"),
             getattr(self, "_attr_name", "None"),
-            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
+            self.device_info.get("identifiers")
+            if self.device_info
+            else "NO DEVICE INFO",
         )
 
     @property

--- a/custom_components/meraki_ha/core/helpers.py
+++ b/custom_components/meraki_ha/core/helpers.py
@@ -101,16 +101,14 @@ def process_coordinator_data(
     # Create lookup tables for efficient access in entities
     devices_raw = data.get("devices", [])
     devices = [
-        MerakiDevice.from_dict(d) if isinstance(d, dict) else d
-        for d in devices_raw
+        MerakiDevice.from_dict(d) if isinstance(d, dict) else d for d in devices_raw
     ]
     devices_by_serial = {d.serial: d for d in devices if d.serial}
     data["devices"] = devices
 
     networks_raw = data.get("networks", [])
     networks = [
-        MerakiNetwork.from_dict(n) if isinstance(n, dict) else n
-        for n in networks_raw
+        MerakiNetwork.from_dict(n) if isinstance(n, dict) else n for n in networks_raw
     ]
     networks_by_id = {n.id: n for n in networks if n.id}
     data["networks"] = networks

--- a/custom_components/meraki_ha/core/utils/api_utils.py
+++ b/custom_components/meraki_ha/core/utils/api_utils.py
@@ -64,7 +64,10 @@ def handle_meraki_errors(
                 _LOGGER.info("Meraki feature disabled (skipping): %s", error_msg)
                 sig = inspect.signature(func)
                 return_type = sig.return_annotation
-                if return_type is list or getattr(return_type, "__origin__", None) is list:
+                if (
+                    return_type is list
+                    or getattr(return_type, "__origin__", None) is list
+                ):
                     return cast(T, [])
                 return cast(T, {})
             if _is_informational_error(err):


### PR DESCRIPTION
This PR addresses a crash in `SwitchPortSensor` caused by `MerakiAppliancePort` objects being accessed via `.get()` which is only available on dictionaries. The fix checks for the `to_dict` method and converts the object if necessary.

Additionally, this PR fixes several linting issues (line length) and applies formatting to ensure the codebase passes `ruff` checks.

Tests were verified locally by temporarily adjusting dependency versions to match the environment.

---
*PR created automatically by Jules for task [2208219105383270072](https://jules.google.com/task/2208219105383270072) started by @brewmarsh*