### PR TITLE
Move Local Imports to Top-Level in discovery/service.py

### DIFF
--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -19,6 +19,14 @@ from ..const import (
     CONF_ENABLE_SSID_SENSORS,
 )
 from ..types import MerakiDevice
+from .handlers.gx import GXHandler
+from .handlers.mr import MRHandler
+from .handlers.ms import MSHandler
+from .handlers.mt import MTHandler
+from .handlers.mv import MVHandler
+from .handlers.mx import MXHandler
+from .handlers.network import NetworkHandler
+from .handlers.ssid import SSIDHandler
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -69,15 +77,6 @@ class DeviceDiscoveryService:
         handler based on the device's model type. It also discovers
         network-level and virtual SSID entities.
         """
-        from .handlers.gx import GXHandler
-        from .handlers.mr import MRHandler
-        from .handlers.ms import MSHandler
-        from .handlers.mt import MTHandler
-        from .handlers.mv import MVHandler
-        from .handlers.mx import MXHandler
-        from .handlers.network import NetworkHandler
-        from .handlers.ssid import SSIDHandler
-
         HANDLER_MAPPING = {
             "MR": MRHandler,
             "MV": MVHandler,

--- a/custom_components/meraki_ha/sensor/__init__.py
+++ b/custom_components/meraki_ha/sensor/__init__.py
@@ -8,7 +8,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from ..const import CONF_ENABLE_ORG_SENSORS, DOMAIN
-from ..discovery.service import DeviceDiscoveryService
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,6 +18,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> bool:
     """Set up Meraki sensor entities from a config entry."""
+    from ..discovery.service import DeviceDiscoveryService
+
     if config_entry.entry_id not in hass.data[DOMAIN]:
         return False
 

--- a/tests/discovery/test_service.py
+++ b/tests/discovery/test_service.py
@@ -80,16 +80,16 @@ async def test_discover_entities_delegates_to_handler(
 
     with (
         patch(
-            "custom_components.meraki_ha.discovery.handlers.mr.MRHandler"
+            "custom_components.meraki_ha.discovery.service.MRHandler"
         ) as MockMRHandler,
         patch(
-            "custom_components.meraki_ha.discovery.handlers.mv.MVHandler"
+            "custom_components.meraki_ha.discovery.service.MVHandler"
         ) as MockMVHandler,
         patch(
-            "custom_components.meraki_ha.discovery.handlers.network.NetworkHandler"
+            "custom_components.meraki_ha.discovery.service.NetworkHandler"
         ) as MockNetworkHandler,
         patch(
-            "custom_components.meraki_ha.discovery.handlers.ssid.SSIDHandler"
+            "custom_components.meraki_ha.discovery.service.SSIDHandler"
         ) as MockSSIDHandler,
     ):
         MockMRHandler.return_value = mock_mr_handler_instance


### PR DESCRIPTION
Moved handler imports to the top-level in `discovery/service.py` to prevent blocking the event loop when the camera component is initialized. Fixed circular dependencies by deferring imports in `sensor/__init__.py`.

Fixes #1629

---
*PR created automatically by Jules for task [8884058198380441587](https://jules.google.com/task/8884058198380441587) started by @brewmarsh*