### PR TITLE
chore: Fix linting violations in network.py and test_consolidation.py

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -388,7 +388,8 @@ class NetworkEndpoints:
                     network_id,
                 )
                 try:
-                    # Replacing invalid networks.getNetworkVlans with appliance.getNetworkApplianceVlans
+                    # Replacing invalid networks.getNetworkVlans with
+                    # appliance.getNetworkApplianceVlans
                     # using getattr for a second layer of safety
                     vlan_method = getattr(
                         self._api_client.dashboard.appliance,

--- a/tests/core/coordinator_helpers/test_consolidation.py
+++ b/tests/core/coordinator_helpers/test_consolidation.py
@@ -1,9 +1,13 @@
 """Tests for the Data Consolidation logic."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import DataFetchManager
-from custom_components.meraki_ha.core.models.device import MerakiDevice
+
+from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
+    DataFetchManager,
+)
+
 
 @pytest.fixture
 def mock_client():
@@ -12,8 +16,8 @@ def mock_client():
     client._disabled_features = set()
     client.has_dashboard = True
 
-    # Mock run_with_semaphore to return an awaitable that returns its input if it was a coro
-    # or just returns a mock result.
+    # Mock run_with_semaphore to return an awaitable that returns its input
+    # if it was a coro or just returns a mock result.
     async def mock_run(coro_or_val):
         if hasattr(coro_or_val, "__await__"):
             return await coro_or_val
@@ -22,10 +26,12 @@ def mock_client():
     client.run_with_semaphore = AsyncMock(side_effect=mock_run)
     return client
 
+
 @pytest.fixture
 def data_fetch_manager(mock_client):
     """Fixture for DataFetchManager."""
     return DataFetchManager(mock_client)
+
 
 @pytest.mark.asyncio
 async def test_consolidation_switch_ports(data_fetch_manager, mock_client):
@@ -41,30 +47,36 @@ async def test_consolidation_switch_ports(data_fetch_manager, mock_client):
         "devices": [{"serial": switch_serial, "productType": "switch"}],
         "appliance_uplink_statuses": [],
         "sensor_readings": [],
-        "switch_ports_statuses": [
-            {"serial": switch_serial, "ports": switch_ports}
-        ]
+        "switch_ports_statuses": [{"serial": switch_serial, "ports": switch_ports}],
     }
     data_fetch_manager._async_fetch_initial_data = AsyncMock(return_value=mock_initial)
     data_fetch_manager._fetch_batch_camera_analytics = AsyncMock(return_value={})
-    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(return_value=[])
+    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(
+        return_value=[]
+    )
 
     # Spy on strategy.build_device_tasks
-    strategy_spy = MagicMock(wraps=data_fetch_manager.switch_strategy.build_device_tasks)
+    strategy_spy = MagicMock(
+        wraps=data_fetch_manager.switch_strategy.build_device_tasks
+    )
     data_fetch_manager.switch_strategy.build_device_tasks = strategy_spy
 
     # 2. Execute get_all_data
-    with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_network_data", return_value={"appliance_traffic": {}, "vlans": {}}):
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_network_data",
+        return_value={"appliance_traffic": {}, "vlans": {}},
+    ):
         result = await data_fetch_manager.get_all_data()
 
     # 3. Assertions
     # Ensure build_device_tasks was called with the batch data
     strategy_spy.assert_called()
     call_args = strategy_spy.call_args
-    assert f"ports_statuses_{switch_serial}" in call_args[0][2] # detail_data parameter
+    assert f"ports_statuses_{switch_serial}" in call_args[0][2]  # detail_data parameter
 
     # Ensure the device has the ports statuses
     assert result["devices"][0].ports_statuses == switch_ports
+
 
 @pytest.mark.asyncio
 async def test_consolidation_camera_analytics(data_fetch_manager, mock_client):
@@ -79,21 +91,30 @@ async def test_consolidation_camera_analytics(data_fetch_manager, mock_client):
         "devices": [{"serial": camera_serial, "productType": "camera"}],
         "appliance_uplink_statuses": [],
         "sensor_readings": [],
-        "switch_ports_statuses": []
+        "switch_ports_statuses": [],
     }
     data_fetch_manager._async_fetch_initial_data = AsyncMock(return_value=mock_initial)
 
     # Mock batch analytics fetch
     mock_analytics = {f"camera_analytics_{camera_serial}": camera_analytics}
-    data_fetch_manager._fetch_batch_camera_analytics = AsyncMock(return_value=mock_analytics)
-    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(return_value=[])
+    data_fetch_manager._fetch_batch_camera_analytics = AsyncMock(
+        return_value=mock_analytics
+    )
+    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(
+        return_value=[]
+    )
 
     # Spy on strategy.build_device_tasks
-    strategy_spy = MagicMock(wraps=data_fetch_manager.camera_strategy.build_device_tasks)
+    strategy_spy = MagicMock(
+        wraps=data_fetch_manager.camera_strategy.build_device_tasks
+    )
     data_fetch_manager.camera_strategy.build_device_tasks = strategy_spy
 
     # 2. Execute
-    with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_network_data", return_value={"appliance_traffic": {}, "vlans": {}}):
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_network_data",
+        return_value={"appliance_traffic": {}, "vlans": {}},
+    ):
         result = await data_fetch_manager.get_all_data()
 
     # 3. Assertions
@@ -102,6 +123,7 @@ async def test_consolidation_camera_analytics(data_fetch_manager, mock_client):
     assert f"camera_analytics_{camera_serial}" in call_args[0][2]
     assert result["devices"][0].analytics == camera_analytics
 
+
 @pytest.mark.asyncio
 async def test_consolidation_clients(data_fetch_manager, mock_client):
     """Test that device clients are derived from network clients."""
@@ -109,7 +131,7 @@ async def test_consolidation_clients(data_fetch_manager, mock_client):
     device_serial = "Q789"
     mock_clients = [
         {"mac": "AA:BB:CC:DD:EE:FF", "recentDeviceSerial": device_serial},
-        {"mac": "11:22:33:44:55:66", "recentDeviceSerial": "OTHER_SERIAL"}
+        {"mac": "11:22:33:44:55:66", "recentDeviceSerial": "OTHER_SERIAL"},
     ]
 
     mock_initial = {
@@ -118,20 +140,27 @@ async def test_consolidation_clients(data_fetch_manager, mock_client):
         "devices": [{"serial": device_serial, "productType": "wireless"}],
         "appliance_uplink_statuses": [],
         "sensor_readings": [],
-        "switch_ports_statuses": []
+        "switch_ports_statuses": [],
     }
     data_fetch_manager._async_fetch_initial_data = AsyncMock(return_value=mock_initial)
     data_fetch_manager._fetch_batch_camera_analytics = AsyncMock(return_value={})
 
     # Mock network client fetch
-    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(return_value=mock_clients)
+    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(
+        return_value=mock_clients
+    )
 
     # Spy on derive_device_clients
-    derive_spy = MagicMock(wraps=data_fetch_manager.client_fetcher.derive_device_clients)
+    derive_spy = MagicMock(
+        wraps=data_fetch_manager.client_fetcher.derive_device_clients
+    )
     data_fetch_manager.client_fetcher.derive_device_clients = derive_spy
 
     # 2. Execute
-    with patch("custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_network_data", return_value={"appliance_traffic": {}, "vlans": {}}):
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_network_data",
+        return_value={"appliance_traffic": {}, "vlans": {}},
+    ):
         result = await data_fetch_manager.get_all_data()
 
     # 3. Assertions


### PR DESCRIPTION
Fixed line length violations in `custom_components/meraki_ha/core/api/endpoints/network.py` and `tests/core/coordinator_helpers/test_consolidation.py` to satisfy `ruff` requirements. Verified with `run_checks.sh`.

---
*PR created automatically by Jules for task [18000901690591942692](https://jules.google.com/task/18000901690591942692) started by @brewmarsh*