### PR TITLE
Fix RuntimeWarning in test_client.py

### DIFF
--- a/tests/core/api/test_client.py
+++ b/tests/core/api/test_client.py
@@ -303,6 +303,7 @@ async def test_build_detail_tasks_for_appliance_device(api_client):
     api_client.appliance.get_network_appliance_settings = MagicMock(
         return_value="task_settings"
     )
+    api_client.appliance.get_appliance_ports = MagicMock(return_value="task_ports")
 
     # Act
     with patch("asyncio.create_task", side_effect=lambda x: x):
@@ -315,6 +316,7 @@ async def test_build_detail_tasks_for_appliance_device(api_client):
     assert tasks[f"l3_firewall_rules_{network_with_appliance.id}"] == "task_firewall"
     assert tasks[f"traffic_shaping_{network_with_appliance.id}"] == "task_shaping"
     assert tasks[f"vpn_status_{network_with_appliance.id}"] == "task_vpn"
+    assert tasks[f"appliance_ports_{network_with_appliance.id}"] == "task_ports"
     assert tasks[f"content_filtering_{network_with_appliance.id}"] == "task_filtering"
 
     # Check device tasks


### PR DESCRIPTION
Fixes a `RuntimeWarning` in `tests/core/api/test_client.py` where an `AsyncMock` coroutine was created but never awaited during the execution of `test_build_detail_tasks_for_appliance_device`. This was caused by `get_appliance_ports` not being mocked in a test scenario where `asyncio.create_task` was patched to be synchronous.

Changes:
- Added a mock for `api_client.appliance.get_appliance_ports` in `tests/core/api/test_client.py`.
- Added an assertion to verify that the task for `appliance_ports` is correctly created.

---
*PR created automatically by Jules for task [9418939486579500376](https://jules.google.com/task/9418939486579500376) started by @brewmarsh*