### PR TITLE
Standardize Entity Names for Network and VLAN Sensors

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -11,7 +11,7 @@ from .meraki_network_entity import MerakiNetworkEntity
 class MerakiVLANEntity(MerakiNetworkEntity):
     """Representation of a Meraki VLAN."""
 
-    _attr_has_entity_name = False
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -33,4 +33,12 @@ class MerakiVLANEntity(MerakiNetworkEntity):
 
         vlan_id = vlan["id"]
         vlan_label = vlan.get("name") or ""
-        self._attr_name = f"{network.name} VLAN {vlan_id} {vlan_label}"
+        prefix = f"VLAN {vlan_id}"
+        if vlan_label:
+            prefix = f"{prefix} {vlan_label}"
+
+        current_name = getattr(self, "_attr_name", None)
+        if current_name:
+            self._attr_name = f"{prefix} {current_name}"
+        else:
+            self._attr_name = prefix

--- a/custom_components/meraki_ha/sensor/network/network_clients.py
+++ b/custom_components/meraki_ha/sensor/network/network_clients.py
@@ -22,7 +22,9 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
     """Representation of a Meraki network-level client counter."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_has_entity_name = False
+    _attr_has_entity_name = True
+    _attr_name = "Clients"
+    _attr_translation_key = "network_clients"
 
     def __init__(
         self,
@@ -35,7 +37,6 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
         super().__init__(coordinator, config_entry, network_data)
         self._network_control_service = network_control_service
         self._attr_unique_id = f"meraki_network_clients_{self._network_id}"
-        self._attr_name = f"{network_data.name} Active Clients"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/sensor/network/vlan.py
+++ b/custom_components/meraki_ha/sensor/network/vlan.py
@@ -19,6 +19,7 @@ class MerakiVLANIDSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN ID sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "VLAN ID"
 
     def __init__(
         self,
@@ -47,6 +48,7 @@ class MerakiVLANIPv4EnabledSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN IPv4 Enabled sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "IPv4 enabled"
 
     def __init__(
         self,
@@ -77,6 +79,7 @@ class MerakiVLANIPv4InterfaceSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN IPv4 Interface IP sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "IPv4 interface IP"
 
     def __init__(
         self,
@@ -107,6 +110,7 @@ class MerakiVLANIPv4UplinkSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN IPv4 Uplink sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "IPv4 uplink"
 
     def __init__(
         self,
@@ -138,6 +142,7 @@ class MerakiVLANIPv6EnabledSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN IPv6 Enabled sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "IPv6 enabled"
 
     def __init__(
         self,
@@ -171,6 +176,7 @@ class MerakiVLANIPv6InterfaceSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN IPv6 Interface IP sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "IPv6 interface IP"
 
     def __init__(
         self,
@@ -204,6 +210,7 @@ class MerakiVLANIPv6UplinkSensor(MerakiVLANEntity, SensorEntity):
     """Representation of a Meraki VLAN IPv6 Uplink sensor."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "IPv6 uplink"
 
     def __init__(
         self,

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -161,6 +161,30 @@
       },
       "energy": {
         "name": "Energy"
+      },
+      "network_clients": {
+        "name": "Clients"
+      },
+      "vlan_id": {
+        "name": "VLAN ID"
+      },
+      "ipv4_enabled": {
+        "name": "IPv4 enabled"
+      },
+      "ipv4_interface_ip": {
+        "name": "IPv4 interface IP"
+      },
+      "ipv4_uplink": {
+        "name": "IPv4 uplink"
+      },
+      "ipv6_enabled": {
+        "name": "IPv6 enabled"
+      },
+      "ipv6_interface_ip": {
+        "name": "IPv6 interface IP"
+      },
+      "ipv6_uplink": {
+        "name": "IPv6 uplink"
       }
     },
     "switch": {

--- a/custom_components/meraki_ha/switch/vlan_dhcp.py
+++ b/custom_components/meraki_ha/switch/vlan_dhcp.py
@@ -19,6 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
     """Representation of a Meraki VLAN's DHCP handling switch."""
 
+    _attr_name = "DHCP"
+
     def __init__(
         self,
         coordinator: MerakiDataUpdateCoordinator,
@@ -36,7 +38,6 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "dhcp_handling"
         )
-        self._attr_name = "DHCP"
         self._update_internal_state()
 
     def _update_internal_state(self) -> None:

--- a/custom_components/meraki_ha/translations/en.json
+++ b/custom_components/meraki_ha/translations/en.json
@@ -156,6 +156,30 @@
       },
       "radio_settings": {
         "name": "Radio Settings"
+      },
+      "network_clients": {
+        "name": "Clients"
+      },
+      "vlan_id": {
+        "name": "VLAN ID"
+      },
+      "ipv4_enabled": {
+        "name": "IPv4 enabled"
+      },
+      "ipv4_interface_ip": {
+        "name": "IPv4 interface IP"
+      },
+      "ipv4_uplink": {
+        "name": "IPv4 uplink"
+      },
+      "ipv6_enabled": {
+        "name": "IPv6 enabled"
+      },
+      "ipv6_interface_ip": {
+        "name": "IPv6 interface IP"
+      },
+      "ipv6_uplink": {
+        "name": "IPv6 uplink"
       }
     },
     "switch": {

--- a/tests/core/test_entity_naming.py
+++ b/tests/core/test_entity_naming.py
@@ -44,7 +44,7 @@ def test_vlan_naming(mock_coordinator):
     entity = MerakiVLANEntity(mock_coordinator, config_entry, "N_12345", vlan)
 
     assert entity.device_info["name"] == "Site A"
-    assert entity.name == "Site A VLAN 10 VoIP"
+    assert entity.name == "VLAN 10 VoIP"
 
 
 def test_camera_naming(mock_coordinator):

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -92,7 +92,8 @@ async def test_vlan_sensor_creation(mock_coordinator):
     assert len(vlan_sensors) == 14
 
     # Filter for sensors of the first VLAN
-    vlan1_sensors = [s for s in vlan_sensors if s.name == "Test Network VLAN 1 VLAN 1"]
+    # Note: With has_entity_name=True, the name property returns the entity name
+    vlan1_sensors = [s for s in vlan_sensors if "VLAN 1 VLAN 1" in s.name]
     assert len(vlan1_sensors) == 7
 
     # Find the specific sensors for VLAN 1 by translation_key


### PR DESCRIPTION
This pull request standardizes the entity names for Meraki network sensors and VLAN sensors to align with modern Home Assistant naming conventions.

Key changes:
- `MerakiNetworkClientsSensor` now uses `_attr_has_entity_name = True` and class attributes for its name and translation key.
- `MerakiVLANEntity` has been updated to use `_attr_has_entity_name = True`. It now dynamically constructs `_attr_name` by prepending the VLAN ID and label to the sensor-specific name defined in subclasses.
- All 7 VLAN sensor classes and the VLAN DHCP switch have been updated with `_attr_name` class attributes following Sentence Case (e.g., "IPv4 enabled").
- Translation files (`en.json` and `strings.json`) now include entries for `network_clients` and the various VLAN sensor attributes.
- Unit tests in `tests/sensor/network/test_vlan.py` and `tests/core/test_entity_naming.py` have been updated to verify the new naming format.
- A minor bug where `_attr_name` could be accessed before initialization in `MerakiVLANEntity` was fixed using `getattr`.

These changes ensure that sensors are properly registered under the Network device in Home Assistant and appear with clear, descriptive names in the UI.

Fixes #1733

---
*PR created automatically by Jules for task [746494589504121050](https://jules.google.com/task/746494589504121050) started by @brewmarsh*