### PR TITLE
chore: fix linting error in test_data_fetch_manager_features.py

### DIFF
--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -9,7 +9,6 @@ import pytest
 from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
     DataFetchManager,
 )
-from custom_components.meraki_ha.types import MerakiNetwork
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Ruff identified and fixed an unused import (`MerakiNetwork`) and a missing newline at the end of the file in `tests/core/test_data_fetch_manager_features.py`. This commit applies the fix to ensure the codebase complies with linting standards.

Verified by running the specific test:
`export PYTHONPATH=$PYTHONPATH:. && python -m pytest tests/core/test_data_fetch_manager_features.py`

---
*PR created automatically by Jules for task [7338296745792600742](https://jules.google.com/task/7338296745792600742) started by @brewmarsh*