### PR TITLE
Move DeviceDiscoveryService Import to Top-Level

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import secrets
 import string
-from typing import TYPE_CHECKING
 
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
@@ -24,16 +23,13 @@ from .coordinator import MerakiDataUpdateCoordinator
 from .core.repositories.camera_repository import CameraRepository
 from .core.repository import MerakiRepository
 from .core.timed_access_manager import TimedAccessManager
+from .discovery.service import DeviceDiscoveryService
 from .frontend import async_register_frontend, async_remove_frontend
 from .services.camera_service import CameraService
 from .services.device_control_service import DeviceControlService
 from .services.network_control_service import NetworkControlService
 from .services.switch_port_service import SwitchPortService
 from .webhook import async_register_webhook, async_unregister_webhook
-
-if TYPE_CHECKING:
-    from .discovery.service import DeviceDiscoveryService
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,9 +79,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         Whether the setup was successful.
 
     """
-    # Defer import to avoid circular dependency
-    from .discovery.service import DeviceDiscoveryService
-
     await async_register_frontend(hass, entry)
     async_setup_websocket_api(hass)
     coordinator = MerakiDataUpdateCoordinator(hass, entry)


### PR DESCRIPTION
Moved the DeviceDiscoveryService import to the top-level of custom_components/meraki_ha/__init__.py to prevent blocking the event loop during async_setup_entry. Verified that the module is still importable and that all tests pass.

Fixes #1668

---
*PR created automatically by Jules for task [16480749723932885507](https://jules.google.com/task/16480749723932885507) started by @brewmarsh*