### PR TITLE
Fix Dynamic Tag Generation for GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,13 @@ jobs:
           commit_message: "chore(release): version bump"
           branch: ${{ github.ref_name }}
 
+      - name: Get version
+        id: get_version
+        run: echo "tag=v$(jq -r .version custom_components/meraki_ha/manifest.json)" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v$(jq -r .version custom_components/meraki_ha/manifest.json)
+          tag_name: ${{ steps.get_version.outputs.tag }}
           prerelease: ${{ github.ref_name == 'beta' }}
           generate_release_notes: true

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -15,7 +15,7 @@ from ...core.fetch_strategies.appliance import ApplianceFetchStrategy
 from ...core.fetch_strategies.camera import CameraFetchStrategy
 from ...core.fetch_strategies.switch import SwitchFetchStrategy
 from ...core.fetch_strategies.wireless import WirelessFetchStrategy
-from ...core.models.device import MerakiAppliancePort, MerakiDevice
+from ...core.models.device import MerakiDevice
 from ...core.models.network import MerakiNetwork
 from ...core.parsers.appliance import parse_appliance_data
 from ...core.parsers.network import parse_network_data

--- a/custom_components/meraki_ha/core/fetch_strategies/base.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..api.client import MerakiAPIClient

--- a/custom_components/meraki_ha/core/parsers/network.py
+++ b/custom_components/meraki_ha/core/parsers/network.py
@@ -29,9 +29,7 @@ def parse_network_data(
     disabled_features: set[str],
     coordinator: Any = None,  # Added to support status messages
 ) -> dict[str, Any]:
-    """
-    Parse and process network-level data.
-    """
+    """Parse and process network-level data."""
     appliance_traffic: dict[str, Any] = {}
     vlan_by_network: dict[str, list[MerakiVlan]] = {}
     l3_firewall_rules_by_network: dict[str, list[MerakiFirewallRule]] = {}
@@ -120,7 +118,7 @@ def _parse_traffic(
     """Parse appliance traffic data."""
     key = f"traffic_{network_id}"
     data = detail_data.get(key)
-    
+
     if isinstance(data, MerakiTrafficAnalysisError):
         disabled_features.add(key)
         appliance_traffic[network_id] = {"error": "disabled", "reason": str(data)}

--- a/custom_components/meraki_ha/discovery/handlers/universal.py
+++ b/custom_components/meraki_ha/discovery/handlers/universal.py
@@ -8,6 +8,12 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
+from ...binary_sensor.device.camera_motion import MerakiMotionSensor
+from ...binary_sensor.device.meraki_mt_binary_base import MerakiMtBinarySensor
+from ...binary_sensor.switch_port import SwitchPortSensor
+from ...button.device.camera_snapshot import MerakiSnapshotButton
+from ...button.reboot import MerakiRebootButton
+from ...camera import MerakiCamera
 from ...const import DOMAIN
 from ...const_conf import (
     CONF_ENABLE_CAMERA_ENTITIES,
@@ -18,9 +24,10 @@ from ...const_conf import (
 from ...core.errors import MerakiInformationalError
 from ...descriptions import (
     MT_BATTERY_DESCRIPTION,
-    MT_CO2_DESCRIPTION,
     MT_BUTTON_DESCRIPTION,
+    MT_CO2_DESCRIPTION,
     MT_CURRENT_DESCRIPTION,
+    MT_DOOR_DESCRIPTION,
     MT_ENERGY_DESCRIPTION,
     MT_FREQUENCY_DESCRIPTION,
     MT_HUMIDITY_DESCRIPTION,
@@ -33,26 +40,19 @@ from ...descriptions import (
     MT_TVOC_DESCRIPTION,
     MT_VOLTAGE_DESCRIPTION,
     MT_WATER_DESCRIPTION,
-    MT_DOOR_DESCRIPTION,
 )
-from ...sensor.device.meraki_mt_base import MerakiMtSensor
-from ...binary_sensor.device.meraki_mt_binary_base import MerakiMtBinarySensor
-from ...switch.mt40_power_outlet import MerakiMt40PowerOutlet
-from ...sensor.device.appliance_uplink import MerakiApplianceUplinkSensor
 from ...sensor.device.appliance_port import MerakiAppliancePortSensor
-from ...binary_sensor.switch_port import SwitchPortSensor
-from ...sensor.device.poe_usage import MerakiPoeUsageSensor
-from ...button.reboot import MerakiRebootButton
-from ...sensor.device.device_status import MerakiDeviceStatusSensor
-from ...camera import MerakiCamera
+from ...sensor.device.appliance_uplink import MerakiApplianceUplinkSensor
 from ...sensor.device.camera_analytics import (
     MerakiPersonCountSensor,
     MerakiVehicleCountSensor,
 )
-from ...binary_sensor.device.camera_motion import MerakiMotionSensor
-from ...button.device.camera_snapshot import MerakiSnapshotButton
+from ...sensor.device.device_status import MerakiDeviceStatusSensor
+from ...sensor.device.meraki_mt_base import MerakiMtSensor
+from ...sensor.device.poe_usage import MerakiPoeUsageSensor
 from ...sensor.device.rtsp_url import MerakiRtspUrlSensor
 from ...switch.camera_controls import AnalyticsSwitch
+from ...switch.mt40_power_outlet import MerakiMt40PowerOutlet
 from .base import BaseDeviceHandler
 
 if TYPE_CHECKING:

--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -1,6 +1,5 @@
 """Test DataFetchManager feature flags."""
 
-import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/discovery/handlers/test_universal.py
+++ b/tests/discovery/handlers/test_universal.py
@@ -1,11 +1,16 @@
 """Tests for the UniversalHandler."""
 
 from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from custom_components.meraki_ha.discovery.handlers.universal import UniversalHandler
-from custom_components.meraki_ha.core.models.device import MerakiDevice
+
 from custom_components.meraki_ha.button.reboot import MerakiRebootButton
-from custom_components.meraki_ha.sensor.device.device_status import MerakiDeviceStatusSensor
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+from custom_components.meraki_ha.discovery.handlers.universal import UniversalHandler
+from custom_components.meraki_ha.sensor.device.device_status import (
+    MerakiDeviceStatusSensor,
+)
+
 
 @pytest.fixture
 def mock_coordinator():

--- a/tests/sensor/network/test_ssid_client_count.py
+++ b/tests/sensor/network/test_ssid_client_count.py
@@ -1,10 +1,11 @@
 """Test the Meraki SSID Client Count sensor."""
 
 from unittest.mock import MagicMock
-from homeassistant.components.sensor import SensorStateClass
+
 from custom_components.meraki_ha.sensor.network.ssid_client_count import (
     MerakiSSIDClientCountSensor,
 )
+
 
 async def test_ssid_client_count_sensor_wireless_settings() -> None:
     """Test the SSID client count sensor using wireless_settings."""

--- a/tests/sensor/network/test_ssid_details.py
+++ b/tests/sensor/network/test_ssid_details.py
@@ -1,11 +1,14 @@
 """Test the Meraki SSID detail sensors."""
 
 from unittest.mock import MagicMock
+
 from homeassistant.const import UnitOfDataRate
+
 from custom_components.meraki_ha.sensor.network.ssid_details import (
-    MerakiSSIDTotalUploadLimitSensor,
     MerakiSSIDMinBitrate24GhzSensor,
+    MerakiSSIDTotalUploadLimitSensor,
 )
+
 
 async def test_ssid_total_upload_limit_sensor() -> None:
     """Test the SSID total upload limit sensor."""


### PR DESCRIPTION
The release workflow was failing with a 422 Unprocessable Entity error because the `tag_name` was being passed as a literal string `v$(jq -r .version custom_components/meraki_ha/manifest.json)` instead of the evaluated version.

I fixed this by:
1. Adding a `Get version` step in `.github/workflows/release.yml` that extracts the version from `manifest.json` and sets it as an output named `tag`.
2. Updating the `Create GitHub Release` step to use `${{ steps.get_version.outputs.tag }}`.

I also verified the YAML validity and ran the existing test suite and linting checks.
Target Branch: beta

Fixes #1741

---
*PR created automatically by Jules for task [3910853204503405862](https://jules.google.com/task/3910853204503405862) started by @brewmarsh*