### PR TITLE
Fix Sensor API Crash (Remove Invalid 'energy' Metric)

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/sensor.py
+++ b/custom_components/meraki_ha/core/api/endpoints/sensor.py
@@ -102,7 +102,6 @@ class SensorEndpoints:
             "current",
             "door",
             "downstreamPower",
-            "energyUsage",
             "frequency",
             "humidity",
             "noise",


### PR DESCRIPTION
Removed the invalid 'energyUsage' metric from the `getOrganizationSensorReadingsLatest` API call in `custom_components/meraki_ha/core/api/endpoints/sensor.py`. This resolves a 400 Bad Request error that was causing the sensor data fetch to fail. Other valid metrics like `realPower`, `apparentPower`, `powerFactor`, `voltage`, `current`, and `frequency` are preserved. Verified with unit tests, ruff, and mypy.

Fixes #1694

---
*PR created automatically by Jules for task [17168747915131661278](https://jules.google.com/task/17168747915131661278) started by @brewmarsh*