### PR TITLE
Update MXHandler to Yield Port and Status Entities

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/mx.py
+++ b/custom_components/meraki_ha/discovery/handlers/mx.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
-from ...binary_sensor.switch_port import SwitchPortSensor
 from ...button.reboot import MerakiRebootButton
 from ...const import CONF_ENABLE_DEVICE_STATUS, CONF_ENABLE_PORT_SENSORS, DOMAIN
+from ...sensor.device.appliance_port import MerakiAppliancePortSensor
 from ...sensor.device.appliance_uplink import MerakiApplianceUplinkSensor
 from ...sensor.device.device_status import MerakiDeviceStatusSensor
 from .base import BaseDeviceHandler
@@ -67,6 +67,14 @@ class MXHandler(BaseDeviceHandler):
     async def discover_entities(self) -> list[Entity]:
         """Discover entities for the device."""
         _LOGGER.debug("MXHandler checking device %s", self.device.serial)
+
+        if self.device.model and self.device.model.startswith("MX"):
+            _LOGGER.debug(
+                "MX Debug - Serial: %s | Status: %s | Port Count: %s",
+                self.device.serial,
+                getattr(self.device, "status", "MISSING"),
+                len(getattr(self.device, "appliance_ports", [])),
+            )
 
         # Check Uplinks
         uplink_data = getattr(self.device, "appliance_uplink_statuses", None)
@@ -163,7 +171,7 @@ class MXHandler(BaseDeviceHandler):
             if self.device and self.device.appliance_ports:
                 for port in self.device.appliance_ports:
                     entities.append(
-                        SwitchPortSensor(self._coordinator, self.device, port)
+                        MerakiAppliancePortSensor(self._coordinator, self.device, port)
                     )
         else:
             _LOGGER.debug("Uplink sensors disabled for device %s", self.device.serial)

--- a/tests/discovery/handlers/test_mx.py
+++ b/tests/discovery/handlers/test_mx.py
@@ -6,12 +6,16 @@ import pytest
 
 from custom_components.meraki_ha.button.reboot import MerakiRebootButton
 from custom_components.meraki_ha.discovery.handlers.mx import MXHandler
+from custom_components.meraki_ha.sensor.device.appliance_port import (
+    MerakiAppliancePortSensor,
+)
 from custom_components.meraki_ha.sensor.device.appliance_uplink import (
     MerakiApplianceUplinkSensor,
 )
 from custom_components.meraki_ha.sensor.device.device_status import (
     MerakiDeviceStatusSensor,
 )
+from custom_components.meraki_ha.types import MerakiAppliancePort
 
 from ...const import MOCK_CONFIG_ENTRY, MOCK_MX_DEVICE
 
@@ -64,3 +68,33 @@ async def test_discover_entities_creates_reboot_button_and_status_sensor(
     assert any(isinstance(e, MerakiRebootButton) for e in entities)
     assert any(isinstance(e, MerakiDeviceStatusSensor) for e in entities)
     assert any(isinstance(e, MerakiApplianceUplinkSensor) for e in entities)
+
+
+@pytest.mark.asyncio
+async def test_discover_entities_creates_port_sensors(
+    mock_coordinator,
+    mock_camera_service,
+    mock_control_service,
+    mock_network_control_service,
+):
+    """Test that discover_entities creates MerakiAppliancePortSensor."""
+    device = MOCK_MX_DEVICE
+    device.appliance_ports = [
+        MerakiAppliancePort(number=1, enabled=True, status="connected"),
+        MerakiAppliancePort(number=2, enabled=True, status="disconnected"),
+    ]
+
+    handler = MXHandler(
+        mock_coordinator,
+        device,
+        MOCK_CONFIG_ENTRY,
+        mock_control_service,
+        mock_network_control_service,
+    )
+
+    entities = await handler.discover_entities()
+
+    port_sensors = [e for e in entities if isinstance(e, MerakiAppliancePortSensor)]
+    assert len(port_sensors) == 2
+    assert port_sensors[0].unique_id == f"{device.serial}_port_1"
+    assert port_sensors[1].unique_id == f"{device.serial}_port_2"


### PR DESCRIPTION
Updated the MXHandler to correctly use the MerakiAppliancePortSensor class for security appliance ports, which resolves the issue where ports were missing for devices like the MX75. Additionally, added diagnostic logging to help troubleshoot "Unknown" status reports and updated tests to verify the fix.

Fixes #1681

---
*PR created automatically by Jules for task [2318628439362527815](https://jules.google.com/task/2318628439362527815) started by @brewmarsh*