### PR TITLE
Implement Global Fetch Timeout in Coordinator

### DIFF
--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -160,9 +161,14 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if self.update_interval
                 else 300
             )
-            data = await self.data_fetch_manager.get_all_data(
-                self.last_successful_data, timespan=timespan
-            )
+            try:
+                async with asyncio.timeout(30):  # HA default setup limit
+                    data = await self.data_fetch_manager.get_all_data(
+                        self.last_successful_data, timespan=timespan
+                    )
+            except TimeoutError:
+                _LOGGER.error("Meraki API took too long; check for semaphore deadlock")
+                raise UpdateFailed("API Timeout") from None
 
             if not data:
                 _LOGGER.warning("API call to get_all_data returned no data.")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const import DOMAIN
@@ -79,3 +80,21 @@ async def test_update_data_handles_errors(coordinator, mock_data_fetch_manager):
         data["appliance_traffic"][MOCK_NETWORK.id]["reason"]
         == "Traffic analysis is not enabled"
     )
+
+@pytest.mark.asyncio
+async def test_update_data_handles_timeout(coordinator, mock_data_fetch_manager):
+    """Test that _async_update_data handles timeout."""
+    # Arrange
+    mock_data_fetch_manager.get_all_data.side_effect = TimeoutError()
+
+    # Act & Assert
+
+    # 1. Test with stale data (should return stale data after logging error)
+    coordinator.last_successful_data = {"test": "data"}
+    data = await coordinator._async_update_data()
+    assert data == {"test": "data"}
+
+    # 2. Test without stale data (should raise UpdateFailed)
+    coordinator.last_successful_data = {}
+    with pytest.raises(UpdateFailed, match="API Timeout"):
+        await coordinator._async_update_data()


### PR DESCRIPTION
This PR implements a global fetch timeout in the `MerakiDataUpdateCoordinator` to prevent the integration from hanging indefinitely. 

Key changes:
1. **Timeout Wrapper**: The `get_all_data` call in `_async_update_data` is now wrapped with `asyncio.timeout(30)`. This ensures that if the Meraki API takes too long, the integration fails gracefully rather than being cancelled by Home Assistant's internal task manager.
2. **Error Handling**: On `TimeoutError`, a specific error message is logged: `"Meraki API took too long; check for semaphore deadlock"`, and `UpdateFailed("API Timeout")` is raised.
3. **Graceful Fallback**: The existing exception handling in the coordinator catches the `UpdateFailed` and returns the last successful data if available, maintaining entity states while logging a warning about the timeout.
4. **Unit Testing**: A new test case `test_update_data_handles_timeout` has been added to `tests/test_coordinator.py` to verify both the propagation of `UpdateFailed` and the successful fallback to stale data.

Fixes #1760

---
*PR created automatically by Jules for task [10561986148167509387](https://jules.google.com/task/10561986148167509387) started by @brewmarsh*