### PR TITLE
Update Deployment Script to Auto-Fill Config Flow Forms

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/mr.py
+++ b/custom_components/meraki_ha/discovery/handlers/mr.py
@@ -8,7 +8,7 @@ entities for Meraki MR series (wireless) devices.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from .base import BaseDeviceHandler
 

--- a/tests/scripts/reset_integration.py
+++ b/tests/scripts/reset_integration.py
@@ -204,36 +204,63 @@ async def add_integration(session):
             logger.error(f"Failed to start config flow: {resp.status}")
             logger.error(await resp.text())
             return False
+        current_step = await resp.json()
 
-        start_data = await resp.json()
-        flow_id = start_data.get("flow_id")
-        if not flow_id:
-            logger.error(f"Could not find flow_id in response: {start_data}")
+    flow_id = current_step.get("flow_id")
+    if not flow_id:
+        logger.error(f"Could not find flow_id in response: {current_step}")
+        return False
+    logger.info(f"Config flow started. flow_id: {flow_id}")
+
+    # 2. Iterate through flow steps
+    while True:
+        step_type = current_step.get("type")
+
+        if step_type == "create_entry":
+            logger.info("SUCCESS: Integration re-added via REST API.")
+            return True
+
+        if step_type == "abort":
+            reason = current_step.get("reason")
+            if reason == "already_configured":
+                logger.info("Integration is already configured.")
+                return True
+            logger.error(f"Flow aborted: {current_step}")
             return False
-        logger.info(f"Config flow started. flow_id: {flow_id}")
 
-    # 2. Submit Credentials
-    submit_url = f"{HA_URL}/api/config/config_entries/flow/{flow_id}"
-    submit_payload = {
-        "meraki_api_key": MERAKI_API_KEY,
-        "meraki_org_id": MERAKI_ORG_ID,
-    }
-    logger.info(f"POST {submit_url}")
+        if step_type == "form":
+            step_id = current_step.get("step_id")
+            logger.info(f"ℹ️ Received form step: {step_id}")
 
-    async with session.post(submit_url, json=submit_payload) as resp:
-        if resp.status != 200:
-            logger.error(f"Failed to submit credentials: {resp.status}")
-            logger.error(await resp.text())
-            return False
+            payload = {}
+            # Step-specific logic
+            if step_id == "user":
+                payload = {
+                    "meraki_api_key": MERAKI_API_KEY,
+                    "meraki_org_id": MERAKI_ORG_ID,
+                }
+            else:
+                # Build payload from defaults in schema
+                for field in current_step.get("data_schema", []):
+                    if "default" in field:
+                        payload[field["name"]] = field["default"]
+                    elif field.get("required"):
+                        logger.warning(
+                            f"Required field '{field['name']}' has no default value."
+                        )
 
-        submit_data = await resp.json()
+            submit_url = f"{HA_URL}/api/config/config_entries/flow/{flow_id}"
+            logger.info(f"POST {submit_url} for step {step_id} with payload: {payload}")
+            async with session.post(submit_url, json=payload) as resp:
+                if resp.status != 200:
+                    logger.error(f"Failed to submit step {step_id}: {resp.status}")
+                    logger.error(await resp.text())
+                    return False
+                current_step = await resp.json()
+            continue
 
-    # 3. Final Verification
-    if submit_data.get("type") == "create_entry":
-        logger.info("SUCCESS: Integration re-added via REST API.")
-        return True
-    else:
-        logger.error(f"FAILED: Unexpected final response: {submit_data}")
+        logger.error(f"FAILED: Unexpected response type: {step_type}")
+        logger.debug(f"Response: {current_step}")
         return False
 
 


### PR DESCRIPTION
The deployment script `tests/scripts/reset_integration.py` was failing because it assumed a single-step config flow for the Meraki HA integration. Recent updates added a second step (options configuration) after API key submission.

This PR refactors the `add_integration` function in the deployment script to use a robust loop that:
1. Starts the config flow.
2. If a response of type `form` is received:
    - If it's the `user` step, it submits the API key and Org ID from environment variables.
    - Otherwise, it iterates through the `data_schema` and constructs a payload using the `default` value for each field.
3. Repeats until `create_entry` (success) or `abort` (with special handling for `already_configured`) is reached.

This change ensures that automated staging deployments and tests can successfully navigate the config flow using default settings.

Fixes #1632

---
*PR created automatically by Jules for task [4857119429849744872](https://jules.google.com/task/4857119429849744872) started by @brewmarsh*