### PR TITLE
Audit and refactor strategies to prevent semaphore deadlocks

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -356,11 +356,9 @@ class NetworkEndpoints:
         """
         try:
             # First try the appliance-level call
-            res = await self._api_client.run_with_semaphore(
-                self._api_client.run_sync(
-                    self._api_client.dashboard.appliance.getNetworkApplianceVlans,
-                    networkId=network_id,
-                )
+            res = await self._api_client.run_sync(
+                self._api_client.dashboard.appliance.getNetworkApplianceVlans,
+                networkId=network_id,
             )
             validated = validate_response(res)
             if isinstance(validated, list):
@@ -381,11 +379,9 @@ class NetworkEndpoints:
                     network_id,
                 )
                 try:
-                    res = await self._api_client.run_with_semaphore(
-                        self._api_client.run_sync(
-                            self._api_client.dashboard.networks.getNetworkVlans,
-                            networkId=network_id,
-                        )
+                    res = await self._api_client.run_sync(
+                        self._api_client.dashboard.networks.getNetworkVlans,
+                        networkId=network_id,
                     )
                     validated = validate_response(res)
                     if isinstance(validated, list):
@@ -473,10 +469,8 @@ class NetworkEndpoints:
         }
         filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
-        return await self._api_client.run_with_semaphore(
-            self._api_client.run_sync(
-                self._api_client.dashboard.networks.getNetworkEvents,
-                network_id,
-                **filtered_kwargs,
-            )
+        return await self._api_client.run_sync(
+            self._api_client.dashboard.networks.getNetworkEvents,
+            network_id,
+            **filtered_kwargs,
         )

--- a/custom_components/meraki_ha/core/api/endpoints/wireless.py
+++ b/custom_components/meraki_ha/core/api/endpoints/wireless.py
@@ -205,7 +205,7 @@ class WirelessEndpoints:
         self,
         network_id: str,
         product_types: list[str],
-    ) -> dict[str, asyncio.Task[Any]]:
+    ) -> dict[str, Any]:
         """
         Get tasks to fetch detailed data for a network.
 
@@ -219,17 +219,13 @@ class WirelessEndpoints:
             A dictionary of tasks.
 
         """
-        tasks: dict[str, asyncio.Task[Any]] = {}
+        tasks: dict[str, Any] = {}
         if "wireless" in product_types:
-            tasks[f"ssids_{network_id}"] = asyncio.create_task(
-                self._api_client.run_with_semaphore(
-                    self.get_network_ssids(network_id),
-                ),
+            tasks[f"ssids_{network_id}"] = self._api_client.run_with_semaphore(
+                self.get_network_ssids(network_id),
             )
-            tasks[f"rf_profiles_{network_id}"] = asyncio.create_task(
-                self._api_client.run_with_semaphore(
-                    self.get_network_wireless_rf_profiles(network_id),
-                ),
+            tasks[f"rf_profiles_{network_id}"] = self._api_client.run_with_semaphore(
+                self.get_network_wireless_rf_profiles(network_id),
             )
         return tasks
 

--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -41,67 +41,51 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
     def build_network_tasks(
         self,
         network_id: str,
-        tasks: dict[str, asyncio.Task[Any]],
+        tasks: dict[str, Any],
     ) -> None:
         """Add appliance specific network tasks."""
         if f"traffic_{network_id}" not in self._disabled_features:
-            tasks[f"traffic_{network_id}"] = asyncio.create_task(
-                self.client.run_with_semaphore(
-                    self.client.network.get_network_traffic(network_id, "appliance"),
-                )
+            tasks[f"traffic_{network_id}"] = self.client.run_with_semaphore(
+                self.client.network.get_network_traffic(network_id, "appliance"),
             )
 
         if f"vlans_{network_id}" not in self._disabled_features:
-            tasks[f"vlans_{network_id}"] = asyncio.create_task(
-                self.client.run_with_semaphore(
-                    self.client.network.get_vlan_data(network_id),
-                )
+            tasks[f"vlans_{network_id}"] = self.client.run_with_semaphore(
+                self.client.network.get_vlan_data(network_id),
             )
 
         if self.enable_firewall_rules:
-            tasks[f"l3_firewall_rules_{network_id}"] = asyncio.create_task(
-                self.client.run_with_semaphore(
-                    self.client.appliance.get_l3_firewall_rules(network_id),
-                )
+            tasks[f"l3_firewall_rules_{network_id}"] = self.client.run_with_semaphore(
+                self.client.appliance.get_l3_firewall_rules(network_id),
             )
         if self.enable_traffic_shaping:
-            tasks[f"traffic_shaping_{network_id}"] = asyncio.create_task(
-                self.client.run_with_semaphore(
-                    self.client.appliance.get_traffic_shaping(network_id),
-                )
+            tasks[f"traffic_shaping_{network_id}"] = self.client.run_with_semaphore(
+                self.client.appliance.get_traffic_shaping(network_id),
             )
         if self.enable_vpn_management:
-            tasks[f"vpn_status_{network_id}"] = asyncio.create_task(
-                self.client.run_with_semaphore(
-                    self.client.appliance.get_vpn_status(network_id),
-                )
+            tasks[f"vpn_status_{network_id}"] = self.client.run_with_semaphore(
+                self.client.appliance.get_vpn_status(network_id),
             )
-        tasks[f"appliance_ports_{network_id}"] = asyncio.create_task(
-            self.client.run_with_semaphore(
-                self.client.appliance.get_appliance_ports(network_id),
-            )
+        tasks[f"appliance_ports_{network_id}"] = self.client.run_with_semaphore(
+            self.client.appliance.get_appliance_ports(network_id),
         )
-        tasks[f"content_filtering_{network_id}"] = asyncio.create_task(
-            self.client.run_with_semaphore(
-                self.client.appliance.get_network_appliance_content_filtering(
-                    network_id,
-                ),
-            )
+        tasks[f"content_filtering_{network_id}"] = self.client.run_with_semaphore(
+            self.client.appliance.get_network_appliance_content_filtering(
+                network_id,
+            ),
         )
 
     def build_device_tasks(
         self,
         device: MerakiDevice,
-        tasks: dict[str, asyncio.Task[Any]],
+        tasks: dict[str, Any],
     ) -> None:
         """Add appliance specific device tasks."""
         if device.network_id:
-            tasks[f"appliance_settings_{device.serial}"] = asyncio.create_task(
-                self.client.run_with_semaphore(
-                    self.client.appliance.get_network_appliance_settings(
-                        device.network_id,
-                    ),
-                )
+            tasks[f"appliance_settings_{device.serial}"] = self.client.run_with_semaphore(
+                self.client.appliance.get_network_appliance_settings(
+                    device.network_id,
+                ),
             )
 
     def process_network_traffic(

--- a/custom_components/meraki_ha/core/fetch_strategies/camera.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/camera.py
@@ -15,25 +15,19 @@ class CameraFetchStrategy(BaseFetchStrategy):
     def build_device_tasks(
         self,
         device: MerakiDevice,
-        tasks: dict[str, asyncio.Task[Any]],
+        tasks: dict[str, Any],
     ) -> None:
         """Add camera specific device tasks."""
-        tasks[f"video_settings_{device.serial}"] = asyncio.create_task(
-            self.client.run_with_semaphore(
-                self.client.camera.get_camera_video_settings(device.serial),
-            )
+        tasks[f"video_settings_{device.serial}"] = self.client.run_with_semaphore(
+            self.client.camera.get_camera_video_settings(device.serial),
         )
-        tasks[f"sense_settings_{device.serial}"] = asyncio.create_task(
-            self.client.run_with_semaphore(
-                self.client.camera.get_camera_sense_settings(device.serial),
-            )
+        tasks[f"sense_settings_{device.serial}"] = self.client.run_with_semaphore(
+            self.client.camera.get_camera_sense_settings(device.serial),
         )
-        tasks[f"camera_analytics_{device.serial}"] = asyncio.create_task(
-            self.client.run_with_semaphore(
-                self.client.camera.get_device_camera_analytics_recent(
-                    device.serial,
-                ),
-            )
+        tasks[f"camera_analytics_{device.serial}"] = self.client.run_with_semaphore(
+            self.client.camera.get_device_camera_analytics_recent(
+                device.serial,
+            ),
         )
 
     def process_device_details(

--- a/custom_components/meraki_ha/core/fetch_strategies/switch.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/switch.py
@@ -15,13 +15,11 @@ class SwitchFetchStrategy(BaseFetchStrategy):
     def build_device_tasks(
         self,
         device: MerakiDevice,
-        tasks: dict[str, asyncio.Task[Any]],
+        tasks: dict[str, Any],
     ) -> None:
         """Add switch specific device tasks."""
-        tasks[f"ports_statuses_{device.serial}"] = asyncio.create_task(
-            self.client.run_with_semaphore(
-                self.client.switch.get_device_switch_ports_statuses(device.serial),
-            )
+        tasks[f"ports_statuses_{device.serial}"] = self.client.run_with_semaphore(
+            self.client.switch.get_device_switch_ports_statuses(device.serial),
         )
 
     def process_device_details(


### PR DESCRIPTION
This submission audits and refactors the Meraki HA integration's data fetching strategies and API helpers to eliminate semaphore deadlocks. 

Key changes include:
1. **Separation of Task Building and Execution**: Strategies now populate the task dictionary with coroutines rather than immediately creating `asyncio.Task` objects. This ensures that the event loop doesn't start executing these tasks (and attempting semaphore acquisition) until they are explicitly gathered by the `DataFetchManager`.
2. **Elimination of Nested Semaphores**: Internal `run_with_semaphore` wrappers were removed from `get_vlan_data` and `get_network_events` in `NetworkEndpoints`. Since strategies already wrap these calls in `run_with_semaphore`, the internal wrappers were causing recursive acquisition attempts, leading to deadlocks.
3. **Consistency Across Strategies**: Refactored Appliance, Wireless, Camera, and Switch strategies to follow the same pattern, ensuring long-term stability and preventing similar bugs in other component types.
4. **Type Hint Updates**: Updated type hints from `dict[str, asyncio.Task]` to `dict[str, Any]` to correctly reflect that the dictionaries now hold awaitables/coroutines.

Verified the fix by running existing unit tests for the `DataFetchManager` and `ApplianceFetchStrategy`, ensuring no regressions were introduced.

Fixes #1759

---
*PR created automatically by Jules for task [14837691980661957804](https://jules.google.com/task/14837691980661957804) started by @brewmarsh*