### PR TITLE
Fix linting error in coordinator.py

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -21,7 +21,6 @@ from .const import DOMAIN
 from .const_conf import (
     CONF_ENABLE_FIREWALL_RULES,
     CONF_ENABLE_VPN_MANAGEMENT,
-    CONF_INTEGRATION_TITLE,
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
 )

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -69,7 +69,8 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             api_key=entry.data[CONF_MERAKI_API_KEY],
             org_id=entry.data[CONF_MERAKI_ORG_ID],
         )
-        # Feature flags can be in either options (user-controlled) or data (initial setup)
+        # Feature flags can be in either options (user-controlled)
+        # or data (initial setup)
         enable_vpn = entry.options.get(
             CONF_ENABLE_VPN_MANAGEMENT,
             entry.data.get(CONF_ENABLE_VPN_MANAGEMENT, DEFAULT_ENABLE_VPN_MANAGEMENT),


### PR DESCRIPTION
Fix line length violation reported by ruff in `custom_components/meraki_ha/coordinator.py`.

---
*PR created automatically by Jules for task [10282024939267800533](https://jules.google.com/task/10282024939267800533) started by @brewmarsh*