### PR TITLE
Downgrade Disabled Feature Errors in api_utils.py

### DIFF
--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -8,6 +8,8 @@ from typing import Final
 
 DOMAIN: Final = "meraki_ha"
 MANUFACTURER: Final = "Cisco Meraki"
+WEBHOOK_ID_FORMAT: Final = "meraki_ha_{entry_id}"
+DATA_CLIENT: Final = "meraki_client"
 
 # ... (Previous constants)
 

--- a/custom_components/meraki_ha/core/utils/api_utils.py
+++ b/custom_components/meraki_ha/core/utils/api_utils.py
@@ -65,12 +65,8 @@ def handle_meraki_errors(
             )
             is_vlan_disabled = "VLANs are not enabled" in error_msg
 
-            if (
-                isinstance(err, APIError) and getattr(err, "status", None) == 400
-            ) and (is_traffic_analysis or is_vlan_disabled):
-                if error_msg not in _LOGGED_ERRORS:
-                    _LOGGER.info("Meraki feature disabled (skipping): %s", error_msg)
-                    _LOGGED_ERRORS.add(error_msg)
+            if is_traffic_analysis or is_vlan_disabled:
+                _LOGGER.debug("Meraki feature disabled (skipping): %s", error_msg)
 
                 # Attempt to mark the feature as disabled in the client session
                 # This prevents subsequent API calls for this feature
@@ -96,7 +92,14 @@ def handle_meraki_errors(
                     or getattr(return_type, "__origin__", None) is list
                 ):
                     return cast(T, [])
-                return cast(T, {})
+                if (
+                    return_type is dict
+                    or getattr(return_type, "__origin__", None) is dict
+                ):
+                    return cast(T, {})
+
+                # Return the error object as a last resort if return type is not list/dict
+                return cast(T, MerakiInformationalError(error_msg))
 
             if isinstance(err, APIError) and _is_informational_error(err):
                 raise MerakiInformationalError(f"Informational error: {err}") from err

--- a/tests/discovery/handlers/test_universal.py
+++ b/tests/discovery/handlers/test_universal.py
@@ -136,7 +136,7 @@ async def test_universal_handler_mx_capabilities(
         mock_network_control_service,
     )
 
-entities = await handler.discover_entities()
+    entities = await handler.discover_entities()
 
     assert any(isinstance(e, MerakiRebootButton) for e in entities)
     assert any(isinstance(e, MerakiDeviceStatusSensor) for e in entities)


### PR DESCRIPTION
This change addresses the issue where production logs were filled with 400 Bad Request errors for features already identified as disabled by the API client. 

Key changes:
1. In `api_utils.py`, the `handle_meraki_errors` decorator now checks for specific error strings: "Traffic Analysis with Hostname Visibility" and "VLANs are not enabled".
2. When these strings are found, the log level is set to DEBUG.
3. The function returns a type-safe empty value (list or dict) based on the return annotation of the decorated function. If no collection type is hinted, it returns the `MerakiInformationalError` object.
4. Simplified the condition by removing the strict `status == 400` check, making the error suppression more resilient to API status code variations.
5. Fixed `const.py` by adding missing `WEBHOOK_ID_FORMAT` and `DATA_CLIENT` constants which were causing import errors.
6. Fixed a syntax error (indentation) in `tests/discovery/handlers/test_universal.py`.

Fixes #1732

---
*PR created automatically by Jules for task [5999205013918866200](https://jules.google.com/task/5999205013918866200) started by @brewmarsh*