### PR TITLE
Fix MerakiNetworkEntity inheritance and related issues

### DIFF
--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -116,7 +116,3 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
 
         return True
 
-    @property
-    def entity_category(self) -> EntityCategory | None:
-        """Return the entity category."""
-        return None  # Override in child classes if needed

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...types import MerakiNetwork
+from . import BaseMerakiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiNetworkEntity(CoordinatorEntity):
+class MerakiNetworkEntity(BaseMerakiEntity):
     """Representation of a Meraki Network."""
 
     coordinator: MerakiDataUpdateCoordinator
@@ -26,30 +25,7 @@ class MerakiNetworkEntity(CoordinatorEntity):
         network: MerakiNetwork,
     ) -> None:
         """Initialize the network entity."""
-        super().__init__(coordinator=coordinator)
-        self._config_entry = config_entry
+        super().__init__(
+            coordinator=coordinator, config_entry=config_entry, network_id=network.id
+        )
         self._network = network
-        self._network_id = network.id
-
-        if hasattr(self, "entity_description") and self.entity_description:
-            self._attr_name = f"{network.name} {self.entity_description.name}"
-
-        self._attr_device_info = DeviceInfo(
-            identifiers={(self._config_entry.domain, f"network_{network.id}")},
-            name=network.name,
-            manufacturer="Cisco Meraki",
-            model="Network",
-        )
-        _LOGGER.debug(
-            "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s | _attr_name: %s | Device Identifiers: %s",
-            self.entity_id if hasattr(self, "entity_id") else "New Entity",
-            self.__class__.__name__,
-            getattr(self, "_attr_has_entity_name", "Not Set"),
-            getattr(self, "_attr_name", "None"),
-            self.device_info.get("identifiers") if self.device_info else "NO DEVICE INFO",
-        )
-
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        return self._attr_device_info

--- a/custom_components/meraki_ha/number/uplink_bandwidth.py
+++ b/custom_components/meraki_ha/number/uplink_bandwidth.py
@@ -36,7 +36,7 @@ class MerakiUplinkBandwidthNumber(MerakiNetworkEntity, NumberEntity):
             f"uplink_bandwidth_{self._network_id}_{self._uplink}_{self._direction}"
         )
         self._attr_name = (
-            f"{self._network.name} {self._uplink.capitalize()} "
+            f"{self._uplink.capitalize()} "
             f"{self._direction.capitalize()} Limit"
         )
         self._attr_native_unit_of_measurement = "kbps"

--- a/custom_components/meraki_ha/platforms/sensor/network/info.py
+++ b/custom_components/meraki_ha/platforms/sensor/network/info.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from ....coordinator import MerakiDataUpdateCoordinator
-from ....core.entities.network import MerakiNetworkEntity
+from ....core.entities.meraki_network_entity import MerakiNetworkEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,48 +30,39 @@ class MerakiNetworkInfoSensor(MerakiNetworkEntity):
             network_id: The ID of the network.
 
         """
+        network = coordinator.get_network(network_id)
+        if not network:
+            # Handle the case where network is not found
+            raise ValueError(f"Network {network_id} not found")
+
         super().__init__(
             coordinator=coordinator,
-            network_id=network_id,
-            name="Network Information",
-            unique_id_suffix="network_info",
+            config_entry=coordinator.config_entry,  # type: ignore[arg-type]
+            network=network,
         )
+        self._attr_name = "Network Information"
+        self._attr_unique_id = f"{network_id}_network_info"
 
     @property
     def native_value(self) -> str | None:
         """Return the network name."""
-        if not self.network_data:
+        if not self._network:
             return None
-        if isinstance(self.network_data, dict):
-            return self.network_data.get("name")
-        return getattr(self.network_data, "name", None)
+        return self._network.name
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        if not self.network_data:
+        if not self._network:
             return {}
 
-        if isinstance(self.network_data, dict):
-            return {
-                "hostname": self.network_data.get("name"),
-                "notes": self.network_data.get("notes"),
-                "network_id": self.network_data.get("id"),
-                "organization_id": self.network_data.get("organizationId"),
-                "product_types": self.network_data.get("productTypes"),
-                "tags": self.network_data.get("tags", []),
-                "time_zone": self.network_data.get("timeZone"),
-                "url": self.network_data.get("url"),
-            }
-
         return {
-            "hostname": getattr(self.network_data, "name", None),
-            "notes": getattr(self.network_data, "notes", None),
-            "network_id": getattr(self.network_data, "id", None),
-            "organization_id": getattr(self.network_data, "organization_id", None),
-            "product_types": getattr(self.network_data, "product_types", []),
-            "tags": getattr(self.network_data, "tags", []),
-            "time_zone": getattr(self.network_data, "time_zone", None),
-            # url is not in MerakiNetwork dataclass
-            "url": getattr(self.network_data, "url", None),
+            "hostname": self._network.name,
+            "notes": self._network.notes,
+            "network_id": self._network.id,
+            "organization_id": self._network.organization_id,
+            "product_types": self._network.product_types,
+            "tags": self._network.tags,
+            "time_zone": self._network.time_zone,
+            "url": getattr(self._network, "url", None),
         }


### PR DESCRIPTION
Refactors `MerakiNetworkEntity` to inherit from `BaseMerakiEntity`, ensuring consistent behavior across entities. Fixes broken imports and initialization in `MerakiNetworkInfoSensor`. Updates `MerakiUplinkBandwidthNumber` to prevent double naming due to `has_entity_name=True`. Removes `entity_category` property override in `BaseMerakiEntity` to allow subclasses to set their category. Verified with tests.

---
*PR created automatically by Jules for task [18006680967603177645](https://jules.google.com/task/18006680967603177645) started by @brewmarsh*