### PR TITLE
Create GitHub Action for Agent Readiness Scorecard

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -1,0 +1,40 @@
+name: Agent Readiness Scorecard
+
+on:
+  pull_request:
+    branches:
+      - beta
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  readiness-score:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tool
+        run: pip install git+https://github.com/brewmarsh/agent-readiness-scorecard.git
+
+      - name: Run scorecard
+        run: agent-readiness-scorecard check --path custom_components/meraki_ha --format markdown > readiness_report.md
+
+      - name: Upload readiness report
+        uses: actions/upload-artifact@v4
+        with:
+          name: readiness-report
+          path: readiness_report.md
+
+      - name: Post comment to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: readiness_report.md

--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -1,4 +1,4 @@
-name: Agent Readiness Scorecard
+name: Agent readiness scorecard
 
 on:
   pull_request:
@@ -25,16 +25,18 @@ jobs:
         run: pip install git+https://github.com/brewmarsh/agent-readiness-scorecard.git
 
       - name: Run scorecard
-        run: agent-readiness-scorecard check --path custom_components/meraki_ha --format markdown > readiness_report.md
+        continue-on-error: true
+        run: agent-score score custom_components/meraki_ha --report readiness_report.md
 
       - name: Upload readiness report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: readiness-report
           path: readiness_report.md
 
       - name: Post comment to PR
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: readiness_report.md

--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -12,6 +12,9 @@ on:
 jobs:
   readiness-score:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds a new GitHub Action workflow to assess the integration's compatibility with AI Agents. The workflow runs the `agent-readiness-scorecard` tool on pull requests targeting `beta` or `main`, as well as on a nightly schedule. Results are published as an artifact and posted as a comment on pull requests.

Fixes #1634

---
*PR created automatically by Jules for task [14946773206134075545](https://jules.google.com/task/14946773206134075545) started by @brewmarsh*