### PR TITLE
Sync Config Flow with Strategy Architecture

### DIFF
--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -62,16 +62,6 @@ class MerakiAuthentication:
             )
         return client
 
-    def _find_organization(self, organizations: list[dict[str, Any]]) -> str | None:
-        """Find the organization by ID and return its name."""
-        if not organizations:
-            return None
-
-        for org in organizations:
-            if org.get("id") == self.organization_id:
-                return org.get("name")
-        return None
-
     def _handle_sdk_error(self, error: MerakiSDKAPIError) -> NoReturn:
         """Handle Meraki SDK API errors by mapping them to HA exceptions."""
         if error.status == 401:
@@ -101,8 +91,8 @@ class MerakiAuthentication:
         """
         Validate Meraki API credentials using the Meraki SDK.
 
-        Makes a request to the Meraki API to fetch organizations and checks
-        if the provided organization ID is present in the response.
+        Makes a request to the Meraki API to fetch organization details and
+        checks if the provided API key has access to it.
 
         Returns
         -------
@@ -118,15 +108,13 @@ class MerakiAuthentication:
         client = await self._async_get_authenticated_client()
 
         try:
-            all_organizations: list[
-                dict[str, Any]
-            ] = await client.organization.get_organizations()
+            organization: dict[str, Any] = await client.organization.get_organization()
 
-            fetched_org_name = self._find_organization(all_organizations)
+            fetched_org_name = organization.get("name")
 
-            if fetched_org_name is None:
+            if not fetched_org_name:
                 _LOGGER.warning(
-                    "Organization ID %s not found in accessible organizations.",
+                    "Organization ID %s details could not be retrieved.",
                     self.organization_id,
                 )
                 raise InvalidOrgID(
@@ -145,6 +133,11 @@ class MerakiAuthentication:
             raise ConfigEntryAuthFailed(f"Authentication failed: {e}") from e
         except MerakiConnectionError as e:
             _LOGGER.error("Connection error: %s", e)
+            # If it's a 404 error, map it to InvalidOrgID
+            if "404" in str(e) or "not found" in str(e).lower():
+                raise InvalidOrgID(
+                    f"Organization ID {self.organization_id} not found.",
+                ) from e
             raise MerakiConnectionError(f"Connection error: {e}") from e
         except MerakiSDKAPIError as e:
             self._handle_sdk_error(e)

--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -18,7 +18,13 @@ except ImportError:
     )
 
 from .const import DOMAIN
-from .const_conf import CONF_INTEGRATION_TITLE, CONF_MERAKI_API_KEY, CONF_MERAKI_ORG_ID
+from .const_conf import (
+    CONF_ENABLE_FIREWALL_RULES,
+    CONF_ENABLE_VPN_MANAGEMENT,
+    CONF_INTEGRATION_TITLE,
+    CONF_MERAKI_API_KEY,
+    CONF_MERAKI_ORG_ID,
+)
 from .core.errors import MerakiAuthenticationError, MerakiConnectionError
 from .helpers.schema import populate_schema_defaults
 from .schemas import CONFIG_SCHEMA, OPTIONS_SCHEMA
@@ -81,23 +87,27 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
             from .authentication import validate_meraki_credentials
 
             try:
+                api_key = user_input[CONF_MERAKI_API_KEY]
+                org_id = user_input[CONF_MERAKI_ORG_ID]
                 validation_result = await validate_meraki_credentials(
                     self.hass,
-                    user_input[CONF_MERAKI_API_KEY],
-                    user_input[CONF_MERAKI_ORG_ID],
+                    api_key,
+                    org_id,
                 )
-                self.data[CONF_MERAKI_API_KEY] = user_input[CONF_MERAKI_API_KEY]
-                self.data[CONF_MERAKI_ORG_ID] = user_input[CONF_MERAKI_ORG_ID]
-                self.data["org_name"] = validation_result.get(
-                    "org_name",
-                    user_input[CONF_MERAKI_ORG_ID],
-                )
+                org_name = validation_result.get("org_name", org_id)
 
-                await self.async_set_unique_id(user_input[CONF_MERAKI_ORG_ID])
+                await self.async_set_unique_id(org_id)
                 self._abort_if_unique_id_configured()
 
-                # Show the general form by default
-                return await self.async_step_init()
+                return self.async_create_entry(
+                    title=org_name,
+                    data={
+                        CONF_MERAKI_API_KEY: api_key,
+                        CONF_MERAKI_ORG_ID: org_id,
+                        CONF_ENABLE_VPN_MANAGEMENT: False,
+                        CONF_ENABLE_FIREWALL_RULES: False,
+                    },
+                )
 
             except MerakiAuthenticationError:
                 errors["base"] = "invalid_auth"
@@ -113,35 +123,6 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
             step_id="user",
             data_schema=CONFIG_SCHEMA,
             errors=errors,
-        )
-
-    async def async_step_init(
-        self,
-        user_input: dict[str, Any] | None = None,
-    ) -> ConfigFlowResult:
-        """
-        Handle the general settings step.
-
-        Args:
-        ----
-            user_input: The user input.
-
-        Returns
-        -------
-            The flow result.
-
-        """
-        if user_input is not None:
-            self.options.update(user_input)
-            return self.async_create_entry(
-                title=self.data.get("org_name", CONF_INTEGRATION_TITLE),
-                data=self.data,
-                options=self.options,
-            )
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=OPTIONS_SCHEMA,
         )
 
     @staticmethod

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -69,17 +69,25 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             api_key=entry.data[CONF_MERAKI_API_KEY],
             org_id=entry.data[CONF_MERAKI_ORG_ID],
         )
+        # Feature flags can be in either options (user-controlled) or data (initial setup)
+        enable_vpn = entry.options.get(
+            CONF_ENABLE_VPN_MANAGEMENT,
+            entry.data.get(CONF_ENABLE_VPN_MANAGEMENT, DEFAULT_ENABLE_VPN_MANAGEMENT),
+        )
+        enable_firewall = entry.options.get(
+            CONF_ENABLE_FIREWALL_RULES,
+            entry.data.get(CONF_ENABLE_FIREWALL_RULES, DEFAULT_ENABLE_FIREWALL_RULES),
+        )
+        enable_traffic = entry.options.get(
+            CONF_ENABLE_TRAFFIC_SHAPING,
+            entry.data.get(CONF_ENABLE_TRAFFIC_SHAPING, DEFAULT_ENABLE_TRAFFIC_SHAPING),
+        )
+
         self.data_fetch_manager = DataFetchManager(
             client=self.api,
-            enable_vpn_management=entry.options.get(
-                CONF_ENABLE_VPN_MANAGEMENT, DEFAULT_ENABLE_VPN_MANAGEMENT
-            ),
-            enable_firewall_rules=entry.options.get(
-                CONF_ENABLE_FIREWALL_RULES, DEFAULT_ENABLE_FIREWALL_RULES
-            ),
-            enable_traffic_shaping=entry.options.get(
-                CONF_ENABLE_TRAFFIC_SHAPING, DEFAULT_ENABLE_TRAFFIC_SHAPING
-            ),
+            enable_vpn_management=enable_vpn,
+            enable_firewall_rules=enable_firewall,
+            enable_traffic_shaping=enable_traffic,
         )
         self.devices_by_serial: dict[str, MerakiDevice] = {}
         self.networks_by_id: dict[str, MerakiNetwork] = {}

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -32,8 +32,8 @@ async def test_validate_meraki_credentials(hass: HomeAssistant) -> None:
         "custom_components.meraki_ha.authentication.MerakiAPIClient",
     ) as mock_client:
         mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.organization.get_organizations = AsyncMock(
-            return_value=[{"id": "test-org-id", "name": "Test Org"}],
+        mock_client.return_value.organization.get_organization = AsyncMock(
+            return_value={"id": "test-org-id", "name": "Test Org"},
         )
         result = await validate_meraki_credentials(hass, "test-api-key", "test-org-id")
         assert result == {"org_name": "Test Org", "valid": True}
@@ -56,8 +56,8 @@ async def test_validate_meraki_credentials_invalid_org(hass: HomeAssistant) -> N
         pytest.raises(InvalidOrgID),
     ):
         mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.organization.get_organizations = AsyncMock(
-            return_value=[{"id": "other-org-id", "name": "Other Org"}],
+        mock_client.return_value.organization.get_organization = AsyncMock(
+            return_value={},
         )
         await validate_meraki_credentials(hass, "test-api-key", "test-org-id")
 
@@ -79,7 +79,7 @@ async def test_validate_meraki_credentials_auth_failed(hass: HomeAssistant) -> N
         pytest.raises(ConfigEntryAuthFailed),
     ):
         mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.organization.get_organizations = AsyncMock(
+        mock_client.return_value.organization.get_organization = AsyncMock(
             side_effect=MerakiAuthenticationError("test"),
         )
         await validate_meraki_credentials(hass, "test-api-key", "test-org-id")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -55,21 +55,15 @@ async def test_form(hass: HomeAssistant) -> None:
                 "meraki_org_id": "test-org-id",
             },
         )
-        assert result2["type"] == FlowResultType.FORM
-        assert result2["step_id"] == "init"
-
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
-            {},
-        )
         await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.CREATE_ENTRY
-    assert result3["title"] == "Test Org"
-    assert result3["data"] == {
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Test Org"
+    assert result2["data"] == {
         "meraki_api_key": "test-api-key",
         "meraki_org_id": "test-org-id",
-        "org_name": "Test Org",
+        "enable_vpn_management": False,
+        "enable_firewall_rules": False,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 


### PR DESCRIPTION
This PR refactors the Meraki integration's configuration flow to align with the new strategy-based architecture (v2.3.0 Milestone).

Key changes:
- `config_flow.py`: `async_step_user` now collects API Key and Org ID and creates the entry directly, bypassing the previous `async_step_init`. Default feature toggles (`enable_vpn_management`, `enable_firewall_rules`) are now stored in the entry `data`.
- `authentication.py`: Refactored `validate_credentials` to use `client.organization.get_organization()` for more efficient validation and organization name retrieval. Added specific handling for 404 errors.
- `coordinator.py`: Updated to read feature flags from both `entry.options` and `entry.data`, ensuring that configurations set during initial setup are respected.
- `tests/`: Updated `test_authentication.py` and `test_config_flow.py` to reflect the streamlined setup and new API calls.

These changes simplify the onboarding process and ensure the integration correctly initializes its data fetching strategies.

Fixes #1749

---
*PR created automatically by Jules for task [13878443646784850996](https://jules.google.com/task/13878443646784850996) started by @brewmarsh*