### PR TITLE
Add device_info to MerakiNetworkEntity and Fix Naming

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -58,7 +58,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
     """
 
     _attr_brand = "Cisco Meraki"
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
 
     coordinator: MerakiDataUpdateCoordinator
 
@@ -77,7 +77,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
         self._device_serial = device.serial or ""
         self._camera_service = camera_service
         self._attr_unique_id = f"{self._device_serial}-camera"
-        self._attr_name = None
+        self._attr_name = device.name
         self._attr_model = self.device_data.model
         _LOGGER.debug(
             "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s "

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity import DeviceInfo  # Ensure this is imported
+from homeassistant.helpers.entity import DeviceInfo
 
+from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...types import MerakiNetwork
 from . import BaseMerakiEntity
@@ -46,6 +47,15 @@ class MerakiNetworkEntity(BaseMerakiEntity):
         )
 
     @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        return self._attr_device_info
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the network."""
+        # The network is required for this entity, and so is its ID.
+        # These assertions help mypy understand that these are not None.
+        assert self._network is not None
+        assert self._network.id is not None
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._network.id)},
+            name=self._network.name or f"Network {self._network.id}",
+            manufacturer="Meraki",
+            model="Meraki Network",
+        )

--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity import DeviceInfo
 
 from ...coordinator import MerakiDataUpdateCoordinator
-from . import BaseMerakiEntity
+from .meraki_network_entity import MerakiNetworkEntity
 
 
-class MerakiVLANEntity(BaseMerakiEntity):
+class MerakiVLANEntity(MerakiNetworkEntity):
     """Representation of a Meraki VLAN."""
+
+    _attr_has_entity_name = False
 
     def __init__(
         self,
@@ -20,37 +21,16 @@ class MerakiVLANEntity(BaseMerakiEntity):
         vlan: dict,
     ) -> None:
         """Initialize the VLAN entity."""
+        network = coordinator.get_network(network_id)
+        if network is None:
+            raise ValueError(f"Network {network_id} not found for VLAN entity")
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
-            network_id=network_id,
+            network=network,
         )
         self._vlan = vlan
-        if self._network_id is None:
-            raise ValueError("Network ID cannot be None for a VLAN entity")
-        if self._network is None:
-            raise ValueError(f"Network {self._network_id} not found for VLAN entity")
 
-        # Handle vlan as a dictionary
         vlan_id = vlan["id"]
-
-        if not vlan_id:
-            raise ValueError("VLAN ID not found in VLAN data")
-
         vlan_label = vlan.get("name") or ""
-        device_name = f"{self._network.name} VLAN {vlan_id}"
-        if vlan_label:
-            device_name += f" {vlan_label}"
-
-        self._attr_device_info = DeviceInfo(
-            identifiers={(self._config_entry.domain, f"vlan_{network_id}_{vlan_id}")},
-            name=device_name,
-            manufacturer="Cisco Meraki",
-            model="VLAN",
-            via_device=(self._config_entry.domain, f"network_{network_id}"),
-        )
-
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        return self._attr_device_info
+        self._attr_name = f"{network.name} VLAN {vlan_id} {vlan_label}"

--- a/custom_components/meraki_ha/sensor/network/network_clients.py
+++ b/custom_components/meraki_ha/sensor/network/network_clients.py
@@ -22,7 +22,7 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
     """Representation of a Meraki network-level client counter."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
 
     def __init__(
         self,
@@ -35,7 +35,7 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
         super().__init__(coordinator, config_entry, network_data)
         self._network_control_service = network_control_service
         self._attr_unique_id = f"meraki_network_clients_{self._network_id}"
-        self._attr_name = "Clients"
+        self._attr_name = f"{network_data.name} Active Clients"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/core/test_entity_naming.py
+++ b/tests/core/test_entity_naming.py
@@ -43,7 +43,8 @@ def test_vlan_naming(mock_coordinator):
 
     entity = MerakiVLANEntity(mock_coordinator, config_entry, "N_12345", vlan)
 
-    assert entity.device_info["name"] == "Site A VLAN 10 VoIP"
+    assert entity.device_info["name"] == "Site A"
+    assert entity.name == "Site A VLAN 10 VoIP"
 
 
 def test_camera_naming(mock_coordinator):
@@ -69,8 +70,8 @@ def test_camera_naming(mock_coordinator):
 
     entity = MerakiCamera(mock_coordinator, config_entry, device, camera_service)
 
-    assert entity.has_entity_name is True
-    assert entity.name is None
+    assert entity.has_entity_name is False
+    assert entity.name == "Front Door"
     assert entity.device_info["name"] == "Front Door"
 
 

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -92,9 +92,7 @@ async def test_vlan_sensor_creation(mock_coordinator):
     assert len(vlan_sensors) == 14
 
     # Filter for sensors of the first VLAN
-    vlan1_sensors = [
-        s for s in vlan_sensors if s.device_info["name"] == "Test Network VLAN 1 VLAN 1"
-    ]
+    vlan1_sensors = [s for s in vlan_sensors if s.name == "Test Network VLAN 1 VLAN 1"]
     assert len(vlan1_sensors) == 7
 
     # Find the specific sensors for VLAN 1 by translation_key
@@ -122,7 +120,7 @@ async def test_vlan_sensor_creation(mock_coordinator):
     assert id_sensor.unique_id == "meraki_vlan_net1_1_vlan_id"
     # assert id_sensor.name == "VLAN ID" # Cannot access name without platform
     assert id_sensor.native_value == 1
-    assert id_sensor.device_info["name"] == "Test Network VLAN 1 VLAN 1"
+    assert id_sensor.device_info["name"] == "Test Network"
 
     # Assertions for IPv4 Enabled Sensor
     assert ipv4_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv4_enabled"

--- a/tests/switch/test_vlan_dhcp.py
+++ b/tests/switch/test_vlan_dhcp.py
@@ -20,11 +20,19 @@ def mock_coordinator_with_vlan_data(mock_coordinator: MagicMock) -> MagicMock:
         "name": "VLAN 1",
         "dhcpHandling": "Run a DHCP server",
     }
+    network = MerakiNetwork(id="net1", name="Network 1")
     mock_coordinator.data = {
         "vlans": {"net1": [vlan1]},
-        "networks": [MerakiNetwork(id="net1", name="Network 1")],
+        "networks": [network],
     }
     mock_coordinator.is_pending.return_value = False
+
+    def get_network(network_id):
+        if network_id == "net1":
+            return network
+        return None
+
+    mock_coordinator.get_network = MagicMock(side_effect=get_network)
     return mock_coordinator
 
 

--- a/tests/test_naming_conventions.py
+++ b/tests/test_naming_conventions.py
@@ -41,8 +41,8 @@ async def test_naming_conventions():
         camera_service=mock_camera_service,
         config_entry=mock_config_entry,
     )
-    assert camera.has_entity_name is True
-    assert camera.name is None
+    assert camera.has_entity_name is False
+    assert camera.name == "Office Camera"
     assert camera.device_info["name"] == "Office Camera"
 
     motion_sensor = MerakiMotionSensor(


### PR DESCRIPTION
This submission fixes orphaned entities by adding `device_info` to `MerakiNetworkEntity` and enforces manual naming for Cameras, VLANs, and Network Clients to resolve naming inconsistencies. All relevant tests have been updated to reflect these changes.

Fixes #1615

---
*PR created automatically by Jules for task [15949811865199359822](https://jules.google.com/task/15949811865199359822) started by @brewmarsh*