### PR TITLE
Fix DataFetchManager timeouts and linting issues

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -60,9 +60,9 @@ class DataFetchManager:
         self.camera_strategy = CameraFetchStrategy(client, self._disabled_features)
 
     async def _async_gather_with_timeout(
-        self, 
-        tasks: dict[str, Any], 
-        timeout: int = 25, 
+        self,
+        tasks: dict[str, Any],
+        timeout: int = 25,
         label: str = "Tasks"
     ) -> dict[str, Any]:
         """Gather tasks with a hard timeout to prevent deadlocks."""
@@ -70,7 +70,7 @@ class DataFetchManager:
             return {}
 
         _LOGGER.debug("Starting %s: %s items", label, len(tasks))
-        
+
         try:
             results = await asyncio.wait_for(
                 asyncio.gather(*tasks.values(), return_exceptions=True),
@@ -114,7 +114,7 @@ class DataFetchManager:
     ) -> dict[str, Any]:
         """Orchestrate task building across all strategies."""
         detail_tasks: dict[str, Any] = {}
-        
+
         for network in networks:
             if not network.id:
                 continue
@@ -122,7 +122,9 @@ class DataFetchManager:
             p_types = network.product_types
 
             if "wireless" in p_types:
-                self.wireless_strategy.build_network_tasks(net_id, p_types, detail_tasks)
+                self.wireless_strategy.build_network_tasks(
+                    net_id, p_types, detail_tasks
+                )
             if "appliance" in p_types:
                 self.appliance_strategy.build_network_tasks(net_id, detail_tasks)
 
@@ -154,12 +156,15 @@ class DataFetchManager:
             if not network.id:
                 continue
             network_id = cast(str, network.id)
-            
+
             self.wireless_strategy.process_network_data(
                 network_id, detail_data, previous_data, processed_data
             )
             self.appliance_strategy.process_network_traffic(
-                network_id, detail_data, previous_data, processed_data["appliance_traffic"]
+                network_id,
+                detail_data,
+                previous_data,
+                processed_data["appliance_traffic"],
             )
             self.appliance_strategy.process_network_vlans(
                 network_id, detail_data, previous_data, processed_data["vlans"]
@@ -170,14 +175,18 @@ class DataFetchManager:
         }
 
         for device in devices:
-            prev = previous_devices_by_serial.get(device.serial) if device.serial else None
-            
+            prev = (
+                previous_devices_by_serial.get(device.serial) if device.serial else None
+            )
+
             if device.product_type == "camera":
                 self.camera_strategy.process_device_details(device, detail_data, prev)
             elif device.product_type == "switch":
                 self.switch_strategy.process_device_details(device, detail_data, prev)
             elif device.product_type == "appliance":
-                self.appliance_strategy.process_device_details(device, detail_data, prev)
+                self.appliance_strategy.process_device_details(
+                    device, detail_data, prev
+                )
 
         return processed_data
 
@@ -186,7 +195,7 @@ class DataFetchManager:
         previous_data: dict[str, Any] | None = None,
         timespan: int | None = None,
     ) -> dict[str, Any]:
-        """Main entry point for the coordinator update cycle."""
+        """Fetch all data for the coordinator update cycle."""
         previous_data = previous_data or {}
         _LOGGER.debug("Fetching fresh Meraki data from API")
 
@@ -204,7 +213,9 @@ class DataFetchManager:
         ]
 
         # 3. Apply baseline parsers (Uplinks & Sensors)
-        parse_appliance_data(devices_list, initial_results.get("appliance_uplink_statuses"))
+        parse_appliance_data(
+            devices_list, initial_results.get("appliance_uplink_statuses")
+        )
         parse_sensor_data(devices_list, initial_results.get("sensor_readings", []), [])
 
         # 4. Fetch Details (Strategy + Timeout Protection)
@@ -215,16 +226,24 @@ class DataFetchManager:
 
         # 5. Fetch Clients (Network & Device level)
         client_tasks = {
-            "network_clients": self.client_fetcher.async_fetch_network_clients(networks_list),
-            "device_clients": self.client_fetcher.async_fetch_device_clients(devices_list),
+            "network_clients": self.client_fetcher.async_fetch_network_clients(
+                networks_list
+            ),
+            "device_clients": self.client_fetcher.async_fetch_device_clients(
+                devices_list
+            ),
         }
-        client_results = await self._async_gather_with_timeout(client_tasks, label="Client Data")
-        
+        client_results = await self._async_gather_with_timeout(
+            client_tasks, label="Client Data"
+        )
+
         network_clients = client_results.get("network_clients", [])
         device_clients = client_results.get("device_clients", {})
 
         # Inject clients for strategies that require them (e.g. Wireless)
-        detail_data_dict["clients"] = network_clients if isinstance(network_clients, list) else []
+        detail_data_dict["clients"] = (
+            network_clients if isinstance(network_clients, list) else []
+        )
 
         # 6. Final Processing
         processed_detailed_data = self._process_detailed_data(
@@ -232,13 +251,19 @@ class DataFetchManager:
         )
 
         org_data = initial_results.get("organization", {})
-        org_name = org_data.get("name", "Unknown Org") if isinstance(org_data, dict) else "Unknown Org"
+        org_name = (
+            org_data.get("name", "Unknown Org")
+            if isinstance(org_data, dict)
+            else "Unknown Org"
+        )
 
         return {
             "org_name": org_name,
             "networks": networks_list,
             "devices": devices_list,
             "clients": network_clients if isinstance(network_clients, list) else [],
-            "clients_by_serial": device_clients if isinstance(device_clients, dict) else {},
+            "clients_by_serial": (
+                device_clients if isinstance(device_clients, dict) else {}
+            ),
             **processed_detailed_data,
         }

--- a/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
@@ -8,8 +8,7 @@ import pytest
 from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
     DataFetchManager,
 )
-from custom_components.meraki_ha.core.models.network import MerakiNetwork
-from custom_components.meraki_ha.core.models.device import MerakiDevice
+
 
 @pytest.fixture
 def mock_client():
@@ -20,43 +19,74 @@ def mock_client():
     client.run_with_semaphore = AsyncMock()
     return client
 
+
 @pytest.fixture
 def data_fetch_manager(mock_client):
     """Fixture for DataFetchManager."""
     return DataFetchManager(mock_client)
 
+
 @pytest.mark.asyncio
 async def test_fetch_initial_data_timeout(data_fetch_manager, mock_client):
-    """Test that _async_fetch_initial_data logs error and raises TimeoutError on timeout."""
-    with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.asyncio.wait_for", side_effect=asyncio.TimeoutError):
-        with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error") as mock_log_error:
+    """Test that _async_fetch_initial_data logs error and raises TimeoutError."""
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.asyncio.wait_for",
+        side_effect=asyncio.TimeoutError,
+    ):
+        with patch(
+            "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error"
+        ) as mock_log_error:
             with pytest.raises(asyncio.TimeoutError):
                 await data_fetch_manager._async_fetch_initial_data()
-            mock_log_error.assert_called_with("Timeout fetching initial Meraki data")
+            mock_log_error.assert_called_with(
+                "Timeout during %s. Potential semaphore deadlock.", "Initial Batch"
+            )
+
 
 @pytest.mark.asyncio
 async def test_get_all_data_detailed_timeout(data_fetch_manager, mock_client):
-    """Test that get_all_data logs error and raises TimeoutError on detailed data timeout."""
-    data_fetch_manager._async_fetch_initial_data = AsyncMock(return_value={})
+    """Test that get_all_data logs error and raises TimeoutError on detailed timeout."""
+    # Provide data to ensure detail tasks are built
+    data_fetch_manager._async_fetch_initial_data = AsyncMock(
+        return_value={
+            "networks": [{"id": "n1", "productTypes": ["appliance"]}],
+            "devices": [],
+        }
+    )
 
-    with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.asyncio.wait_for", side_effect=asyncio.TimeoutError):
-        with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error") as mock_log_error:
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.asyncio.wait_for",
+        side_effect=asyncio.TimeoutError,
+    ):
+        with patch(
+            "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error"
+        ) as mock_log_error:
             with pytest.raises(asyncio.TimeoutError):
                 await data_fetch_manager.get_all_data()
             # It might be called for detailed data first
-            mock_log_error.assert_any_call("Timeout fetching detailed Meraki data")
+            mock_log_error.assert_any_call(
+                "Timeout during %s. Potential semaphore deadlock.",
+                "Detailed Device Data",
+            )
+
 
 @pytest.mark.asyncio
 async def test_get_all_data_client_timeout(data_fetch_manager, mock_client):
-    """Test that get_all_data logs error and raises TimeoutError on client data timeout."""
+    """Test that get_all_data logs error and raises TimeoutError on client timeout."""
     data_fetch_manager._async_fetch_initial_data = AsyncMock(return_value={})
 
     # We need to bypass the first wait_for (detailed data)
-    with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.asyncio.wait_for") as mock_wait_for:
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.asyncio.wait_for"
+    ) as mock_wait_for:
         # First call returns empty dict (detail data results)
-        mock_wait_for.side_effect = [{}, asyncio.TimeoutError()]
+        mock_wait_for.side_effect = asyncio.TimeoutError
 
-        with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error") as mock_log_error:
+        with patch(
+            "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error"
+        ) as mock_log_error:
             with pytest.raises(asyncio.TimeoutError):
                 await data_fetch_manager.get_all_data()
-            mock_log_error.assert_called_with("Timeout fetching Meraki client data")
+            mock_log_error.assert_called_with(
+                "Timeout during %s. Potential semaphore deadlock.", "Client Data"
+            )


### PR DESCRIPTION
This PR addresses test failures in `test_data_fetcher_timeouts.py` by aligning the test expectations with the actual error messages logged by `DataFetchManager`. It also fixes a logic error in `test_get_all_data_client_timeout` where the test setup did not account for the behavior of `DataFetchManager` when initial data is empty. Additionally, it resolves multiple line length violations (E501) in `custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py` and the test file.

---
*PR created automatically by Jules for task [14715971090127578414](https://jules.google.com/task/14715971090127578414) started by @brewmarsh*