### PR TITLE
fix(ci): resolve unused import in check_import.py

### DIFF
--- a/check_import.py
+++ b/check_import.py
@@ -6,7 +6,8 @@ sys.path.append(os.getcwd())
 
 try:
     from custom_components.meraki_ha.core.api.client import MerakiAPIClient
-    print("Successfully imported MerakiAPIClient")
+
+    print(f"Successfully imported {MerakiAPIClient.__name__}")
 except ImportError as e:
     print(f"ImportError: {e}")
 except Exception as e:


### PR DESCRIPTION
Fixes a linting error in `check_import.py` where `MerakiAPIClient` was imported but not used, causing `ruff` to fail and blocking the CI pipeline. By using the class name in the output, the import is marked as used, allowing the full verification suite to run successfully.

---
*PR created automatically by Jules for task [4553698957667833508](https://jules.google.com/task/4553698957667833508) started by @brewmarsh*