### PR TITLE
Add explicit type signatures for 90% Type Safety Index

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/camera.py
+++ b/custom_components/meraki_ha/core/api/endpoints/camera.py
@@ -75,7 +75,7 @@ class CameraEndpoints:
 
     @handle_meraki_errors
     async def update_camera_video_settings(
-        self, serial: str, **kwargs
+        self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Update video settings for a specific camera."""
         result = await self._api_client.run_sync(
@@ -91,7 +91,7 @@ class CameraEndpoints:
 
     @handle_meraki_errors
     async def update_camera_sense_settings(
-        self, serial: str, **kwargs
+        self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Update sense settings for a specific camera."""
         result = await self._api_client.run_sync(
@@ -140,7 +140,7 @@ class CameraEndpoints:
 
     @handle_meraki_errors
     async def generate_device_camera_snapshot(
-        self, serial: str, **kwargs
+        self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Generate a snapshot of what the camera sees."""
         snapshot = await self._api_client.run_sync(

--- a/custom_components/meraki_ha/core/api/endpoints/devices.py
+++ b/custom_components/meraki_ha/core/api/endpoints/devices.py
@@ -80,7 +80,7 @@ class DevicesEndpoints:
         return validated
 
     @handle_meraki_errors
-    async def update_device(self, serial: str, **kwargs) -> dict[str, Any]:
+    async def update_device(self, serial: str, **kwargs: Any) -> dict[str, Any]:
         """
         Update a device.
 

--- a/custom_components/meraki_ha/core/coordinator_helpers/service_setup.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/service_setup.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 
 from custom_components.meraki_ha.const import DOMAIN
@@ -50,19 +50,19 @@ async def async_setup_services(
 ) -> None:
     """Set up the services for the Meraki integration."""
 
-    async def _async_reboot_device(call) -> None:
+    async def _async_reboot_device(call: ServiceCall) -> None:
         """Reboot a device."""
         if device_control_service:
             await device_control_service.async_reboot(call.data["serial"])
 
-    async def _async_cycle_port(call) -> None:
+    async def _async_cycle_port(call: ServiceCall) -> None:
         """Cycle a switch port."""
         if switch_port_service:
             await switch_port_service.async_cycle_ports(
                 call.data["serial"], [call.data["port_id"]]
             )
 
-    async def _async_generate_snapshot(call) -> None:
+    async def _async_generate_snapshot(call: ServiceCall) -> None:
         """Generate a camera snapshot."""
         if camera_service and (serial := call.data.get("serial")):
             await camera_service.generate_snapshot(serial)

--- a/custom_components/meraki_ha/platforms/sensor/device/uplink_status.py
+++ b/custom_components/meraki_ha/platforms/sensor/device/uplink_status.py
@@ -6,10 +6,15 @@ sensor entity that displays the status of the primary uplink for a Meraki
 MX security appliance.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ....core.entities.device import MerakiDeviceEntity
+
+if TYPE_CHECKING:
+    from ....coordinator import MerakiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +30,7 @@ class MerakiUplinkStatusSensor(MerakiDeviceEntity):
 
     def __init__(
         self,
-        coordinator,
+        coordinator: MerakiDataUpdateCoordinator,
         device_serial: str,
     ) -> None:
         """Initialize the Meraki MX Appliance Uplink Status sensor."""

--- a/custom_components/meraki_ha/sensor/device/radio_settings.py
+++ b/custom_components/meraki_ha/sensor/device/radio_settings.py
@@ -1,5 +1,9 @@
 """Placeholder for the Meraki Radio Settings Sensor."""
 
+from __future__ import annotations
+
+from typing import Any
+
 
 class MerakiRadioSettingsSensor:
     """
@@ -9,6 +13,6 @@ class MerakiRadioSettingsSensor:
     deleted file that is still referenced in the sensor registry.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the placeholder."""
         pass

--- a/custom_components/meraki_ha/sensor/network/ssid_details.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_details.py
@@ -73,7 +73,7 @@ class MerakiSSIDTotalUploadLimitSensor(MerakiSSIDDetailSensor):
     _attr_icon = "mdi:upload-network"
     _attr_native_unit_of_measurement = UnitOfDataRate.KILOBITS_PER_SECOND
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the sensor."""
         super().__init__(*args, **kwargs)
         self._attr_unique_id = (
@@ -89,7 +89,7 @@ class MerakiSSIDTotalDownloadLimitSensor(MerakiSSIDDetailSensor):
     _attr_icon = "mdi:download-network"
     _attr_native_unit_of_measurement = UnitOfDataRate.KILOBITS_PER_SECOND
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the sensor."""
         super().__init__(*args, **kwargs)
         self._attr_unique_id = (
@@ -104,7 +104,7 @@ class MerakiSSIDMandatoryDhcpSensor(MerakiSSIDDetailSensor):
 
     _attr_icon = "mdi:ip-network"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the sensor."""
         super().__init__(*args, **kwargs)
         self._attr_unique_id = (
@@ -122,7 +122,7 @@ class MerakiSSIDMinBitrate24GhzSensor(MerakiSSIDDetailSensor):
     _attr_icon = "mdi:speedometer-slow"
     _attr_native_unit_of_measurement = UnitOfDataRate.MEGABITS_PER_SECOND
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the sensor."""
         super().__init__(*args, **kwargs)
         self._attr_unique_id = (
@@ -143,7 +143,7 @@ class MerakiSSIDMinBitrate5GhzSensor(MerakiSSIDDetailSensor):
     _attr_icon = "mdi:speedometer"
     _attr_native_unit_of_measurement = UnitOfDataRate.MEGABITS_PER_SECOND
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the sensor."""
         super().__init__(*args, **kwargs)
         self._attr_unique_id = (

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -31,7 +33,7 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         self._attr_native_value = 0
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {"vlans": self._vlan_list}
 

--- a/custom_components/meraki_ha/switch/adult_content_filtering.py
+++ b/custom_components/meraki_ha/switch/adult_content_filtering.py
@@ -1,11 +1,14 @@
 """Switch entity for controlling Meraki Adult Content Filtering on an SSID."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..entity import MerakiEntity
@@ -43,7 +46,7 @@ class MerakiAdultContentFilteringSwitch(MerakiEntity, SwitchEntity):
         )
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
         return resolve_device_info(self._ssid, self._config_entry)
 

--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -9,7 +9,6 @@ import pytest
 from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
     DataFetchManager,
 )
-from custom_components.meraki_ha.types import MerakiNetwork
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This submission adds explicit type signatures to various functions and properties across the `meraki_ha` integration. These changes ensure that the integration meets the 90% Type Safety Index requirement for the v2.3.0 milestone.

Files modified:
- `custom_components/meraki_ha/sensor/device/radio_settings.py`
- `custom_components/meraki_ha/sensor/network/ssid_details.py`
- `custom_components/meraki_ha/sensor/network/vlans_list.py`
- `custom_components/meraki_ha/switch/adult_content_filtering.py`
- `custom_components/meraki_ha/core/api/endpoints/devices.py`
- `custom_components/meraki_ha/core/api/endpoints/camera.py`
- `custom_components/meraki_ha/core/coordinator_helpers/service_setup.py`
- `custom_components/meraki_ha/platforms/sensor/device/uplink_status.py`

Verification:
- Ran `mypy custom_components/meraki_ha --disallow-untyped-defs --disallow-incomplete-defs` and it reported success for all 189 source files.
- Ran `./run_checks.sh` and all tests, linting, and security checks passed.
- Verified against `AGENTS.md` rules.

Fixes #1690

---
*PR created automatically by Jules for task [13880997367408118984](https://jules.google.com/task/13880997367408118984) started by @brewmarsh*