### PR TITLE
Implement Persistent Feature Disabling in Fetch Strategies

### DIFF
--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -27,13 +27,13 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
     def __init__(
         self,
         client: MerakiAPIClient,
-        disabled_features: set[str],
+        _disabled_features: set[str],
         enable_vpn_management: bool,
         enable_firewall_rules: bool,
         enable_traffic_shaping: bool,
     ) -> None:
         """Initialize the appliance fetch strategy."""
-        super().__init__(client, disabled_features)
+        super().__init__(client, _disabled_features)
         self.enable_vpn_management = enable_vpn_management
         self.enable_firewall_rules = enable_firewall_rules
         self.enable_traffic_shaping = enable_traffic_shaping
@@ -44,17 +44,17 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
         tasks: dict[str, asyncio.Task[Any]],
     ) -> None:
         """Add appliance specific network tasks."""
-        if f"traffic_{network_id}" not in self.disabled_features:
+        if f"traffic_{network_id}" not in self._disabled_features:
             tasks[f"traffic_{network_id}"] = asyncio.create_task(
                 self.client.run_with_semaphore(
                     self.client.network.get_network_traffic(network_id, "appliance"),
                 )
             )
 
-        if f"vlans_{network_id}" not in self.disabled_features:
+        if f"vlans_{network_id}" not in self._disabled_features:
             tasks[f"vlans_{network_id}"] = asyncio.create_task(
                 self.client.run_with_semaphore(
-                    self.client.get_vlan_data(network_id),
+                    self.client.network.get_vlan_data(network_id),
                 )
             )
 
@@ -115,11 +115,17 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
         key = f"traffic_{network_id}"
         data = detail_data.get(key)
         if isinstance(data, MerakiTrafficAnalysisError):
-            self.disabled_features.add(key)
+            self._disabled_features.add(key)
             _LOGGER.info(
                 "Traffic analysis is not enabled for network %s.",
                 network_id,
             )
+            appliance_traffic[network_id] = {
+                "error": "disabled",
+                "reason": str(data),
+            }
+        elif isinstance(data, MerakiInformationalError) and "traffic analysis" in str(data).lower():
+            self._disabled_features.add(key)
             appliance_traffic[network_id] = {
                 "error": "disabled",
                 "reason": str(data),
@@ -140,13 +146,13 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
         key = f"vlans_{network_id}"
         data = detail_data.get(key)
         if isinstance(data, (MerakiVlanError, MerakiVlansDisabledError)):
+            self._disabled_features.add(key)
             if isinstance(data, MerakiVlanError):
-                self.disabled_features.add(key)
                 _LOGGER.info(str(data))
             vlan_by_network[network_id] = []
         elif isinstance(data, MerakiInformationalError):
             if "vlans are not enabled" in str(data).lower():
-                self.disabled_features.add(key)
+                self._disabled_features.add(key)
                 vlan_by_network[network_id] = []
         elif isinstance(data, list):
             vlan_by_network[network_id] = data

--- a/custom_components/meraki_ha/core/fetch_strategies/base.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/base.py
@@ -11,13 +11,13 @@ if TYPE_CHECKING:
 class BaseFetchStrategy:
     """Base class for fetch strategies."""
 
-    def __init__(self, client: MerakiAPIClient, disabled_features: set[str]) -> None:
+    def __init__(self, client: MerakiAPIClient, _disabled_features: set[str]) -> None:
         """
         Initialize the strategy.
 
         Args:
             client: The Meraki API client.
-            disabled_features: A set of disabled features.
+            _disabled_features: A set of disabled features.
         """
         self.client = client
-        self.disabled_features = disabled_features
+        self._disabled_features = _disabled_features

--- a/tests/core/coordinator_helpers/test_data_fetcher.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher.py
@@ -1,3 +1,6 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
 @pytest.mark.asyncio
 async def test_get_all_data_includes_switch_ports(data_fetch_manager, mock_client):
     """Test that get_all_data returns switch ports statuses."""

--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -1,0 +1,92 @@
+"""Test ApplianceFetchStrategy."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from custom_components.meraki_ha.core.fetch_strategies.appliance import ApplianceFetchStrategy
+from custom_components.meraki_ha.core.errors import (
+    MerakiTrafficAnalysisError,
+    MerakiVlanError,
+    MerakiVlansDisabledError,
+)
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.run_with_semaphore.side_effect = lambda x: x
+    return client
+
+@pytest.fixture
+def disabled_features():
+    return set()
+
+@pytest.fixture
+def strategy(mock_client, disabled_features):
+    return ApplianceFetchStrategy(
+        client=mock_client,
+        _disabled_features=disabled_features,
+        enable_vpn_management=False,
+        enable_firewall_rules=False,
+        enable_traffic_shaping=False,
+    )
+
+def test_build_network_tasks_skips_disabled(strategy, disabled_features):
+    """Test that build_network_tasks skips disabled features."""
+    network_id = "net1"
+    disabled_features.add(f"traffic_{network_id}")
+    disabled_features.add(f"vlans_{network_id}")
+
+    tasks = {}
+    with patch("asyncio.create_task", side_effect=lambda x: x):
+        strategy.build_network_tasks(network_id, tasks)
+
+    assert f"traffic_{network_id}" not in tasks
+    assert f"vlans_{network_id}" not in tasks
+
+def test_build_network_tasks_includes_enabled(strategy, disabled_features):
+    """Test that build_network_tasks includes enabled features."""
+    network_id = "net1"
+
+    tasks = {}
+    with patch("asyncio.create_task", side_effect=lambda x: x):
+        strategy.build_network_tasks(network_id, tasks)
+
+    assert f"traffic_{network_id}" in tasks
+    assert f"vlans_{network_id}" in tasks
+
+def test_process_network_traffic_disables_on_error(strategy, disabled_features):
+    """Test that process_network_traffic disables the feature on error."""
+    network_id = "net1"
+    key = f"traffic_{network_id}"
+    detail_data = {key: MerakiTrafficAnalysisError("Disabled")}
+    appliance_traffic = {}
+
+    strategy.process_network_traffic(network_id, detail_data, {}, appliance_traffic)
+
+    assert key in disabled_features
+    assert appliance_traffic[network_id]["error"] == "disabled"
+
+def test_process_network_vlans_disables_on_vlan_error(strategy, disabled_features):
+    """Test that process_network_vlans disables the feature on MerakiVlanError."""
+    network_id = "net1"
+    key = f"vlans_{network_id}"
+    detail_data = {key: MerakiVlanError("Disabled")}
+    vlan_by_network = {}
+
+    strategy.process_network_vlans(network_id, detail_data, {}, vlan_by_network)
+
+    assert key in disabled_features
+    assert vlan_by_network[network_id] == []
+
+def test_process_network_vlans_disables_on_vlans_disabled_error(strategy, disabled_features):
+    """Test that process_network_vlans disables the feature on MerakiVlansDisabledError."""
+    network_id = "net1"
+    key = f"vlans_{network_id}"
+    detail_data = {key: MerakiVlansDisabledError("Disabled")}
+    vlan_by_network = {}
+
+    strategy.process_network_vlans(network_id, detail_data, {}, vlan_by_network)
+
+    assert key in disabled_features
+    assert vlan_by_network[network_id] == []


### PR DESCRIPTION
This submission implements persistent feature disabling for the Meraki Appliance fetch strategy. It ensures that failing API calls for Traffic Analysis and VLANs are skipped in subsequent polling intervals once they have encountered a 400-type error or other informational errors indicating they are not enabled. This is achieved by utilizing a shared `_disabled_features` set. The implementation also fixes an inconsistency in the VLAN data fetching call.

Fixes #1734

---
*PR created automatically by Jules for task [6692915284929541616](https://jules.google.com/task/6692915284929541616) started by @brewmarsh*