### PR TITLE
fix: resolve missing MX uplink sensors by using device attribute

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/mx.py
+++ b/custom_components/meraki_ha/discovery/handlers/mx.py
@@ -69,7 +69,7 @@ class MXHandler(BaseDeviceHandler):
         _LOGGER.debug("MXHandler checking device %s", self.device.serial)
 
         # Check Uplinks
-        uplink_data = getattr(self.device, "appliance_uplinks", None)
+        uplink_data = getattr(self.device, "appliance_uplink_statuses", None)
         _LOGGER.debug("Device %s Uplink Data: %s", self.device.serial, uplink_data)
 
         # Check Performance
@@ -105,14 +105,10 @@ class MXHandler(BaseDeviceHandler):
         if self._config_entry.options.get(CONF_ENABLE_PORT_SENSORS, True):
             # Collect data from API
             uplink_data_by_interface: dict[str, dict[str, Any]] = {}
-            if self._coordinator.data and self._coordinator.data.get(
-                "appliance_uplink_statuses"
-            ):
-                for status in self._coordinator.data["appliance_uplink_statuses"]:
-                    if status.get("serial") == self.device.serial:
-                        for uplink in status.get("uplinks", []):
-                            if interface := uplink.get("interface"):
-                                uplink_data_by_interface[interface] = uplink
+            if self.device.appliance_uplink_statuses:
+                for uplink in self.device.appliance_uplink_statuses:
+                    if interface := uplink.get("interface"):
+                        uplink_data_by_interface[interface] = uplink
 
             # Identify interfaces from existing entities in the registry
             # to handle cases where API data is temporarily missing.

--- a/tests/discovery/handlers/test_mx.py
+++ b/tests/discovery/handlers/test_mx.py
@@ -6,6 +6,9 @@ import pytest
 
 from custom_components.meraki_ha.button.reboot import MerakiRebootButton
 from custom_components.meraki_ha.discovery.handlers.mx import MXHandler
+from custom_components.meraki_ha.sensor.device.appliance_uplink import (
+    MerakiApplianceUplinkSensor,
+)
 from custom_components.meraki_ha.sensor.device.device_status import (
     MerakiDeviceStatusSensor,
 )
@@ -33,17 +36,26 @@ def mock_camera_service():
     return AsyncMock()
 
 
+@pytest.fixture
+def mock_network_control_service():
+    """Fixture for a mock NetworkControlService."""
+    return MagicMock()
+
+
 @pytest.mark.asyncio
 async def test_discover_entities_creates_reboot_button_and_status_sensor(
-    mock_coordinator, mock_camera_service, mock_control_service
+    mock_coordinator,
+    mock_camera_service,
+    mock_control_service,
+    mock_network_control_service,
 ):
     """Test that discover_entities creates a MerakiRebootButton."""
     handler = MXHandler(
         mock_coordinator,
         MOCK_MX_DEVICE,
         MOCK_CONFIG_ENTRY,
-        mock_camera_service,
         mock_control_service,
+        mock_network_control_service,
     )
 
     entities = await handler.discover_entities()
@@ -51,3 +63,4 @@ async def test_discover_entities_creates_reboot_button_and_status_sensor(
     assert len(entities) >= 2
     assert any(isinstance(e, MerakiRebootButton) for e in entities)
     assert any(isinstance(e, MerakiDeviceStatusSensor) for e in entities)
+    assert any(isinstance(e, MerakiApplianceUplinkSensor) for e in entities)


### PR DESCRIPTION
Fixed an issue in MXHandler.discover_entities where it was incorrectly looking for appliance uplink statuses in coordinator.data instead of the populated MerakiDevice object. This resulted in missed uplink sensors. Added a test case to verify the fix and updated debug logging to check the correct attribute.

---
*PR created automatically by Jules for task [3654890988719479169](https://jules.google.com/task/3654890988719479169) started by @brewmarsh*