### PR TITLE
Fix Invalid Version Component in scripts/release.sh

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -14,7 +14,6 @@ from functools import partial
 from typing import Any, cast
 
 import meraki
-
 from homeassistant.core import HomeAssistant
 
 from ...core.errors import (

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@
 # Usage:
 #   ./scripts/release.sh <part>
 #
-#   <part>: 'beta' to increment the build number for a beta release.
+#   <part>: 'beta' to increment the patch version for a beta release.
 #           'patch' to finalize a release (removes beta suffix).
 #
 set -euo pipefail
@@ -55,7 +55,7 @@ echo "Successfully synced ${BUMP_CONFIG_FILE}"
 BUMP_PART=""
 case "${PART}" in
   beta)
-    BUMP_PART="build"
+    BUMP_PART="patch"
     ;;
   patch)
     BUMP_PART="patch"


### PR DESCRIPTION
This PR fixes the "Unknown version component: build" error in the release script.

The script was using `BUMP_PART="build"`, but `.bumpversion.toml` only recognizes standard components (`major`, `minor`, `patch`) because `build` is not explicitly defined as a part.

Changes:
- Modified `scripts/release.sh` to use `patch` for the `beta` release case.
- Updated documentation in `scripts/release.sh`.
- Minor whitespace adjustment in `custom_components/meraki_ha/core/api/client.py`.

Verified with `bump-my-version` dry-runs and full test suite (after resolving a pre-existing `ModuleNotFoundError` in the beta branch).

Fixes #1651

---
*PR created automatically by Jules for task [5933270529671418936](https://jules.google.com/task/5933270529671418936) started by @brewmarsh*