### PR TITLE
Log MT40 Raw Data Payload

### DIFF
--- a/custom_components/meraki_ha/core/parsers/sensors.py
+++ b/custom_components/meraki_ha/core/parsers/sensors.py
@@ -54,6 +54,8 @@ def parse_sensor_data(
             device.readings = device_readings
 
             for reading in device_readings:
+                if reading.get("metric") == "power":
+                    _LOGGER.debug("MT40 Power Reading Payload: %s", reading)
                 metric = reading.get("metric")
                 if metric == "noise":
                     device.ambient_noise = (


### PR DESCRIPTION
This PR adds a debug log statement to `custom_components/meraki_ha/core/parsers/sensors.py` to capture the raw JSON payload of Meraki sensor readings when the metric is "power". This is intended to assist in diagnosing missing sensors for MT40 devices by revealing the exact keys provided by the API.

Key changes:
- Inserted `_LOGGER.debug` call in the `parse_sensor_data` reading loop.
- Verified that the change doesn't break existing parsing logic.
- Ensured compliance with Home Assistant Sentence Case and integration standards.

Fixes #1684

---
*PR created automatically by Jules for task [2553950409944955351](https://jules.google.com/task/2553950409944955351) started by @brewmarsh*