### PR TITLE
Restore Missing Webhook and Data Client Constants

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -119,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Set up webhook
-    webhook_id = WEBHOOK_ID_FORMAT.format(entry_id=entry.entry_id)
+    webhook_id = WEBHOOK_ID_FORMAT.format(entry.entry_id)
     hass.data[DOMAIN][entry.entry_id]["webhook_id"] = webhook_id
     if not entry.data.get("webhook_secret"):
         secret = "".join(secrets.choice(string.ascii_letters) for _ in range(32))

--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -8,6 +8,8 @@ from typing import Final
 
 DOMAIN: Final = "meraki_ha"
 MANUFACTURER: Final = "Cisco Meraki"
+DATA_CLIENT: Final = "meraki_client"
+WEBHOOK_ID_FORMAT: Final = "meraki_ha_{}"
 
 # ... (Previous constants)
 


### PR DESCRIPTION
This PR restores two missing constants in `const.py`: `WEBHOOK_ID_FORMAT` and `DATA_CLIENT`. 

- `WEBHOOK_ID_FORMAT` was defined as `"meraki_ha_{}"` as per requirements.
- `DATA_CLIENT` was identified as missing during verification and was restored as `"meraki_client"` to fix `ImportError` in `TimedAccessManager` and relevant tests.
- `__init__.py` was updated to use positional formatting for the webhook ID (`WEBHOOK_ID_FORMAT.format(entry.entry_id)`) to match the new constant definition and prevent `IndexError` at runtime.

Verification:
- `pytest tests/test_integration_setup.py` (Pass)
- `pytest tests/test_webhook_registration.py` (Pass)
- `pytest tests/test_e2e_ipsk.py` (Pass)
- `pytest tests/test_simple.py` (Pass)
- Manual import check: `python3 -c "from custom_components.meraki_ha import config_flow"` (Pass after installing dependencies)

Adheres to Home Assistant Sentence Case standards and use of `Final` type hints for constants.

Fixes #1747

---
*PR created automatically by Jules for task [2797962042916240763](https://jules.google.com/task/2797962042916240763) started by @brewmarsh*