### PR TITLE
Debug Task Volume and Implement Semaphore Safety

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -119,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Set up webhook
-    webhook_id = WEBHOOK_ID_FORMAT.format(entry.entry_id)
+    webhook_id = WEBHOOK_ID_FORMAT.format(entry_id=entry.entry_id)
     hass.data[DOMAIN][entry.entry_id]["webhook_id"] = webhook_id
     if not entry.data.get("webhook_secret"):
         secret = "".join(secrets.choice(string.ascii_letters) for _ in range(32))

--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -91,7 +91,7 @@ class MerakiAPIClient:
         self.sensor = SensorEndpoints(self)
 
         # Semaphore to limit concurrent API calls
-        self._semaphore = asyncio.Semaphore(2)
+        self._semaphore = asyncio.Semaphore(10)
 
     @property
     def has_dashboard(self) -> bool:

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -253,6 +253,7 @@ class DataFetchManager:
         )
 
         detail_tasks = self._build_detail_tasks(networks_list, devices_list)
+        _LOGGER.debug("Starting gather for %s detail tasks", len(detail_tasks))
         detail_data_results = await asyncio.gather(
             *detail_tasks.values(), return_exceptions=True
         )


### PR DESCRIPTION
This change addresses potential deadlocks by increasing the API semaphore capacity and adding logging to monitor task volume. It also fixes a bug in webhook ID formatting that was causing test failures.

Fixes #1758

---
*PR created automatically by Jules for task [16104222965855571760](https://jules.google.com/task/16104222965855571760) started by @brewmarsh*