### PR TITLE
Complete Migration of Data Fetcher Tests to Strategy Suites

### DIFF
--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -1,6 +1,6 @@
 """Test ApplianceFetchStrategy."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,6 +18,7 @@ from custom_components.meraki_ha.core.fetch_strategies.appliance import (
 def mock_client():
     """Fixture for a mock Meraki API client."""
     client = MagicMock()
+    # Mock run_with_semaphore to just return the coroutine/call
     client.run_with_semaphore.side_effect = lambda x: x
     return client
 
@@ -39,6 +40,7 @@ def strategy(mock_client, disabled_features):
         enable_traffic_shaping=False,
     )
 
+
 def test_build_network_tasks_skips_disabled(strategy, disabled_features):
     """Test that build_network_tasks skips disabled features."""
     network_id = "net1"
@@ -46,22 +48,70 @@ def test_build_network_tasks_skips_disabled(strategy, disabled_features):
     disabled_features.add(f"vlans_{network_id}")
 
     tasks = {}
-    with patch("asyncio.create_task", side_effect=lambda x: x):
-        strategy.build_network_tasks(network_id, tasks)
+    strategy.build_network_tasks(network_id, tasks)
 
     assert f"traffic_{network_id}" not in tasks
     assert f"vlans_{network_id}" not in tasks
+
 
 def test_build_network_tasks_includes_enabled(strategy, disabled_features):
     """Test that build_network_tasks includes enabled features."""
     network_id = "net1"
 
     tasks = {}
-    with patch("asyncio.create_task", side_effect=lambda x: x):
-        strategy.build_network_tasks(network_id, tasks)
+    strategy.build_network_tasks(network_id, tasks)
 
     assert f"traffic_{network_id}" in tasks
     assert f"vlans_{network_id}" in tasks
+    # Verify always-on tasks
+    assert f"appliance_ports_{network_id}" in tasks
+    assert f"content_filtering_{network_id}" in tasks
+
+
+def test_build_network_tasks_respects_feature_flags(mock_client, disabled_features):
+    """Test that build_network_tasks respects boolean feature flags."""
+    network_id = "net1"
+
+    # All enabled
+    strategy_enabled = ApplianceFetchStrategy(
+        client=mock_client,
+        _disabled_features=disabled_features,
+        enable_vpn_management=True,
+        enable_firewall_rules=True,
+        enable_traffic_shaping=True,
+    )
+    tasks = {}
+    strategy_enabled.build_network_tasks(network_id, tasks)
+    assert f"vpn_status_{network_id}" in tasks
+    assert f"l3_firewall_rules_{network_id}" in tasks
+    assert f"traffic_shaping_{network_id}" in tasks
+
+    # All disabled
+    strategy_disabled = ApplianceFetchStrategy(
+        client=mock_client,
+        _disabled_features=disabled_features,
+        enable_vpn_management=False,
+        enable_firewall_rules=False,
+        enable_traffic_shaping=False,
+    )
+    tasks = {}
+    strategy_disabled.build_network_tasks(network_id, tasks)
+    assert f"vpn_status_{network_id}" not in tasks
+    assert f"l3_firewall_rules_{network_id}" not in tasks
+    assert f"traffic_shaping_{network_id}" not in tasks
+
+
+def test_build_device_tasks(strategy):
+    """Test that build_device_tasks adds correct tasks."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    mock_device.network_id = "NET1"
+    tasks = {}
+
+    strategy.build_device_tasks(mock_device, tasks)
+
+    assert f"appliance_settings_{mock_device.serial}" in tasks
+
 
 def test_process_network_traffic_disables_on_error(strategy, disabled_features):
     """Test that process_network_traffic disables the feature on error."""
@@ -75,6 +125,7 @@ def test_process_network_traffic_disables_on_error(strategy, disabled_features):
     assert key in disabled_features
     assert appliance_traffic[network_id]["error"] == "disabled"
 
+
 def test_process_network_vlans_disables_on_vlan_error(strategy, disabled_features):
     """Test that process_network_vlans disables the feature on MerakiVlanError."""
     network_id = "net1"
@@ -86,6 +137,7 @@ def test_process_network_vlans_disables_on_vlan_error(strategy, disabled_feature
 
     assert key in disabled_features
     assert vlan_by_network[network_id] == []
+
 
 def test_process_network_vlans_disables_on_vlans_disabled_error(
     strategy, disabled_features
@@ -100,3 +152,36 @@ def test_process_network_vlans_disables_on_vlans_disabled_error(
 
     assert key in disabled_features
     assert vlan_by_network[network_id] == []
+
+
+def test_process_device_details_ports(strategy):
+    """Test processing device details for appliance ports."""
+    mock_device = MagicMock()
+    mock_device.network_id = "net1"
+    detail_data = {
+        "appliance_ports_net1": [
+            {"number": 1, "enabled": True},
+            {"number": 2, "enabled": False},
+        ]
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    assert len(mock_device.appliance_ports) == 2
+    assert mock_device.appliance_ports[0].number == 1
+    assert mock_device.appliance_ports[1].enabled is False
+
+
+def test_process_device_details_settings(strategy):
+    """Test processing device details for appliance settings."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    detail_data = {
+        "appliance_settings_SERIAL1": {
+            "dynamicDns": {"enabled": True, "prefix": "test"}
+        }
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    assert mock_device.dynamic_dns == {"enabled": True, "prefix": "test"}

--- a/tests/core/fetch_strategies/test_camera_strategy.py
+++ b/tests/core/fetch_strategies/test_camera_strategy.py
@@ -1,0 +1,128 @@
+"""Test CameraFetchStrategy."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.core.fetch_strategies.camera import (
+    CameraFetchStrategy,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Fixture for a mock Meraki API client."""
+    client = MagicMock()
+    # Mock run_with_semaphore to just return the coroutine/call
+    client.run_with_semaphore.side_effect = lambda x: x
+    return client
+
+
+@pytest.fixture
+def disabled_features():
+    """Fixture for the disabled features set."""
+    return set()
+
+
+@pytest.fixture
+def strategy(mock_client, disabled_features):
+    """Fixture for the CameraFetchStrategy."""
+    return CameraFetchStrategy(
+        client=mock_client,
+        _disabled_features=disabled_features,
+    )
+
+
+def test_build_device_tasks(strategy):
+    """Test that build_device_tasks adds camera-specific tasks."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    tasks = {}
+
+    strategy.build_device_tasks(mock_device, tasks)
+
+    assert f"video_settings_{mock_device.serial}" in tasks
+    assert f"sense_settings_{mock_device.serial}" in tasks
+    assert f"camera_analytics_{mock_device.serial}" in tasks
+
+
+def test_build_device_tasks_skips_analytics_if_in_detail_data(strategy):
+    """Test that build_device_tasks skips analytics if already in detail_data."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    tasks = {}
+    detail_data = {f"camera_analytics_{mock_device.serial}": [{"some": "data"}]}
+
+    strategy.build_device_tasks(mock_device, tasks, detail_data=detail_data)
+
+    assert f"video_settings_{mock_device.serial}" in tasks
+    assert f"sense_settings_{mock_device.serial}" in tasks
+    assert f"camera_analytics_{mock_device.serial}" not in tasks
+
+
+def test_process_device_details_video_settings(strategy):
+    """Test processing device details for camera video settings."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    key = f"video_settings_{mock_device.serial}"
+    detail_data = {
+        key: {
+            "rtsp_url": "rtsp://test.com/stream",
+            "rtspServerEnabled": True,
+        }
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    assert mock_device.video_settings == detail_data[key]
+    assert mock_device.rtsp_url == "rtsp://test.com/stream"
+
+
+def test_process_device_details_sense_settings(strategy):
+    """Test processing device details for camera sense settings."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    key = f"sense_settings_{mock_device.serial}"
+    detail_data = {
+        key: {
+            "senseEnabled": True,
+        }
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    assert mock_device.sense_settings == detail_data[key]
+
+
+def test_process_device_details_analytics(strategy):
+    """Test processing device details for camera analytics."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    key = f"camera_analytics_{mock_device.serial}"
+    detail_data = {
+        key: [{"zoneId": "1", "entrances": 5}]
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    assert mock_device.analytics == detail_data[key]
+
+
+def test_process_device_details_fallback_to_prev(strategy):
+    """Test processing device details falls back to previous data."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    detail_data = {}
+    prev_device = {
+        "video_settings": {"rtsp_url": "rtsp://prev.com"},
+        "rtsp_url": "rtsp://prev.com",
+        "sense_settings": {"sense": "prev"},
+        "analytics": [{"prev": "data"}],
+    }
+
+    strategy.process_device_details(mock_device, detail_data, prev_device)
+
+    assert mock_device.video_settings == prev_device["video_settings"]
+    assert mock_device.rtsp_url == prev_device["rtsp_url"]
+    assert mock_device.sense_settings == prev_device["sense_settings"]
+    assert mock_device.analytics == prev_device["analytics"]

--- a/tests/core/fetch_strategies/test_switch_strategy.py
+++ b/tests/core/fetch_strategies/test_switch_strategy.py
@@ -1,0 +1,84 @@
+"""Test SwitchFetchStrategy."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.core.fetch_strategies.switch import (
+    SwitchFetchStrategy,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Fixture for a mock Meraki API client."""
+    client = MagicMock()
+    # Mock run_with_semaphore to just return the coroutine/call
+    client.run_with_semaphore.side_effect = lambda x: x
+    return client
+
+
+@pytest.fixture
+def disabled_features():
+    """Fixture for the disabled features set."""
+    return set()
+
+
+@pytest.fixture
+def strategy(mock_client, disabled_features):
+    """Fixture for the SwitchFetchStrategy."""
+    return SwitchFetchStrategy(
+        client=mock_client,
+        _disabled_features=disabled_features,
+    )
+
+
+def test_build_device_tasks(strategy):
+    """Test that build_device_tasks adds switch-specific tasks."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    tasks = {}
+
+    strategy.build_device_tasks(mock_device, tasks)
+
+    assert f"ports_statuses_{mock_device.serial}" in tasks
+
+
+def test_build_device_tasks_skips_if_in_detail_data(strategy):
+    """Test that build_device_tasks skips tasks if already in detail_data."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    tasks = {}
+    detail_data = {f"ports_statuses_{mock_device.serial}": [{"portId": "1"}]}
+
+    strategy.build_device_tasks(mock_device, tasks, detail_data=detail_data)
+
+    assert f"ports_statuses_{mock_device.serial}" not in tasks
+
+
+def test_process_device_details(strategy):
+    """Test processing device details for switch ports statuses."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    key = f"ports_statuses_{mock_device.serial}"
+    detail_data = {
+        key: [{"portId": "1", "status": "Connected"}]
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    assert mock_device.ports_statuses == detail_data[key]
+
+
+def test_process_device_details_fallback_to_prev(strategy):
+    """Test processing device details falls back to previous data."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    detail_data = {}
+    prev_device = {
+        "ports_statuses": [{"portId": "1", "status": "Disconnected"}]
+    }
+
+    strategy.process_device_details(mock_device, detail_data, prev_device)
+
+    assert mock_device.ports_statuses == prev_device["ports_statuses"]

--- a/tests/core/fetch_strategies/test_wireless_strategy.py
+++ b/tests/core/fetch_strategies/test_wireless_strategy.py
@@ -1,0 +1,71 @@
+"""Test WirelessFetchStrategy."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.meraki_ha.core.fetch_strategies.wireless import (
+    WirelessFetchStrategy,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Fixture for a mock Meraki API client."""
+    client = MagicMock()
+    # Mock run_with_semaphore to just return the coroutine/call
+    client.run_with_semaphore.side_effect = lambda x: x
+    return client
+
+
+@pytest.fixture
+def disabled_features():
+    """Fixture for the disabled features set."""
+    return set()
+
+
+@pytest.fixture
+def strategy(mock_client, disabled_features):
+    """Fixture for the WirelessFetchStrategy."""
+    return WirelessFetchStrategy(
+        client=mock_client,
+        _disabled_features=disabled_features,
+    )
+
+
+def test_build_network_tasks(strategy, mock_client):
+    """Test that build_network_tasks calls the correct client methods."""
+    network_id = "net1"
+    product_types = ["wireless"]
+    tasks = {}
+    mock_client.wireless.get_network_detail_tasks.return_value = {"task1": "coro1"}
+
+    strategy.build_network_tasks(network_id, product_types, tasks)
+
+    mock_client.wireless.get_network_detail_tasks.assert_called_once_with(
+        network_id, product_types
+    )
+    assert "task1" in tasks
+
+
+@patch("custom_components.meraki_ha.core.fetch_strategies.wireless.parse_wireless_data")
+def test_process_network_data(mock_parse, strategy):
+    """Test that process_network_data calls parse_wireless_data and updates results."""
+    network_id = "net1"
+    detail_data = {"clients": [{"id": "c1"}]}
+    previous_data = {}
+    processed_data = {}
+
+    mock_parse.return_value = {
+        "ssids": [{"name": "SSID1"}],
+        "wireless_settings": {"setting1": "val1"},
+        "rf_profiles": {"profile1": "data1"},
+    }
+
+    strategy.process_network_data(
+        network_id, detail_data, previous_data, processed_data
+    )
+
+    assert processed_data["ssids"] == [{"name": "SSID1"}]
+    assert processed_data["wireless_settings"] == {"setting1": "val1"}
+    assert processed_data["rf_profiles"] == {"profile1": "data1"}


### PR DESCRIPTION
This PR completes the migration of data fetcher tests to the specific strategy test suites, as part of the v2.3.0 milestone.

Key changes:
- Comprehensive test coverage for `ApplianceFetchStrategy`, including feature flags for VPN, Firewall, and Traffic Shaping.
- New test files for `CameraFetchStrategy`, `SwitchFetchStrategy`, and `WirelessFetchStrategy`.
- Resolution of E501 linting failures by applying multi-line formatting.
- Prevention of naming collisions in the test suite by adopting the `_strategy.py` suffix.
- All strategy-specific logic previously in the legacy `test_data_fetcher.py` is now fully covered in the dedicated strategy suites.

Fixes #1745

---
*PR created automatically by Jules for task [2262709512841756618](https://jules.google.com/task/2262709512841756618) started by @brewmarsh*