### PR TITLE
Fix MT40 Sensor Key Mappings in parse_sensor_data

### DIFF
--- a/custom_components/meraki_ha/core/parsers/sensors.py
+++ b/custom_components/meraki_ha/core/parsers/sensors.py
@@ -66,8 +66,28 @@ def parse_sensor_data(
                     device.real_power = power_data.get("realPower") or power_data.get(
                         "draw"
                     )
-                elif metric == "power_factor":
-                    device.power_factor = reading.get("power_factor", {}).get("factor")
+                elif metric in ("power_factor", "powerFactor"):
+                    pf_data = reading.get("power_factor") or reading.get("powerFactor")
+                    if isinstance(pf_data, dict):
+                        device.power_factor = pf_data.get("factor") or pf_data.get(
+                            "percentage"
+                        )
+                elif metric == "frequency":
+                    freq_data = reading.get("frequency")
+                    if isinstance(freq_data, dict):
+                        device.frequency = freq_data.get("level")
+                    elif isinstance(freq_data, (int, float)):
+                        device.frequency = freq_data
+                elif metric in ("energy", "energyUsage"):
+                    energy_data = reading.get("energy") or reading.get("energyUsage")
+                    if isinstance(energy_data, dict):
+                        device.energy = (
+                            energy_data.get("energyUsage")
+                            or energy_data.get("draw")
+                            or energy_data.get("apparentPower")
+                        )
+                    elif isinstance(energy_data, (int, float)):
+                        device.energy = energy_data
                 elif metric == "current":
                     device.current = reading.get("current", {}).get("draw")
                 elif metric == "voltage":

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -119,6 +119,19 @@ class MerakiMtSensor(CoordinatorEntity, RestoreSensor):
                             self._attr_native_value = self._maybe_get_value(
                                 metric_data.get("draw")
                             )
+                        # Special case for energy fallback
+                        if key == "energy" and self._attr_native_value is None:
+                            self._attr_native_value = (
+                                self._maybe_get_value(metric_data.get("energyUsage"))
+                                or self._maybe_get_value(
+                                    metric_data.get("apparentPower")
+                                )
+                            )
+                        # Special case for power factor fallback
+                        if key == "powerFactor" and self._attr_native_value is None:
+                            self._attr_native_value = self._maybe_get_value(
+                                metric_data.get("factor")
+                            )
                         return
 
                     # Special case for noise (nested structure)
@@ -127,6 +140,23 @@ class MerakiMtSensor(CoordinatorEntity, RestoreSensor):
                             metric_data.get("ambient", {}).get("level")
                         )
                         return
+
+        # Fallback to device attributes if not found in readings
+        if self._attr_native_value is None:
+            if key == "frequency":
+                self._attr_native_value = self._maybe_get_value(self._device.frequency)
+            elif key == "powerFactor":
+                self._attr_native_value = self._maybe_get_value(
+                    self._device.power_factor
+                )
+            elif key == "energy":
+                self._attr_native_value = self._maybe_get_value(self._device.energy)
+            elif key == "realPower":
+                self._attr_native_value = self._maybe_get_value(self._device.real_power)
+            elif key == "voltage":
+                self._attr_native_value = self._maybe_get_value(self._device.voltage)
+            elif key == "current":
+                self._attr_native_value = self._maybe_get_value(self._device.current)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/types.py
+++ b/custom_components/meraki_ha/types.py
@@ -47,6 +47,8 @@ class MerakiDevice:
     door_open: bool | None = None
     water_present: bool | None = None
     button_press: dict[str, Any] | None = None
+    frequency: float | None = None
+    energy: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""

--- a/tests/core/parsers/test_mt40_data_parsing.py
+++ b/tests/core/parsers/test_mt40_data_parsing.py
@@ -1,0 +1,84 @@
+"""Tests for MT40 sensor data parsing."""
+
+from custom_components.meraki_ha.core.parsers.sensors import parse_sensor_data
+from custom_components.meraki_ha.types import MerakiDevice
+
+
+def test_parse_mt40_sensor_data_camel_case():
+    """Test parsing MT40 sensor data with CamelCase keys."""
+    device = MerakiDevice(serial="mt40-test", model="MT40")
+    devices = [device]
+
+    sensor_readings = [
+        {
+            "serial": "mt40-test",
+            "readings": [
+                {"metric": "powerFactor", "powerFactor": {"percentage": 95.5}},
+                {"metric": "frequency", "frequency": {"level": 50.1}},
+                {"metric": "energyUsage", "energyUsage": 1234.5},
+            ],
+        }
+    ]
+
+    parse_sensor_data(devices, sensor_readings, [])
+
+    assert device.power_factor == 95.5
+    assert device.frequency == 50.1
+    assert device.energy == 1234.5
+
+
+def test_parse_mt40_sensor_data_nested_energy():
+    """Test parsing MT40 sensor data with nested energyUsage."""
+    device = MerakiDevice(serial="mt40-test", model="MT40")
+    devices = [device]
+
+    sensor_readings = [
+        {
+            "serial": "mt40-test",
+            "readings": [
+                {"metric": "energy", "energy": {"energyUsage": 5678.9}},
+            ],
+        }
+    ]
+
+    parse_sensor_data(devices, sensor_readings, [])
+
+    assert device.energy == 5678.9
+
+
+def test_parse_mt40_sensor_data_apparent_power():
+    """Test parsing MT40 sensor data with apparentPower."""
+    device = MerakiDevice(serial="mt40-test", model="MT40")
+    devices = [device]
+
+    sensor_readings = [
+        {
+            "serial": "mt40-test",
+            "readings": [
+                {"metric": "energy", "energy": {"apparentPower": 999.9}},
+            ],
+        }
+    ]
+
+    parse_sensor_data(devices, sensor_readings, [])
+
+    assert device.energy == 999.9
+
+
+def test_parse_mt40_sensor_data_snake_case_fallback():
+    """Test parsing MT40 sensor data with snake_case keys (existing support)."""
+    device = MerakiDevice(serial="mt40-test", model="MT40")
+    devices = [device]
+
+    sensor_readings = [
+        {
+            "serial": "mt40-test",
+            "readings": [
+                {"metric": "power_factor", "power_factor": {"factor": 0.98}},
+            ],
+        }
+    ]
+
+    parse_sensor_data(devices, sensor_readings, [])
+
+    assert device.power_factor == 0.98


### PR DESCRIPTION
The MT40 was showing "Unavailable" for Energy, Frequency, and Power Factor due to a key mismatch between the API response and the parser. This PR updates the parser to handle both snake_case and CamelCase keys often sent by Meraki, maps these values to the MerakiDevice attributes, and adds a fallback mechanism in the MT sensor base class to ensure these values are correctly displayed.

Fixes #1682

---
*PR created automatically by Jules for task [3302074055198170460](https://jules.google.com/task/3302074055198170460) started by @brewmarsh*