### PR TITLE
Refactor DeviceDiscoveryService to use Factory pattern

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/mr.py
+++ b/custom_components/meraki_ha/discovery/handlers/mr.py
@@ -58,7 +58,6 @@ class MRHandler(BaseDeviceHandler):
         camera_service: CameraService,
         control_service: DeviceControlService,
         network_control_service: NetworkControlService,
-        switch_port_coordinator: Any,
     ) -> MRHandler:
         """
         Create an instance of the handler.
@@ -70,7 +69,6 @@ class MRHandler(BaseDeviceHandler):
             camera_service: The camera service.
             control_service: The device control service.
             network_control_service: The network control service.
-            switch_port_coordinator: The switch port coordinator.
 
         """
         return cls(

--- a/custom_components/meraki_ha/discovery/handlers/mt.py
+++ b/custom_components/meraki_ha/discovery/handlers/mt.py
@@ -17,9 +17,6 @@ if TYPE_CHECKING:
     from ....coordinator import (
         MerakiDataUpdateCoordinator,
     )
-    from ....core.coordinators.switch_port_status_coordinator import (
-        SwitchPortStatusCoordinator,
-    )
     from ....services.camera_service import CameraService
     from ....services.network_control_service import NetworkControlService
     from ....types import MerakiDevice
@@ -52,7 +49,6 @@ class MTHandler(BaseDeviceHandler):
         camera_service: CameraService,
         control_service: DeviceControlService,
         network_control_service: NetworkControlService,
-        switch_port_coordinator: SwitchPortStatusCoordinator,
     ) -> MTHandler:
         """Create an instance of the handler."""
         return cls(

--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -199,37 +199,15 @@ class DeviceDiscoveryService:
                 device.serial,
             )
 
-            # Pass the correct services to the handler based on its type
-            if model_prefix == "MV":
-                handler = handler_class(
-                    self._coordinator,
-                    device,
-                    self._config_entry,
-                    self._camera_service,
-                    self._control_service,
-                )
-            elif model_prefix in ("MX", "GX", "GR"):
-                handler = handler_class(
-                    self._coordinator,
-                    device,
-                    self._config_entry,
-                    self._control_service,
-                    self._network_control_service,
-                )
-            elif model_prefix in ("MS", "GS"):
-                handler = handler_class(
-                    self._coordinator,
-                    device,
-                    self._config_entry,
-                    self._control_service,
-                )
-            else:
-                handler = handler_class(
-                    self._coordinator,
-                    device,
-                    self._config_entry,
-                    self._control_service,
-                )
+            # Use the factory method to create the handler
+            handler = handler_class.create(
+                self._coordinator,
+                device,
+                self._config_entry,
+                self._camera_service,
+                self._control_service,
+                self._network_control_service,
+            )
 
             entities = await handler.discover_entities()
             all_entities.extend(entities)

--- a/tests/discovery/test_service.py
+++ b/tests/discovery/test_service.py
@@ -92,8 +92,8 @@ async def test_discover_entities_delegates_to_handler(
             "custom_components.meraki_ha.discovery.handlers.ssid.SSIDHandler"
         ) as MockSSIDHandler,
     ):
-        MockMRHandler.return_value = mock_mr_handler_instance
-        MockMVHandler.return_value = mock_mv_handler_instance
+        MockMRHandler.create.return_value = mock_mr_handler_instance
+        MockMVHandler.create.return_value = mock_mv_handler_instance
 
         mock_network_handler_instance = MagicMock()
         mock_network_handler_instance.discover_entities = AsyncMock(return_value=[])
@@ -107,13 +107,14 @@ async def test_discover_entities_delegates_to_handler(
         MockMRHandler.configure_mock(__name__="MRHandler")
         MockMVHandler.configure_mock(__name__="MVHandler")
 
+        mock_network_control_service = MagicMock()
         service = DeviceDiscoveryService(
             coordinator=mock_coordinator_with_devices,
             config_entry=mock_config_entry,
             meraki_client=MagicMock(),
             camera_service=mock_camera_service,
             control_service=mock_control_service,
-            network_control_service=MagicMock(),
+            network_control_service=mock_network_control_service,
         )
 
         # Act
@@ -124,18 +125,21 @@ async def test_discover_entities_delegates_to_handler(
         assert "mv_entity" in entities
 
         # Assert correct services are passed to each handler
-        MockMRHandler.assert_called_once_with(
+        MockMRHandler.create.assert_called_once_with(
             mock_coordinator_with_devices,
             mock_coordinator_with_devices.data["devices"][0],
             mock_config_entry,
+            mock_camera_service,
             mock_control_service,
+            mock_network_control_service,
         )
-        MockMVHandler.assert_called_once_with(
+        MockMVHandler.create.assert_called_once_with(
             mock_coordinator_with_devices,
             mock_coordinator_with_devices.data["devices"][1],
             mock_config_entry,
             mock_camera_service,
             mock_control_service,
+            mock_network_control_service,
         )
         # We don't check for log warning because "unsupported" model
         # just falls through if no handler matches


### PR DESCRIPTION
Refactored `DeviceDiscoveryService` to use a unified `create` factory method on device handlers, removing conditional instantiation logic. Standardized `create` method signatures in `MRHandler` and `MTHandler` by removing the unused `switch_port_coordinator` argument. Updated unit tests to verify the correct usage of the factory method.

---
*PR created automatically by Jules for task [1262083103799315532](https://jules.google.com/task/1262083103799315532) started by @brewmarsh*