### PR TITLE
fix: Resolve linting and mypy violations

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/wireless.py
+++ b/custom_components/meraki_ha/core/api/endpoints/wireless.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 

--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -82,10 +81,12 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
     ) -> None:
         """Add appliance specific device tasks."""
         if device.network_id:
-            tasks[f"appliance_settings_{device.serial}"] = self.client.run_with_semaphore(
-                self.client.appliance.get_network_appliance_settings(
-                    device.network_id,
-                ),
+            tasks[f"appliance_settings_{device.serial}"] = (
+                self.client.run_with_semaphore(
+                    self.client.appliance.get_network_appliance_settings(
+                        device.network_id,
+                    ),
+                )
             )
 
     def process_network_traffic(

--- a/custom_components/meraki_ha/core/fetch_strategies/camera.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/camera.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from ...core.models.device import MerakiDevice

--- a/custom_components/meraki_ha/core/fetch_strategies/switch.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/switch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from ...core.models.device import MerakiDevice

--- a/custom_components/meraki_ha/core/utils/api_utils.py
+++ b/custom_components/meraki_ha/core/utils/api_utils.py
@@ -61,7 +61,10 @@ def handle_meraki_errors(
                 # Inspect return type to provide a safe empty value
                 sig = inspect.signature(func)
                 return_type = sig.return_annotation
-                if return_type is list or getattr(return_type, "__origin__", None) is list:
+                if (
+                    return_type is list
+                    or getattr(return_type, "__origin__", None) is list
+                ):
                     return cast(T, [])
                 return cast(T, {})
             except (APIError, MerakiInformationalError) as err:
@@ -109,7 +112,9 @@ def handle_meraki_errors(
                     return cast(T, MerakiInformationalError(error_msg))
 
                 if isinstance(err, APIError) and _is_informational_error(err):
-                    raise MerakiInformationalError(f"Informational error: {err}") from err
+                    raise MerakiInformationalError(
+                        f"Informational error: {err}"
+                    ) from err
 
                 # Re-raise MerakiInformationalError if it was already raised
                 # (e.g. by run_sync)

--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -84,6 +84,9 @@ class UplinkProvider:
         if not config_entry.options.get(CONF_ENABLE_PORT_SENSORS, True):
             return []
 
+        if not device.serial:
+            return []
+
         entities: list[Entity] = []
         uplink_data_by_interface: dict[str, dict[str, Any]] = {}
         if device.appliance_uplink_statuses:
@@ -176,7 +179,7 @@ class CameraAnalyticsProvider:
     ) -> list[Entity]:
         """Get entities."""
         camera_service: CameraService | None = kwargs.get("camera_service")
-        if not camera_service:
+        if not camera_service or not device.serial:
             return []
 
         entities: list[Entity] = []
@@ -204,7 +207,7 @@ class CameraStreamProvider:
     ) -> list[Entity]:
         """Get entities."""
         camera_service: CameraService | None = kwargs.get("camera_service")
-        if not camera_service:
+        if not camera_service or not device.serial:
             return []
 
         # If configured, ensure the RTSP stream is enabled by default for cameras


### PR DESCRIPTION
Fixed line length violations in `appliance.py` and `api_utils.py`. Fixed mypy errors in `discovery/providers.py` by adding defensive checks for missing device serials.

---
*PR created automatically by Jules for task [9213150738048192101](https://jules.google.com/task/9213150738048192101) started by @brewmarsh*