### PR TITLE
Silence Traffic Analysis and VLAN 400 Errors

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -42,6 +42,8 @@ class MerakiAPIClient:
     the underlying API session and asynchronous execution.
     """
 
+    _disabled_features: set[str] = set()
+    _enable_vpn_management: bool = False
     appliance: ApplianceEndpoints
     camera: CameraEndpoints
     devices: DevicesEndpoints
@@ -210,6 +212,41 @@ class MerakiAPIClient:
         """
         async with self._semaphore:
             return await coro
+
+    def mark_feature_disabled(
+        self, feature: str, network_id: str | None = None
+    ) -> None:
+        """
+        Mark a feature as disabled for the current session.
+
+        Args:
+            feature: The feature to disable (e.g., "traffic", "vlans").
+            network_id: The ID of the network.
+
+        """
+        key = feature
+        if network_id:
+            key = f"{feature}_{network_id}"
+        self._disabled_features.add(key)
+        _LOGGER.debug("Feature %s marked as disabled for the session", key)
+
+    def is_feature_disabled(self, feature: str, network_id: str | None = None) -> bool:
+        """
+        Check if a feature is disabled for the current session.
+
+        Args:
+            feature: The feature to check.
+            network_id: The ID of the network.
+
+        Returns
+        -------
+            True if disabled, False otherwise.
+
+        """
+        key = feature
+        if network_id:
+            key = f"{feature}_{network_id}"
+        return key in self._disabled_features
 
     @property
     def organization_id(self) -> str:

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -56,7 +56,7 @@ class DataFetchManager:
         self.client_fetcher = ClientFetcher(self.client)
 
         # Set of disabled features to prevent repetitive API calls
-        self._disabled_features: set[str] = set()
+        self._disabled_features = client._disabled_features
 
     async def _async_fetch_initial_data(self) -> dict[str, Any]:
         """

--- a/custom_components/meraki_ha/core/utils/api_utils.py
+++ b/custom_components/meraki_ha/core/utils/api_utils.py
@@ -24,6 +24,9 @@ T = TypeVar("T")
 
 _LOGGER = logging.getLogger(__name__)
 
+# Set of error messages that have already been logged as INFO to avoid flooding
+_LOGGED_ERRORS: set[str] = set()
+
 
 def handle_meraki_errors(
     func: Callable[..., Awaitable[T]],
@@ -55,13 +58,37 @@ def handle_meraki_errors(
             if return_type is list or getattr(return_type, "__origin__", None) is list:
                 return cast(T, [])
             return cast(T, {})
-        except APIError as err:
+        except (APIError, MerakiInformationalError) as err:
             error_msg = str(err)
-            if getattr(err, "status", None) == 400 and (
-                "Traffic Analysis with Hostname Visibility must be enabled" in error_msg
-                or "VLANs are not enabled" in error_msg
-            ):
-                _LOGGER.info("Meraki feature disabled (skipping): %s", error_msg)
+            is_traffic_analysis = (
+                "Traffic Analysis with Hostname Visibility" in error_msg
+            )
+            is_vlan_disabled = "VLANs are not enabled" in error_msg
+
+            if (
+                isinstance(err, APIError) and getattr(err, "status", None) == 400
+            ) and (is_traffic_analysis or is_vlan_disabled):
+                if error_msg not in _LOGGED_ERRORS:
+                    _LOGGER.info("Meraki feature disabled (skipping): %s", error_msg)
+                    _LOGGED_ERRORS.add(error_msg)
+
+                # Attempt to mark the feature as disabled in the client session
+                # This prevents subsequent API calls for this feature
+                instance = args[0] if args else None
+                client = getattr(instance, "_api_client", None)
+                if client:
+                    # Extract network_id from arguments or keyword arguments
+                    network_id = kwargs.get("networkId") or kwargs.get("network_id")
+                    if not network_id and len(args) > 1:
+                        # network_id is typically the first argument after 'self'
+                        network_id = args[1]
+
+                    if network_id and isinstance(network_id, str):
+                        feature = "traffic" if is_traffic_analysis else "vlans"
+                        if hasattr(client, "mark_feature_disabled"):
+                            client.mark_feature_disabled(feature, network_id)
+
+                # Return a type-safe empty value instead of raising an error
                 sig = inspect.signature(func)
                 return_type = sig.return_annotation
                 if (
@@ -70,8 +97,14 @@ def handle_meraki_errors(
                 ):
                     return cast(T, [])
                 return cast(T, {})
-            if _is_informational_error(err):
+
+            if isinstance(err, APIError) and _is_informational_error(err):
                 raise MerakiInformationalError(f"Informational error: {err}") from err
+
+            # Re-raise MerakiInformationalError if it was already raised
+            # (e.g. by run_sync)
+            if isinstance(err, MerakiInformationalError):
+                raise err
 
             _LOGGER.error("Meraki API error: %s", err)
             if _is_auth_error(err):

--- a/tests/core/coordinator_helpers/test_data_fetcher.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher.py
@@ -55,6 +55,7 @@ def mock_client():
     client.sensor.get_organization_sensor_readings_latest = AsyncMock(return_value=[])
 
     client.dashboard = MagicMock()
+    client._disabled_features = set()
 
     # Mock run_with_semaphore to execute the coroutine
     async def run_with_semaphore_side_effect(coro):

--- a/tests/core/utils/test_api_silencing.py
+++ b/tests/core/utils/test_api_silencing.py
@@ -1,0 +1,90 @@
+"""Tests for API silencing and feature disabling."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from meraki.exceptions import APIError
+
+from custom_components.meraki_ha.core.api.client import MerakiAPIClient
+from custom_components.meraki_ha.core.utils.api_utils import handle_meraki_errors
+
+
+class MockResponse:
+    """Mock response for APIError."""
+
+    def __init__(self, status_code, reason, json_data):
+        self.status_code = status_code
+        self.reason = reason
+        self._json_data = json_data
+    def json(self):
+        """Return the JSON data."""
+        return self._json_data
+
+class DummyEndpoint:
+    """Dummy endpoint class for testing handle_meraki_errors."""
+
+    def __init__(self, client):
+        self._api_client = client
+
+    @handle_meraki_errors
+    async def get_traffic(self, network_id: str) -> list:
+        """Mock traffic analysis call."""
+        raise APIError(
+            {"tags": ["test"], "operation": "test"},
+            MockResponse(
+                400,
+                "Bad Request",
+                {
+                    "errors": [
+                        "Traffic Analysis with Hostname Visibility must be enabled"
+                    ]
+                },
+            ),
+        )
+
+    @handle_meraki_errors
+    async def get_vlans(self, network_id: str) -> list:
+        """Mock VLANs call."""
+        raise APIError(
+            {"tags": ["test"], "operation": "test"},
+            MockResponse(
+                400,
+                "Bad Request",
+                {"errors": ["VLANs are not enabled"]},
+            ),
+        )
+
+@pytest.mark.asyncio
+async def test_api_silencing_traffic():
+    """Test that traffic analysis 400 error is silenced and feature disabled."""
+    client = MagicMock(spec=MerakiAPIClient)
+    # Mock the behavior of mark_feature_disabled
+    client._disabled_features = set()
+    def mark_disabled(feature, network_id):
+        client._disabled_features.add(f"{feature}_{network_id}")
+    client.mark_feature_disabled.side_effect = mark_disabled
+
+    endpoint = DummyEndpoint(client)
+
+    result = await endpoint.get_traffic("N_123")
+
+    assert result == []
+    client.mark_feature_disabled.assert_called_once_with("traffic", "N_123")
+    assert "traffic_N_123" in client._disabled_features
+
+@pytest.mark.asyncio
+async def test_api_silencing_vlans():
+    """Test that VLANs 400 error is silenced and feature disabled."""
+    client = MagicMock(spec=MerakiAPIClient)
+    client._disabled_features = set()
+    def mark_disabled(feature, network_id):
+        client._disabled_features.add(f"{feature}_{network_id}")
+    client.mark_feature_disabled.side_effect = mark_disabled
+
+    endpoint = DummyEndpoint(client)
+
+    result = await endpoint.get_vlans("N_123")
+
+    assert result == []
+    client.mark_feature_disabled.assert_called_once_with("vlans", "N_123")
+    assert "vlans_N_123" in client._disabled_features

--- a/tests/test_e2e_ipsk.py
+++ b/tests/test_e2e_ipsk.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 def mock_meraki_client(hass):
     """Create a mock Meraki API client."""
     client = MagicMock(spec=MerakiAPIClient)
+    client._disabled_features = set()
     client.wireless = MagicMock()
     client.wireless.create_identity_psk = AsyncMock(
         return_value={"id": "mock_ipsk_id", "name": "Guest User"}


### PR DESCRIPTION
This PR addresses the issue where the logs were being flooded with ERROR level messages for features not enabled on the Meraki side (Traffic Analysis and VLANs).

Key changes:
1.  **API Error Handling**: The `handle_meraki_errors` decorator in `api_utils.py` now specifically filters for 400 Bad Request errors containing the targeted messages. These are logged once as INFO and the function returns an empty value (`[]` or `{}`).
2.  **Session Disabling**: When these errors occur, the feature is marked as disabled in the `MerakiAPIClient`'s `_disabled_features` set.
3.  **Coordinator Synchronization**: The `DataFetchManager` now shares the `_disabled_features` set with the API client, ensuring that future poll intervals skip the disabled endpoints.
4.  **Testing**: Added a new test file `tests/core/utils/test_api_silencing.py` and updated existing mocks to verify the fix and prevent regressions.

Verified with `./run_checks.sh` and custom test cases.

Fixes #1708

---
*PR created automatically by Jules for task [16905508023323046730](https://jules.google.com/task/16905508023323046730) started by @brewmarsh*