### PR TITLE
Refactor coordinator to remove service coupling

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -99,10 +99,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     camera_service = CameraService(camera_repo)
     network_control_service = NetworkControlService(coordinator.api, coordinator)
 
-    coordinator.device_control_service = device_control_service
-    coordinator.switch_port_service = switch_port_service
-    coordinator.camera_service = camera_service
-
     discovery_service: DeviceDiscoveryService = DeviceDiscoveryService(
         coordinator=coordinator,
         config_entry=entry,
@@ -127,7 +123,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     await discovery_service.discover_entities()
-    await async_setup_services(hass, coordinator)
+    await async_setup_services(
+        hass,
+        device_control_service=device_control_service,
+        switch_port_service=switch_port_service,
+        camera_service=camera_service,
+    )
 
     # Set up webhook
     webhook_id = WEBHOOK_ID_FORMAT.format(entry_id=entry.entry_id)

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -25,12 +25,6 @@ from .core.api.client import MerakiAPIClient as ApiClient
 from .core.helpers import filter_ignored_networks, process_coordinator_data
 from .core.managers import AvailabilityTracker, PendingUpdateManager
 from .types import MerakiDevice, MerakiNetwork
-
-if TYPE_CHECKING:
-    from .services.camera_service import CameraService
-    from .services.device_control_service import DeviceControlService
-    from .services.switch_port_service import SwitchPortService
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,10 +65,6 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self.pending_update_manager = PendingUpdateManager()
         self.availability_tracker = AvailabilityTracker()
-
-        self.device_control_service: DeviceControlService | None = None
-        self.switch_port_service: SwitchPortService | None = None
-        self.camera_service: CameraService | None = None
 
         try:
             scan_interval = int(

--- a/custom_components/meraki_ha/services/__init__.py
+++ b/custom_components/meraki_ha/services/__init__.py
@@ -12,7 +12,9 @@ from homeassistant.helpers import config_validation as cv
 from ..const import DOMAIN
 
 if TYPE_CHECKING:
-    from ..coordinator import MerakiDataUpdateCoordinator
+    from .camera_service import CameraService
+    from .device_control_service import DeviceControlService
+    from .switch_port_service import SwitchPortService
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,12 +40,11 @@ SERVICE_GENERATE_SNAPSHOT_SCHEMA = vol.Schema(
 
 async def async_setup_services(
     hass: HomeAssistant,
-    coordinator: MerakiDataUpdateCoordinator,
+    device_control_service: DeviceControlService,
+    switch_port_service: SwitchPortService,
+    camera_service: CameraService,
 ) -> None:
     """Set up the services for the Meraki integration."""
-    device_control_service = coordinator.device_control_service
-    switch_port_service = coordinator.switch_port_service
-    camera_service = coordinator.camera_service
 
     async def _async_reboot_device(call) -> None:
         """Reboot a device."""
@@ -59,11 +60,8 @@ async def async_setup_services(
 
     async def _async_generate_snapshot(call) -> None:
         """Generate a camera snapshot."""
-        if camera_service and call.data["serial"]:
-            await camera_service.generate_snapshot(call.data["serial"])
-        """Generate a camera snapshot."""
-        if camera_service:
-            await camera_service.generate_snapshot(call.data["serial"])
+        if camera_service and (serial := call.data.get("serial")):
+            await camera_service.generate_snapshot(serial)
 
     hass.services.async_register(
         DOMAIN,


### PR DESCRIPTION
Refactor MerakiDataUpdateCoordinator to remove dependency on service instances. Services are now passed directly to async_setup_services and DeviceDiscoveryService, improving architectural separation and resolving "God Class" coupling issues. Verified that entities receive services via dependency injection and do not rely on coordinator attributes.

---
*PR created automatically by Jules for task [52846580508148293](https://jules.google.com/task/52846580508148293) started by @brewmarsh*