### PR TITLE
Refactor: Resolve circular dependencies in Meraki API Client

### DIFF
--- a/check_import.py
+++ b/check_import.py
@@ -1,11 +1,14 @@
-import sys
 import os
+import sys
 
 # Add the parent directory of custom_components to sys.path
 sys.path.append(os.getcwd())
 
 try:
-    from custom_components.meraki_ha.core.api.client import MerakiAPIClient
+    from custom_components.meraki_ha.core.api.client import (
+        MerakiAPIClient,  # noqa: F401
+    )
+
     print("Successfully imported MerakiAPIClient")
 except ImportError as e:
     print(f"ImportError: {e}")

--- a/custom_components/meraki_ha/core/api/endpoints/appliance.py
+++ b/custom_components/meraki_ha/core/api/endpoints/appliance.py
@@ -15,7 +15,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 from ..cache import async_timed_cache
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 class ApplianceEndpoints:
     """Appliance-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient, hass: HomeAssistant) -> None:
+    def __init__(
+        self, api_client: MerakiApiClientProtocol, hass: HomeAssistant
+    ) -> None:
         """
         Initialize the endpoint.
 

--- a/custom_components/meraki_ha/core/api/endpoints/camera.py
+++ b/custom_components/meraki_ha/core/api/endpoints/camera.py
@@ -13,7 +13,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 from ..cache import async_timed_cache
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class CameraEndpoints:
     """Camera-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient) -> None:
+    def __init__(self, api_client: MerakiApiClientProtocol) -> None:
         """
         Initialize the endpoint.
 

--- a/custom_components/meraki_ha/core/api/endpoints/devices.py
+++ b/custom_components/meraki_ha/core/api/endpoints/devices.py
@@ -11,7 +11,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 )
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 class DevicesEndpoints:
     """Device-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient) -> None:
+    def __init__(self, api_client: MerakiApiClientProtocol) -> None:
         """
         Initialize the endpoint.
 

--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -13,7 +13,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 from ..cache import async_timed_cache
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class NetworkEndpoints:
     """Network-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient) -> None:
+    def __init__(self, api_client: MerakiApiClientProtocol) -> None:
         """
         Initialize the endpoint.
 

--- a/custom_components/meraki_ha/core/api/endpoints/organization.py
+++ b/custom_components/meraki_ha/core/api/endpoints/organization.py
@@ -13,7 +13,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 from ..cache import async_timed_cache
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class OrganizationEndpoints:
     """Organization-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient) -> None:
+    def __init__(self, api_client: MerakiApiClientProtocol) -> None:
         """
         Initialize the endpoint.
 

--- a/custom_components/meraki_ha/core/api/endpoints/sensor.py
+++ b/custom_components/meraki_ha/core/api/endpoints/sensor.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 class SensorEndpoints:
     """Sensor endpoints for the Meraki API."""
 
-    def __init__(self, client: MerakiAPIClient) -> None:
+    def __init__(self, client: MerakiApiClientProtocol) -> None:
         """
         Initialize the sensor endpoints.
 

--- a/custom_components/meraki_ha/core/api/endpoints/switch.py
+++ b/custom_components/meraki_ha/core/api/endpoints/switch.py
@@ -13,7 +13,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 from ..cache import async_timed_cache
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class SwitchEndpoints:
     """Switch-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient) -> None:
+    def __init__(self, api_client: MerakiApiClientProtocol) -> None:
         """
         Initialize the endpoint.
 

--- a/custom_components/meraki_ha/core/api/endpoints/wireless.py
+++ b/custom_components/meraki_ha/core/api/endpoints/wireless.py
@@ -14,7 +14,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
 from ..cache import async_timed_cache
 
 if TYPE_CHECKING:
-    from ..client import MerakiAPIClient
+    from ..protocol import MerakiApiClientProtocol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class WirelessEndpoints:
     """Wireless-related endpoints."""
 
-    def __init__(self, api_client: MerakiAPIClient) -> None:
+    def __init__(self, api_client: MerakiApiClientProtocol) -> None:
         """Initialize the endpoint."""
         self._api_client = api_client
 

--- a/custom_components/meraki_ha/core/api/protocol.py
+++ b/custom_components/meraki_ha/core/api/protocol.py
@@ -1,0 +1,42 @@
+"""Protocol for Meraki API Client."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol
+
+import meraki
+
+if TYPE_CHECKING:
+    from .endpoints.organization import OrganizationEndpoints
+
+
+class MerakiApiClientProtocol(Protocol):
+    """Protocol defining the interface for the Meraki API Client."""
+
+    @property
+    def dashboard(self) -> meraki.DashboardAPI:
+        """Get the Dashboard API instance."""
+        ...
+
+    @property
+    def organization_id(self) -> str:
+        """Get the organization ID."""
+        ...
+
+    @property
+    def organization(self) -> OrganizationEndpoints:
+        """Get the organization endpoints."""
+        ...
+
+    async def run_sync(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run a synchronous function in a thread pool."""
+        ...
+
+    async def run_with_semaphore(self, coro: Awaitable[Any]) -> Any:
+        """Run an awaitable with the semaphore."""
+        ...


### PR DESCRIPTION
Refactor Meraki API Client and Endpoints to resolve circular dependencies using a Protocol.

- Created `MerakiApiClientProtocol` in `custom_components/meraki_ha/core/api/protocol.py`.
- Updated all endpoint classes to use `MerakiApiClientProtocol` for type hinting `api_client`.
- Updated `check_import.py` to fix unused import lint error.
- Verified with `run_checks.sh` (pytest, ruff, bandit, mypy).

---
*PR created automatically by Jules for task [3613492349143454207](https://jules.google.com/task/3613492349143454207) started by @brewmarsh*