### PR TITLE
Implement Retry Logic and URL Normalization in Smoke Test

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -82,16 +82,31 @@ jobs:
           HASS_TOKEN: ${{ secrets.HA_STAGING_TOKEN }}
         run: |
           echo "Scanning logs for Meraki errors via API..."
-          # Allow time for startup noise to settle
-          sleep 10
-          # 1. Fetch the log using the API (Requires the Bearer Token used in previous steps)
-          # Ensure HASS_SERVER and HASS_TOKEN are available in this step's 'env'
-          LOG_CONTENT=$(curl -s -f -H "Authorization: Bearer $HASS_TOKEN" "$HASS_SERVER/api/error_log")
-          # 2. Check if curl failed (e.g. 401 Unauthorized or Connection Refused)
-          if [ $? -ne 0 ]; then
-            echo "::error::Failed to retrieve logs from Home Assistant API."
-            exit 1
-          fi
+
+          # 1. Normalize HASS_SERVER (remove trailing slash)
+          CLEAN_SERVER=$(echo "${HASS_SERVER}" | sed 's:/*$::')
+
+          # 2. Retry loop (Wait up to 60s for API to be ready)
+          for i in {1..6}; do
+            echo "Fetching logs (Attempt $i/6)..."
+            LOG_CONTENT=$(curl -s -f -H "Authorization: Bearer ${HASS_TOKEN}" "$CLEAN_SERVER/api/error_log")
+            if [ $? -eq 0 ]; then
+              break
+            fi
+
+            if [ $i -eq 6 ]; then
+              echo "::error::API timeout or persistent failure after 60s."
+              # Diagnostic check for 401/404
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${HASS_TOKEN}" "$CLEAN_SERVER/api/error_log")
+              echo "Home Assistant API returned status: $HTTP_STATUS"
+              if [ "$HTTP_STATUS" -ne 200 ]; then
+                 echo "::error::Received $HTTP_STATUS from API. Check token permissions and URL."
+              fi
+              exit 1
+            fi
+            sleep 10
+          done
+
           # 3. Grep the content
           if echo "$LOG_CONTENT" | grep -i "custom_components.meraki_ha"; then
             echo "::error::CRITICAL: Found Meraki errors in the log!"

--- a/check_import.py
+++ b/check_import.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 
 # Add the parent directory of custom_components to sys.path
 sys.path.append(os.getcwd())


### PR DESCRIPTION
This PR improves the reliability and observability of the smoke test log-fetching step in the CI/CD pipeline.

Key changes:
1.  **URL Normalization:** Strips trailing slashes from `HASS_SERVER` to prevent invalid double-slash URLs (e.g., `http://server//api/error_log`).
2.  **Retry Mechanism:** Implements a 60-second retry loop (6 attempts, 10s sleep) to wait for Home Assistant's API to become ready during the staging startup phase.
3.  **Enhanced Diagnostics:** If the retry loop fails, a secondary diagnostic `curl` call captures the exact HTTP status code (e.g., 401 Unauthorized, 404 Not Found) and prints it to the GitHub Action logs, helping differentiate between credential issues and incorrect paths.
4.  **Linting Fix:** Includes a minor, non-functional change to `check_import.py` where imports were reordered alphabetically by the `ruff` linter during local verification.

These changes eliminate transient 404/503 errors and provide clearer feedback when failures occur.

Fixes #1710

---
*PR created automatically by Jules for task [165022271224799003](https://jules.google.com/task/165022271224799003) started by @brewmarsh*