### PR TITLE
fix: synchronize version configuration files

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = "2.1.0-beta.106"
+current_version = "2.2.1-beta.34"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.2.1-beta.33",
+  "version": "2.2.1-beta.34",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",


### PR DESCRIPTION
Synchronized `.bumpversion.toml` and `package.json` to match `manifest.json` version `2.2.1-beta.34`. This fixes a version drift where `.bumpversion.toml` was lagging behind (`2.1.0-beta.106`), preventing correct version bumping in future releases.

---
*PR created automatically by Jules for task [5958336085755240659](https://jules.google.com/task/5958336085755240659) started by @brewmarsh*