### PR TITLE
Refactor `types.py` into Domain Models

### DIFF
--- a/check_import.py
+++ b/check_import.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import sys
-import logging
 
 # Configure logging to output to stdout
 logging.basicConfig(

--- a/custom_components/meraki_ha/binary_sensor/device/camera_motion.py
+++ b/custom_components/meraki_ha/binary_sensor/device/camera_motion.py
@@ -17,8 +17,8 @@ from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
     from ...services.camera_service import CameraService
-    from ...types import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
+++ b/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
@@ -14,8 +14,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator as MerakiDataCoordinator
+from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
-from ...types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/binary_sensor/network.py
+++ b/custom_components/meraki_ha/binary_sensor/network.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from ..const import DOMAIN
 from ..coordinator import MerakiDataUpdateCoordinator
-from ..types import MerakiNetwork
+from ..core.models.network import MerakiNetwork
 
 
 async def async_setup_entry(

--- a/custom_components/meraki_ha/binary_sensor/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/switch_port.py
@@ -17,7 +17,7 @@ from ..coordinator import MerakiDataUpdateCoordinator
 from ..helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
-    from ..types import MerakiAppliancePort, MerakiDevice
+    from ..core.models.device import MerakiAppliancePort, MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/button/device/camera_snapshot.py
+++ b/custom_components/meraki_ha/button/device/camera_snapshot.py
@@ -11,8 +11,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.models.device import MerakiDevice
 from ...helpers.device_info_helpers import resolve_device_info
-from ...types import MerakiDevice
 
 if TYPE_CHECKING:
     from ...services.camera_service import CameraService

--- a/custom_components/meraki_ha/button/device/mt15_refresh_data.py
+++ b/custom_components/meraki_ha/button/device/mt15_refresh_data.py
@@ -11,8 +11,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.api.client import MerakiAPIClient
+from ...core.models.device import MerakiDevice
 from ...helpers.device_info_helpers import resolve_device_info
-from ...types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/button/device/switch_port_cycle.py
+++ b/custom_components/meraki_ha/button/device/switch_port_cycle.py
@@ -15,8 +15,8 @@ from homeassistant.helpers.entity import DeviceInfo
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
     from ...services.switch_port_service import SwitchPortService
-    from ...types import MerakiDevice
 
 
 class MerakiSwitchPortCycleButton(ButtonEntity):

--- a/custom_components/meraki_ha/button/reboot.py
+++ b/custom_components/meraki_ha/button/reboot.py
@@ -17,8 +17,8 @@ from homeassistant.helpers.entity import DeviceInfo
 from ..helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
+    from ..core.models.device import MerakiDevice
     from ..services.device_control_service import DeviceControlService
-    from ..types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
     from .coordinator import MerakiDataUpdateCoordinator
+    from .core.models.device import MerakiDevice
     from .services.camera_service import CameraService
-    from .types import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,7 +94,7 @@ class MerakiCamera(CoordinatorEntity, Camera):
     @property
     def device_data(self) -> MerakiDevice:
         """Return the device data from the coordinator."""
-        from .types import MerakiDevice
+        from .core.models.device import MerakiDevice
 
         return self.coordinator.get_device(self._device_serial) or MerakiDevice()
 

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -29,7 +29,8 @@ from .core.api.client import MerakiAPIClient as ApiClient
 from .core.coordinator_helpers.data_fetcher import DataFetchManager
 from .core.helpers import filter_ignored_networks, process_coordinator_data
 from .core.managers import AvailabilityTracker, PendingUpdateManager
-from .types import MerakiDevice, MerakiNetwork
+from .core.models.device import MerakiDevice
+from .core.models.network import MerakiNetwork
 
 if TYPE_CHECKING:
     from custom_components.meraki_ha.services.camera_service import CameraService

--- a/custom_components/meraki_ha/core/coordinator_helpers/client_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/client_fetcher.py
@@ -7,7 +7,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice, MerakiNetwork
+    from ...core.models.device import MerakiDevice
+    from ...core.models.network import MerakiNetwork
     from ..api.client import MerakiAPIClient
 
 

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -16,9 +16,10 @@ from ...core.errors import (
     MerakiVlanError,
     MerakiVlansDisabledError,
 )
+from ...core.models.device import MerakiAppliancePort, MerakiDevice
+from ...core.models.network import MerakiNetwork
 from ...core.parsers.appliance import parse_appliance_data
 from ...core.parsers.sensors import parse_sensor_data
-from ...types import MerakiAppliancePort, MerakiDevice, MerakiNetwork
 from .client_fetcher import ClientFetcher
 
 if TYPE_CHECKING:

--- a/custom_components/meraki_ha/core/entities/meraki_firewall_rule_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_firewall_rule_entity.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import DeviceInfo
 
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...types import MerakiFirewallRule
+from ...core.models.network import MerakiFirewallRule
 from . import BaseMerakiEntity
 
 

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...types import MerakiNetwork
+from ...core.models.network import MerakiNetwork
 from . import BaseMerakiEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/core/helpers.py
+++ b/custom_components/meraki_ha/core/helpers.py
@@ -10,7 +10,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from ..const import DOMAIN
-from ..types import MerakiDevice, MerakiNetwork
+from ..core.models.device import MerakiDevice
+from ..core.models.network import MerakiNetwork
 
 if TYPE_CHECKING:
     from homeassistant.helpers.device_registry import DeviceRegistry

--- a/custom_components/meraki_ha/core/models/__init__.py
+++ b/custom_components/meraki_ha/core/models/__init__.py
@@ -1,9 +1,7 @@
-"""Type definitions for Meraki API data structures (re-exports)."""
+"""Models package for Meraki API data structures."""
 
-from __future__ import annotations
-
-from .core.models.device import MerakiAppliancePort, MerakiDevice
-from .core.models.network import (
+from .device import MerakiAppliancePort, MerakiDevice
+from .network import (
     MerakiFirewallRule,
     MerakiNetwork,
     MerakiTrafficShaping,

--- a/custom_components/meraki_ha/core/models/device.py
+++ b/custom_components/meraki_ha/core/models/device.py
@@ -1,0 +1,167 @@
+"""Device models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class MerakiAppliancePort:
+    """Represents a Meraki Appliance Port."""
+
+    number: int | None = None
+    enabled: bool = False
+    type: str | None = None
+    drop_untagged_traffic: bool = False
+    vlan: int | None = None
+    access_policy: str | None = None
+    allowed_vlans: str | None = None
+    status: str | None = None
+    speed: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "number": self.number,
+            "enabled": self.enabled,
+            "type": self.type,
+            "dropUntaggedTraffic": self.drop_untagged_traffic,
+            "vlan": self.vlan,
+            "accessPolicy": self.access_policy,
+            "allowedVlans": self.allowed_vlans,
+            "status": self.status,
+            "speed": self.speed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiAppliancePort:
+        """Create a MerakiAppliancePort instance from a dictionary."""
+        return cls(
+            number=data.get("number"),
+            enabled=data.get("enabled", False),
+            type=data.get("type"),
+            drop_untagged_traffic=data.get("dropUntaggedTraffic", False),
+            vlan=data.get("vlan"),
+            access_policy=data.get("accessPolicy"),
+            allowed_vlans=data.get("allowedVlans"),
+            status=data.get("status"),
+            speed=data.get("speed"),
+        )
+
+
+@dataclass
+class MerakiDevice:
+    """Dataclass for a Meraki device."""
+
+    serial: str | None = None
+    name: str | None = None
+    model: str | None = None
+    mac: str | None = None
+    lan_ip: str | None = None
+    wan1_ip: str | None = None
+    wan2_ip: str | None = None
+    public_ip: str | None = None
+    network_id: str | None = None
+    appliance_uplink_statuses: list[dict[str, Any]] = field(default_factory=list)
+    status: str | None = None
+    firmware: str | None = None
+    product_type: str | None = None
+    tags: list[str] = field(default_factory=list)
+    address: str | None = None
+    notes: str | None = None
+    url: str | None = None
+    firmware_upgrades: dict[str, Any] | None = None
+    readings: list[dict[str, Any]] = field(default_factory=list)
+    video_settings: dict[str, Any] | None = None
+    rtsp_url: str | None = None
+    sense_settings: dict[str, Any] | None = None
+    analytics: list[dict[str, Any]] = field(default_factory=list)
+    ports_statuses: list[dict[str, Any]] = field(default_factory=list)
+    appliance_ports: list[MerakiAppliancePort] = field(default_factory=list)
+    dynamic_dns: dict[str, Any] | None = None
+    status_messages: list[str] = field(default_factory=list)
+    entity_id: str | None = None
+    ambient_noise: float | None = None
+    pm25: float | None = None
+    real_power: float | None = None
+    power_factor: float | None = None
+    current: float | None = None
+    voltage: float | None = None
+    door_open: bool | None = None
+    water_present: bool | None = None
+    button_press: dict[str, Any] | None = None
+    frequency: float | None = None
+    energy: float | None = None
+    outlet_status: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "serial": self.serial,
+            "name": self.name,
+            "model": self.model,
+            "mac": self.mac,
+            "lanIp": self.lan_ip,
+            "wan1Ip": self.wan1_ip,
+            "wan2Ip": self.wan2_ip,
+            "publicIp": self.public_ip,
+            "networkId": self.network_id,
+            "status": self.status,
+            "firmware": self.firmware,
+            "productType": self.product_type,
+            "tags": self.tags,
+            "address": self.address,
+            "notes": self.notes,
+            "url": self.url,
+            "firmwareUpgrades": self.firmware_upgrades,
+            "readings": self.readings,
+            "videoSettings": self.video_settings,
+            "rtspUrl": self.rtsp_url,
+            "senseSettings": self.sense_settings,
+            "analytics": self.analytics,
+            "portsStatuses": self.ports_statuses,
+            "appliancePorts": [p.to_dict() for p in self.appliance_ports],
+            "dynamicDns": self.dynamic_dns,
+            "statusMessages": self.status_messages,
+            "applianceUplinkStatuses": self.appliance_uplink_statuses,
+            "entity_id": self.entity_id,
+            "outletStatus": self.outlet_status,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiDevice:
+        """Create a MerakiDevice instance from a dictionary."""
+        return cls(
+            serial=data.get("serial"),
+            name=data.get("name"),
+            model=data.get("model"),
+            mac=data.get("mac"),
+            lan_ip=data.get("lanIp"),
+            wan1_ip=data.get("wan1Ip"),
+            wan2_ip=data.get("wan2Ip"),
+            public_ip=data.get("publicIp"),
+            network_id=data.get("networkId"),
+            status=data.get("status"),
+            firmware=data.get("firmware"),
+            product_type=data.get("productType"),
+            tags=data.get("tags", []),
+            address=data.get("address"),
+            notes=data.get("notes"),
+            url=data.get("url"),
+            firmware_upgrades=data.get("firmwareUpgrades"),
+            readings=data.get("readings", []),
+            video_settings=data.get("videoSettings"),
+            rtsp_url=data.get("rtspUrl"),
+            sense_settings=data.get("senseSettings"),
+            analytics=data.get("analytics", []),
+            ports_statuses=data.get("portsStatuses", []),
+            appliance_ports=[
+                MerakiAppliancePort.from_dict(p) for p in data.get("appliancePorts", [])
+            ],
+            dynamic_dns=data.get("dynamicDns"),
+            status_messages=data.get("statusMessages", []),
+            appliance_uplink_statuses=data.get("applianceUplinkStatuses", []),
+            entity_id=data.get("entity_id"),
+            outlet_status=data.get("outletStatus"),
+        )

--- a/custom_components/meraki_ha/core/models/network.py
+++ b/custom_components/meraki_ha/core/models/network.py
@@ -1,0 +1,137 @@
+"""Network models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class MerakiNetwork:
+    """Dataclass for a Meraki network."""
+
+    id: str | None = None
+    name: str | None = None
+    organization_id: str | None = None
+    product_types: list[str] = field(default_factory=list)
+    time_zone: str | None = None
+    tags: list[str] = field(default_factory=list)
+    notes: str | None = None
+    status_messages: list[str] = field(default_factory=list)
+    is_enabled: bool = True
+    ssids: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "organizationId": self.organization_id,
+            "productTypes": self.product_types,
+            "timeZone": self.time_zone,
+            "tags": self.tags,
+            "notes": self.notes,
+            "is_enabled": self.is_enabled,
+            "ssids": self.ssids,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiNetwork:
+        """Create a MerakiNetwork instance from a dictionary."""
+        return cls(
+            id=data.get("id"),
+            name=data.get("name"),
+            organization_id=data.get("organizationId"),
+            product_types=data.get("productTypes", []),
+            time_zone=data.get("timeZone"),
+            tags=data.get("tags", []),
+            notes=data.get("notes"),
+            is_enabled=data.get("is_enabled", True),
+            ssids=data.get("ssids", []),
+        )
+
+
+@dataclass
+class MerakiVlan:
+    """Represents a Meraki VLAN."""
+
+    id: str | None = None
+    name: str | None = None
+    subnet: str | None = None
+    appliance_ip: str | None = None
+    ipv6: dict | None = None
+    dhcp_handling: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiVlan:
+        """Create a MerakiVlan instance from a dictionary."""
+        return cls(
+            id=data.get("id"),
+            name=data.get("name"),
+            subnet=data.get("subnet"),
+            appliance_ip=data.get("applianceIp"),
+            ipv6=data.get("ipv6"),
+            dhcp_handling=data.get("dhcpHandling"),
+        )
+
+
+@dataclass
+class MerakiFirewallRule:
+    """Represents a Meraki L3 Firewall Rule."""
+
+    comment: str | None = None
+    policy: str | None = None
+    protocol: str | None = None
+    dest_port: str | None = None
+    dest_cidr: str | None = None
+    src_port: str | None = None
+    src_cidr: str | None = None
+    syslog_enabled: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiFirewallRule:
+        """Create a MerakiFirewallRule instance from a dictionary."""
+        return cls(
+            comment=data.get("comment"),
+            policy=data.get("policy"),
+            protocol=data.get("protocol"),
+            dest_port=data.get("destPort"),
+            dest_cidr=data.get("destCidr"),
+            src_port=data.get("srcPort"),
+            src_cidr=data.get("srcCidr"),
+            syslog_enabled=data.get("syslogEnabled", False),
+        )
+
+
+@dataclass
+class MerakiTrafficShaping:
+    """Represents Meraki Traffic Shaping settings."""
+
+    enabled: bool = False
+    rules: list = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiTrafficShaping:
+        """Create a MerakiTrafficShaping instance from a dictionary."""
+        return cls(
+            enabled=data.get("enabled", False),
+            rules=data.get("rules", []),
+        )
+
+
+@dataclass
+class MerakiVpn:
+    """Represents Meraki Site-to-Site VPN settings."""
+
+    mode: str | None = None
+    hubs: list = field(default_factory=list)
+    subnets: list = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiVpn:
+        """Create a MerakiVpn instance from a dictionary."""
+        return cls(
+            mode=data.get("mode"),
+            hubs=data.get("hubs", []),
+            subnets=data.get("subnets", []),
+        )

--- a/custom_components/meraki_ha/core/models/sensor.py
+++ b/custom_components/meraki_ha/core/models/sensor.py
@@ -1,0 +1,3 @@
+"""Sensor models for Meraki API data structures."""
+
+from __future__ import annotations

--- a/custom_components/meraki_ha/core/parsers/appliance.py
+++ b/custom_components/meraki_ha/core/parsers/appliance.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ...types import MerakiAppliancePort, MerakiDevice
+from ...core.models.device import MerakiAppliancePort, MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/core/parsers/camera.py
+++ b/custom_components/meraki_ha/core/parsers/camera.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ...types import MerakiDevice
+from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/core/parsers/devices.py
+++ b/custom_components/meraki_ha/core/parsers/devices.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...types import MerakiDevice
+from ...core.models.device import MerakiDevice
 
 
 def parse_device_data(

--- a/custom_components/meraki_ha/core/parsers/network.py
+++ b/custom_components/meraki_ha/core/parsers/network.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ...types import (
+from ...core.models.network import (
     MerakiFirewallRule,
     MerakiNetwork,
     MerakiTrafficShaping,

--- a/custom_components/meraki_ha/core/parsers/sensors.py
+++ b/custom_components/meraki_ha/core/parsers/sensors.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ...types import MerakiDevice
+from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/core/parsers/switch.py
+++ b/custom_components/meraki_ha/core/parsers/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...types import MerakiDevice
+from ...core.models.device import MerakiDevice
 
 
 def parse_switch_data(

--- a/custom_components/meraki_ha/core/parsers/wireless.py
+++ b/custom_components/meraki_ha/core/parsers/wireless.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...types import MerakiNetwork
+from ...core.models.network import MerakiNetwork
 
 
 def parse_wireless_data(

--- a/custom_components/meraki_ha/discovery/handlers/base.py
+++ b/custom_components/meraki_ha/discovery/handlers/base.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ....coordinator import (
         MerakiDataUpdateCoordinator,
     )
-    from ....types import MerakiDevice
+    from ....core.models.device import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/discovery/handlers/gx.py
+++ b/custom_components/meraki_ha/discovery/handlers/gx.py
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity import Entity
 
     from ....coordinator import MerakiDataUpdateCoordinator
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
-    from ....types import MerakiDevice
     from ...services.device_control_service import DeviceControlService
     from ...services.network_control_service import NetworkControlService
 

--- a/custom_components/meraki_ha/discovery/handlers/mr.py
+++ b/custom_components/meraki_ha/discovery/handlers/mr.py
@@ -17,10 +17,10 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity import Entity
 
     from ....coordinator import MerakiDataUpdateCoordinator
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
     from ....services.device_control_service import DeviceControlService
     from ....services.network_control_service import NetworkControlService
-    from ....types import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/discovery/handlers/ms.py
+++ b/custom_components/meraki_ha/discovery/handlers/ms.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity import Entity
 
     from ....coordinator import MerakiDataUpdateCoordinator
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
     from ....services.device_control_service import DeviceControlService
     from ....services.network_control_service import NetworkControlService
-    from ....types import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/discovery/handlers/mt.py
+++ b/custom_components/meraki_ha/discovery/handlers/mt.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
     from ....coordinator import (
         MerakiDataUpdateCoordinator,
     )
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
     from ....services.network_control_service import NetworkControlService
-    from ....types import MerakiDevice
     from ...services.device_control_service import DeviceControlService
 
 

--- a/custom_components/meraki_ha/discovery/handlers/mv.py
+++ b/custom_components/meraki_ha/discovery/handlers/mv.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity import Entity
 
     from ....coordinator import MerakiDataUpdateCoordinator
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
     from ....services.device_control_service import DeviceControlService
     from ....services.network_control_service import NetworkControlService
-    from ....types import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/discovery/handlers/mx.py
+++ b/custom_components/meraki_ha/discovery/handlers/mx.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers.entity import Entity
 
     from ....coordinator import MerakiDataUpdateCoordinator
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
-    from ....types import MerakiDevice
     from ...services.device_control_service import DeviceControlService
     from ...services.network_control_service import NetworkControlService
 

--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from ....coordinator import (
         MerakiDataUpdateCoordinator,
     )
+    from ....core.models.device import MerakiDevice
     from ....services.camera_service import CameraService
-    from ....types import MerakiDevice
     from ...services.device_control_service import DeviceControlService
     from ...services.network_control_service import NetworkControlService
 

--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -18,7 +18,7 @@ from ..const import (
     CONF_ENABLE_NETWORK_SENSORS,
     CONF_ENABLE_SSID_SENSORS,
 )
-from ..types import MerakiDevice
+from ..core.models.device import MerakiDevice
 from .handlers.base import BaseDeviceHandler
 from .handlers.gx import GXHandler
 from .handlers.mr import MRHandler

--- a/custom_components/meraki_ha/event/device/camera_motion.py
+++ b/custom_components/meraki_ha/event/device/camera_motion.py
@@ -17,8 +17,8 @@ from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
     from ...services.camera_service import CameraService
-    from ...types import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/event/device/mt_button.py
+++ b/custom_components/meraki_ha/event/device/mt_button.py
@@ -17,7 +17,7 @@ from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/helpers/device_info_helpers.py
+++ b/custom_components/meraki_ha/helpers/device_info_helpers.py
@@ -8,7 +8,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from ..const import DOMAIN
-from ..types import MerakiDevice, MerakiNetwork
+from ..core.models.device import MerakiDevice
+from ..core.models.network import MerakiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/hubs/network.py
+++ b/custom_components/meraki_ha/hubs/network.py
@@ -11,7 +11,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice, MerakiNetwork
+    from ...core.models.device import MerakiDevice
+    from ...core.models.network import MerakiNetwork
     from ..coordinator import MerakiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
+++ b/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
@@ -12,8 +12,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.api.client import MerakiAPIClient
+from ..core.models.network import MerakiNetwork
 from ..helpers.device_info_helpers import resolve_device_info
-from ..types import MerakiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/meraki_select/vpn.py
+++ b/custom_components/meraki_ha/meraki_select/vpn.py
@@ -12,8 +12,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.api.client import MerakiAPIClient
+from ..core.models.network import MerakiNetwork, MerakiVpn
 from ..helpers.device_info_helpers import resolve_device_info
-from ..types import MerakiNetwork, MerakiVpn
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/number/uplink_bandwidth.py
+++ b/custom_components/meraki_ha/number/uplink_bandwidth.py
@@ -10,7 +10,7 @@ from homeassistant.core import callback
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.entities.meraki_network_entity import MerakiNetworkEntity
-from ..types import MerakiNetwork
+from ..core.models.network import MerakiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -13,8 +13,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.models.device import MerakiAppliancePort, MerakiDevice
 from ...core.utils.naming_utils import format_device_name
-from ...types import MerakiAppliancePort, MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/appliance_uplink.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_uplink.py
@@ -16,7 +16,7 @@ from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/camera_analytics.py
+++ b/custom_components/meraki_ha/sensor/device/camera_analytics.py
@@ -13,7 +13,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/camera_audio_detection.py
+++ b/custom_components/meraki_ha/sensor/device/camera_audio_detection.py
@@ -17,7 +17,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.utils.naming_utils import format_device_name
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/camera_sense_status.py
+++ b/custom_components/meraki_ha/sensor/device/camera_sense_status.py
@@ -17,7 +17,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.utils.naming_utils import format_device_name
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/connected_clients.py
+++ b/custom_components/meraki_ha/sensor/device/connected_clients.py
@@ -15,7 +15,7 @@ from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/data_usage.py
+++ b/custom_components/meraki_ha/sensor/device/data_usage.py
@@ -17,7 +17,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.utils.naming_utils import format_device_name
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -21,9 +21,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
 from ...entity import MerakiEntity
-from ...types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
@@ -16,7 +16,7 @@ from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -16,8 +16,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
-from ...types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
@@ -17,7 +17,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.utils.naming_utils import format_device_name
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
@@ -17,7 +17,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.utils.naming_utils import format_device_name
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -16,7 +16,7 @@ from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.utils.naming_utils import format_device_name
 
 if TYPE_CHECKING:
-    from ...types import MerakiDevice
+    from ...core.models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/rtsp_url.py
+++ b/custom_components/meraki_ha/sensor/device/rtsp_url.py
@@ -13,9 +13,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
 from ...core.utils.network_utils import construct_rtsp_url
-from ...types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...types import MerakiDevice
+from ...core.models.device import MerakiDevice
 
 
 class MerakiSwitchPortSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/meraki_ha/sensor/network/network_clients.py
+++ b/custom_components/meraki_ha/sensor/network/network_clients.py
@@ -9,7 +9,7 @@ from homeassistant.core import callback
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.entities.meraki_network_entity import MerakiNetworkEntity
-from ...types import MerakiNetwork
+from ...core.models.network import MerakiNetwork
 
 if TYPE_CHECKING:
     from ...services.network_control_service import NetworkControlService

--- a/custom_components/meraki_ha/sensor/network/traffic_shaping.py
+++ b/custom_components/meraki_ha/sensor/network/traffic_shaping.py
@@ -9,7 +9,7 @@ from homeassistant.core import callback
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.entities.meraki_network_entity import MerakiNetworkEntity
-from ...types import MerakiNetwork
+from ...core.models.network import MerakiNetwork
 
 
 class TrafficShapingSensor(MerakiNetworkEntity, SensorEntity):

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.entities.meraki_network_entity import MerakiNetworkEntity
-from ...types import MerakiNetwork
+from ...core.models.network import MerakiNetwork
 
 
 class VlansListSensor(MerakiNetworkEntity, SensorEntity):

--- a/custom_components/meraki_ha/switch/camera_controls.py
+++ b/custom_components/meraki_ha/switch/camera_controls.py
@@ -6,7 +6,7 @@ import logging
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.api.client import MerakiAPIClient
-from ..types import MerakiDevice
+from ..core.models.device import MerakiDevice
 from .camera_settings import MerakiCameraSettingSwitchBase
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/switch/camera_profiles.py
+++ b/custom_components/meraki_ha/switch/camera_profiles.py
@@ -9,7 +9,7 @@ from homeassistant.components.switch import SwitchEntityDescription
 from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 
 from ..core.api.client import MerakiAPIClient
-from ..types import MerakiDevice
+from ..core.models.device import MerakiDevice
 from .camera_settings import MerakiCameraSettingSwitchBase
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/meraki_ha/switch/camera_settings.py
+++ b/custom_components/meraki_ha/switch/camera_settings.py
@@ -10,8 +10,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 
 from ..core.api.client import MerakiAPIClient
+from ..core.models.device import MerakiDevice
 from ..entity import MerakiEntity
-from ..types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/switch/content_filtering.py
+++ b/custom_components/meraki_ha/switch/content_filtering.py
@@ -10,8 +10,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..coordinator import MerakiDataUpdateCoordinator
+from ..core.models.network import MerakiNetwork
 from ..helpers.device_info_helpers import resolve_device_info
-from ..types import MerakiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/switch/firewall_rule.py
+++ b/custom_components/meraki_ha/switch/firewall_rule.py
@@ -11,8 +11,8 @@ from homeassistant.core import callback
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.entities.meraki_firewall_rule_entity import MerakiFirewallRuleEntity
+from ..core.models.network import MerakiFirewallRule
 from ..core.utils.entity_id_utils import get_firewall_rule_entity_id
-from ..types import MerakiFirewallRule
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/switch/mt40_power_outlet.py
+++ b/custom_components/meraki_ha/switch/mt40_power_outlet.py
@@ -13,8 +13,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.api.client import MerakiAPIClient
+from ..core.models.device import MerakiDevice
 from ..helpers.device_info_helpers import resolve_device_info
-from ..types import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/switch/setup_helpers.py
+++ b/custom_components/meraki_ha/switch/setup_helpers.py
@@ -14,8 +14,8 @@ from ..const import (
 )
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.api.client import MerakiAPIClient
+from ..core.models.network import MerakiTrafficShaping, MerakiVpn
 from ..core.utils.entity_id_utils import get_firewall_rule_entity_id
-from ..types import MerakiTrafficShaping, MerakiVpn
 from .camera_controls import AnalyticsSwitch
 from .firewall_rule import MerakiFirewallRuleSwitch
 from .meraki_ssid_device_switch import (

--- a/custom_components/meraki_ha/switch/traffic_shaping.py
+++ b/custom_components/meraki_ha/switch/traffic_shaping.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.entities.meraki_network_entity import MerakiNetworkEntity
-from ..types import MerakiTrafficShaping
+from ..core.models.network import MerakiTrafficShaping
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/meraki_ha/switch/vpn.py
+++ b/custom_components/meraki_ha/switch/vpn.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.entities.meraki_network_entity import MerakiNetworkEntity
-from ..types import MerakiNetwork
+from ..core.models.network import MerakiNetwork
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Refactored the `types.py` "God Module" into a granular domain model package (`core/models/`) to improve maintainability and import efficiency. This change split the major data classes into `device.py` and `network.py`, updated `types.py` for backward compatibility via re-exports, and refactored over 60 files to use direct imports. All tests passed, and code review was completed successfully.

Fixes #1692

---
*PR created automatically by Jules for task [1885335609471480051](https://jules.google.com/task/1885335609471480051) started by @brewmarsh*