### PR TITLE
Exclude Battery Entity for MT15 CO2 Sensors

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/mt.py
+++ b/custom_components/meraki_ha/discovery/handlers/mt.py
@@ -69,6 +69,9 @@ class MTHandler(BaseDeviceHandler):
         sensor_descriptions = MT_SENSOR_MODELS.get(model)
         if sensor_descriptions:
             for description in sensor_descriptions:
+                # MT15 is mains-powered and does not have a battery
+                if model == "MT15" and description.key == "battery":
+                    continue
                 entities.append(
                     MerakiMtSensor(self._coordinator, self.device, description)
                 )

--- a/tests/discovery/test_mt_handler.py
+++ b/tests/discovery/test_mt_handler.py
@@ -131,3 +131,44 @@ async def test_mt_handler_discover_entities_mt20(
     assert any(e.entity_description.key == "temperature" for e in sensors)
     assert any(e.entity_description.key == "humidity" for e in sensors)
     assert binary_sensors[0].entity_description.key == "door"
+
+
+async def test_mt_handler_discover_entities_mt15(
+    mock_coordinator_mt_handler: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_control_service: MagicMock,
+):
+    """Test MTHandler discovers entities correctly for MT15."""
+    from custom_components.meraki_ha.core.models.device import MerakiDevice
+
+    device = MerakiDevice.from_dict(
+        {
+            "serial": "mt15-1",
+            "model": "MT15",
+            "name": "MT15 Sensor",
+        }
+    )
+
+    handler = MTHandler(
+        mock_coordinator_mt_handler,
+        device,
+        mock_config_entry,
+        mock_control_service,
+    )
+
+    entities = await handler.discover_entities()
+
+    # MT15 has CO2, TVOC, PM2.5, Temperature, Humidity, Noise.
+    # Battery should be EXCLUDED.
+    assert len(entities) == 6
+    sensors = [e for e in entities if isinstance(e, MerakiMtSensor)]
+
+    assert len(sensors) == 6
+    assert any(e.entity_description.key == "co2" for e in sensors)
+    assert any(e.entity_description.key == "tvoc" for e in sensors)
+    assert any(e.entity_description.key == "pm25" for e in sensors)
+    assert any(e.entity_description.key == "temperature" for e in sensors)
+    assert any(e.entity_description.key == "humidity" for e in sensors)
+    assert any(e.entity_description.key == "noise" for e in sensors)
+    # Ensure battery is NOT present
+    assert not any(e.entity_description.key == "battery" for e in sensors)

--- a/tests/sensor/test_setup_mt_sensors.py
+++ b/tests/sensor/test_setup_mt_sensors.py
@@ -183,7 +183,7 @@ async def test_async_setup_mt15_sensors(
         object.__setattr__(entity, "async_write_ha_state", MagicMock())
         cast(CoordinatorEntity, entity)._handle_coordinator_update()
 
-    assert len(entities) == 7
+    assert len(entities) == 6
 
     sensors_by_key: dict[str, Any] = {
         entity.entity_description.key: entity


### PR DESCRIPTION
Excludes the battery sensor for MT15 devices as they are mains-powered. Updated handler logic and relevant tests.

Fixes #1722

---
*PR created automatically by Jules for task [13701421426405845127](https://jules.google.com/task/13701421426405845127) started by @brewmarsh*