### PR TITLE
fix: enforce MerakiDevice type consistency for appliance_ports

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/switch_port.py
@@ -1,5 +1,7 @@
 """Binary sensor for Meraki switch port status."""
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -15,7 +17,7 @@ from ..coordinator import MerakiDataUpdateCoordinator
 from ..helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
-    from ..types import MerakiDevice
+    from ..types import MerakiAppliancePort, MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,13 +34,17 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
     def __init__(
         self,
         coordinator: MerakiDataUpdateCoordinator,
-        device: "MerakiDevice",
-        port: dict[str, Any],
+        device: MerakiDevice,
+        port: dict[str, Any] | MerakiAppliancePort,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
-        self._port = port
+        if hasattr(port, "to_dict"):
+            self._port = port.to_dict()
+        else:
+            self._port = port
+
         # MX appliances use 'number', MS switches use 'portId'
         port_id = self._port.get("portId") or self._port.get("number")
         self._attr_unique_id = f"{device.serial}_{port_id}"

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -18,7 +18,7 @@ from ...core.errors import (
 )
 from ...core.parsers.appliance import parse_appliance_data
 from ...core.parsers.sensors import parse_sensor_data
-from ...types import MerakiDevice, MerakiNetwork
+from ...types import MerakiAppliancePort, MerakiDevice, MerakiNetwork
 from .client_fetcher import ClientFetcher
 
 if TYPE_CHECKING:
@@ -366,7 +366,11 @@ class DataFetchManager:
         """Process appliance details."""
         if ports := detail_data.get(f"appliance_ports_{device.network_id}"):
             if isinstance(ports, list):
-                device.appliance_ports = ports
+                device.appliance_ports = [
+                    MerakiAppliancePort.from_dict(p)
+                    for p in ports
+                    if isinstance(p, dict)
+                ]
         elif prev_device and "appliance_ports" in prev_device:
             device.appliance_ports = prev_device["appliance_ports"]
 


### PR DESCRIPTION
This PR fixes a type inconsistency where `MerakiDevice.appliance_ports` was being populated with a list of dictionaries instead of `MerakiAppliancePort` objects, violating the dataclass definition. 

Changes:
- In `custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py`, imported `MerakiAppliancePort` and updated `_process_appliance_details` to convert dictionary data to `MerakiAppliancePort` objects.
- In `custom_components/meraki_ha/binary_sensor/switch_port.py`, updated `__init__` to handle `MerakiAppliancePort` objects by converting them to dictionaries using `.to_dict()`. Also added `from __future__ import annotations`.

This ensures the codebase adheres to type definitions and prevents potential `AttributeError` issues in components expecting objects or dictionaries. All checks passed.

---
*PR created automatically by Jules for task [16621924188580301771](https://jules.google.com/task/16621924188580301771) started by @brewmarsh*