### PR TITLE
fix: Update environment requirements and fix type errors

### DIFF
--- a/custom_components/meraki_ha/button/device/switch_port_cycle.py
+++ b/custom_components/meraki_ha/button/device/switch_port_cycle.py
@@ -32,7 +32,7 @@ class MerakiSwitchPortCycleButton(ButtonEntity):
         """Initialize the switch port cycle button."""
         self._service = service
         self._device = device
-        self._port_id = port_info.get("portId") or port_info.get("number")
+        self._port_id = str(port_info.get("portId") or port_info.get("number"))
         self._port_number = self._port_id  # Meraki uses portId as number usually
         self._config_entry = config_entry
 

--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -4,7 +4,6 @@ import logging
 from abc import ABC
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity import DeviceInfo # Ensure this is imported
+from homeassistant.helpers.entity import DeviceInfo  # Ensure this is imported
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...types import MerakiNetwork

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -38,6 +38,8 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self._network:
+            return
         vlans = self.coordinator.data.get("vlans", {}).get(self._network.id, [])
         self._vlan_list = [
             vlan.get("name") or f"VLAN {vlan.get('id')}" for vlan in vlans

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -53,7 +53,7 @@ go2rtc-client==0.2.1
 h11
 habluetooth
 home-assistant-bluetooth
-homeassistant==2025.10.0
+homeassistant==2024.12.5
 meraki==1.54.0
 mypy
 mypy_extensions==1.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@ aiohttp==3.13.3
 bandit==1.7.9
 diskcache==5.6.3
 greenlet==3.3.0
-homeassistant==2025.10.0
+homeassistant==2024.12.5
 janus==1.0.0
 meraki==1.54.0
 numpy==2.3.2
@@ -18,7 +18,7 @@ protobuf==4.25.8
 psutil-home-assistant==0.0.1
 py==1.11.0
 pytest-cov
-pytest-homeassistant-custom-component==0.13.304
+pytest-homeassistant-custom-component==0.13.195
 pytest-mock==3.12.0
 requests==2.32.5
 ruff==0.5.5


### PR DESCRIPTION
- Downgraded `homeassistant` to `2024.12.5` in requirements to support Python 3.12.
- Fixed `TypeError` in `switch_port_cycle.py` by casting port ID to string.
- Fixed `AttributeError` risk in `vlans_list.py` by adding a guard for missing network.
- Fixed unused import in `core/entities/__init__.py`.
- Verified all checks pass with `run_checks.sh`.

---
*PR created automatically by Jules for task [18016446935534921673](https://jules.google.com/task/18016446935534921673) started by @brewmarsh*