### PR TITLE
Verify Config Flow Import Integrity and Refactor

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
@@ -17,14 +17,14 @@ except ImportError:
         DhcpServiceInfo,  # type: ignore[no-redef, attr-defined]
     )
 
-from .authentication import validate_meraki_credentials
-from .const import DOMAIN
+from .const import DOMAIN, WEBHOOK_ID_FORMAT
 from .const_conf import CONF_INTEGRATION_TITLE, CONF_MERAKI_API_KEY, CONF_MERAKI_ORG_ID
-from .coordinator import MerakiDataUpdateCoordinator
 from .core.errors import MerakiAuthenticationError, MerakiConnectionError
 from .helpers.schema import populate_schema_defaults
-from .options_flow import MerakiOptionsFlowHandler
 from .schemas import CONFIG_SCHEMA, OPTIONS_SCHEMA
+
+if TYPE_CHECKING:
+    from .coordinator import MerakiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +78,8 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
         """
         errors: dict[str, str] = {}
         if user_input is not None:
+            from .authentication import validate_meraki_credentials
+
             try:
                 validation_result = await validate_meraki_credentials(
                     self.hass,
@@ -159,6 +161,8 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
             The options flow handler.
 
         """
+        from .options_flow import MerakiOptionsFlowHandler
+
         return MerakiOptionsFlowHandler(config_entry)
 
     async def async_step_reconfigure(
@@ -186,6 +190,8 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
             self.hass.config_entries.async_update_entry(entry, options=new_options)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reconfigure_successful")
+
+        from .coordinator import MerakiDataUpdateCoordinator
 
         coordinator: MerakiDataUpdateCoordinator = self.hass.data[DOMAIN][
             entry.entry_id

--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -1,6 +1,4 @@
-"""
-Constants for the Meraki Home Assistant integration.
-"""
+"""Constants for the Meraki Home Assistant integration."""
 
 from __future__ import annotations
 
@@ -8,6 +6,8 @@ from typing import Final
 
 DOMAIN: Final = "meraki_ha"
 MANUFACTURER: Final = "Cisco Meraki"
+WEBHOOK_ID_FORMAT: Final = "{entry_id}"
+DATA_CLIENT: Final = "meraki_client"
 
 # ... (Previous constants)
 
@@ -31,8 +31,24 @@ DEVICE_CAPABILITIES: Final = {
     "MT10": ["temperature", "humidity", "battery", "signal_strength"],
     "MT11": ["temperature", "humidity", "battery", "signal_strength"],
     "MT12": ["temperature", "humidity", "battery", "signal_strength", "water"],
-    "MT14": ["pm25", "tvoc", "temperature", "humidity", "noise", "battery", "signal_strength"],
-    "MT15": ["co2", "tvoc", "pm25", "temperature", "humidity", "noise", "signal_strength"], # No Battery
+    "MT14": [
+        "pm25",
+        "tvoc",
+        "temperature",
+        "humidity",
+        "noise",
+        "battery",
+        "signal_strength",
+    ],
+    "MT15": [
+        "co2",
+        "tvoc",
+        "pm25",
+        "temperature",
+        "humidity",
+        "noise",
+        "signal_strength",
+    ],  # No Battery
     "MT20": ["temperature", "humidity", "battery", "signal_strength", "door"],
     "MT30": ["button_press", "battery", "signal_strength"],
     "MT40": ["power_monitor", "remote_switch", "signal_strength"],

--- a/tests/core/coordinator_helpers/test_data_fetcher.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher.py
@@ -1,11 +1,13 @@
 """Tests for the Data Fetch Manager."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
     DataFetchManager,
 )
+
 
 @pytest.fixture
 def mock_client():

--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -1,15 +1,18 @@
 """Test ApplianceFetchStrategy."""
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from custom_components.meraki_ha.core.fetch_strategies.appliance import ApplianceFetchStrategy
 from custom_components.meraki_ha.core.errors import (
     MerakiTrafficAnalysisError,
     MerakiVlanError,
     MerakiVlansDisabledError,
 )
+from custom_components.meraki_ha.core.fetch_strategies.appliance import (
+    ApplianceFetchStrategy,
+)
+
 
 @pytest.fixture
 def mock_client():

--- a/tests/discovery/handlers/test_universal.py
+++ b/tests/discovery/handlers/test_universal.py
@@ -136,7 +136,7 @@ async def test_universal_handler_mx_capabilities(
         mock_network_control_service,
     )
 
-entities = await handler.discover_entities()
+    entities = await handler.discover_entities()
 
     assert any(isinstance(e, MerakiRebootButton) for e in entities)
     assert any(isinstance(e, MerakiDeviceStatusSensor) for e in entities)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -40,7 +40,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "custom_components.meraki_ha.config_flow.validate_meraki_credentials",
+            "custom_components.meraki_ha.authentication.validate_meraki_credentials",
             return_value={"valid": True, "org_name": "Test Org"},
         ),
         patch(
@@ -81,7 +81,7 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "custom_components.meraki_ha.config_flow.validate_meraki_credentials",
+        "custom_components.meraki_ha.authentication.validate_meraki_credentials",
         side_effect=MerakiAuthenticationError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -103,7 +103,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "custom_components.meraki_ha.config_flow.validate_meraki_credentials",
+        "custom_components.meraki_ha.authentication.validate_meraki_credentials",
         side_effect=MerakiConnectionError,
     ):
         result2 = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
This change refactors `config_flow.py` to resolve circular dependencies that were blocking the Home Assistant loader. Heavy imports are now performed within the methods where they are needed. Additionally, missing constants `WEBHOOK_ID_FORMAT` and `DATA_CLIENT` were added to `const.py`, and an unrelated indentation error in the test suite was fixed to allow CI checks to pass.

Fixes #1748

---
*PR created automatically by Jules for task [803817225824432363](https://jules.google.com/task/803817225824432363) started by @brewmarsh*