### PR TITLE
Fix Missing Options in Select Entities and Add RF Profile Support

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from ...const_conf import (
     CONF_ENABLE_NETWORK_SENSORS,
     CONF_ENABLE_TRAFFIC_SHAPING,
+    CONF_ENABLE_VPN_MANAGEMENT,
     CONF_ENABLE_VLAN_SENSORS,
 )
 from ...sensor.network.network_clients import MerakiNetworkClientsSensor
@@ -45,6 +46,11 @@ class NetworkHandler(BaseHandler):
 
     async def discover_entities(self) -> AsyncIterator[Entity]:
         """Discover network-level entities."""
+        from ...meraki_select.meraki_content_filtering import (
+            MerakiContentFilteringSelect,
+        )
+        from ...meraki_select.vpn import MerakiVpnSelect
+
         # Check if network sensors are enabled
         if not self._config_entry.options.get(CONF_ENABLE_NETWORK_SENSORS, True):
             _LOGGER.debug("Network sensors are disabled.")
@@ -56,6 +62,21 @@ class NetworkHandler(BaseHandler):
             return
 
         for network in networks:
+            # Select Entities
+            yield MerakiContentFilteringSelect(
+                self._coordinator,
+                self._coordinator.api,
+                self._config_entry,
+                network,
+            )
+            if self._config_entry.options.get(CONF_ENABLE_VPN_MANAGEMENT):
+                yield MerakiVpnSelect(
+                    self._coordinator,
+                    self._coordinator.api,
+                    self._config_entry,
+                    network,
+                )
+
             # Network Clients Sensor
             yield MerakiNetworkClientsSensor(
                 coordinator=self._coordinator,

--- a/custom_components/meraki_ha/discovery/handlers/ssid.py
+++ b/custom_components/meraki_ha/discovery/handlers/ssid.py
@@ -69,6 +69,7 @@ class SSIDHandler(BaseHandler):
 
     async def discover_entities(self) -> AsyncIterator[Entity]:
         """Discover entities for all SSIDs."""
+        from ...meraki_select.rf_profile import MerakiRFProfileSelect
         from ...switch.meraki_ssid_device_switch import (
             MerakiSSIDBroadcastSwitch,
             MerakiSSIDEnabledSwitch,
@@ -173,3 +174,11 @@ class SSIDHandler(BaseHandler):
                     self._config_entry,
                     ssid,
                 )
+
+            # RF Profile Select
+            yield MerakiRFProfileSelect(
+                self._coordinator,
+                self._meraki_client,
+                self._config_entry,
+                ssid,
+            )

--- a/custom_components/meraki_ha/meraki_select/__init__.py
+++ b/custom_components/meraki_ha/meraki_select/__init__.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from ..const import DOMAIN
-from ..const_conf import CONF_ENABLE_VPN_MANAGEMENT
-from .meraki_content_filtering import MerakiContentFilteringSelect
-from .vpn import MerakiVpnSelect
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,29 +21,19 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Meraki select entities."""
+    if config_entry.entry_id not in hass.data[DOMAIN]:
+        return
+
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = entry_data["coordinator"]
-    meraki_client = coordinator.api
+    discovery_service = entry_data["discovery_service"]
 
-    if coordinator.data:
-        select_entities: list[Any] = []
-        for network in coordinator.data.get("networks", []):
-            select_entities.append(
-                MerakiContentFilteringSelect(
-                    coordinator,
-                    meraki_client,
-                    config_entry,
-                    network,
-                )
-            )
-            if config_entry.options.get(CONF_ENABLE_VPN_MANAGEMENT):
-                select_entities.append(
-                    MerakiVpnSelect(
-                        coordinator,
-                        meraki_client,
-                        config_entry,
-                        network,
-                    )
-                )
+    # Entities have already been discovered in __init__.py
+    select_entities = [
+        entity
+        for entity in discovery_service.all_entities
+        if isinstance(entity, SelectEntity)
+    ]
 
+    if select_entities:
+        _LOGGER.debug("Adding %d select entities", len(select_entities))
         async_add_entities(select_entities)

--- a/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
+++ b/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
@@ -45,7 +45,10 @@ class MerakiContentFilteringSelect(CoordinatorEntity, SelectEntity):
         )
 
         self._attr_unique_id = f"meraki-network-{self._network_id}-content-filtering"
+        self._attr_options = []
         self._update_internal_state()
+
+    # ### Entity Logic
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -68,21 +71,25 @@ class MerakiContentFilteringSelect(CoordinatorEntity, SelectEntity):
 
     def _update_internal_state(self) -> None:
         """Update the internal state of the select entity."""
+        # ### Data Mapping
+        options = []
+        current_option = None
+
         if self.coordinator.data and self.coordinator.data.get("content_filtering"):
             content_filtering = self.coordinator.data["content_filtering"].get(
                 self._network_id
             )
             if content_filtering:
-                self._attr_current_option = content_filtering.get(
+                current_option = content_filtering.get(
                     "urlCategoryListSize", "topSites"
                 )
-                self._attr_options = [
+                options = [
                     "topSites",
                     "fullList",
                 ]  # This should be dynamic
-        else:
-            self._attr_current_option = None
-            self._attr_options = []
+
+        self._attr_current_option = current_option
+        self._attr_options = options
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -1,0 +1,138 @@
+"""Select entity for controlling Meraki RF Profiles."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from ..const import DOMAIN
+from ..coordinator import MerakiDataUpdateCoordinator
+from ..core.api.client import MerakiAPIClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
+    """Representation of a Meraki RF Profile select entity."""
+
+    entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        meraki_client: MerakiAPIClient,
+        config_entry: ConfigEntry,
+        ssid_data: dict[str, Any],
+    ) -> None:
+        """Initialize the Meraki RF Profile select entity."""
+        super().__init__(coordinator)
+        self._meraki_client = meraki_client
+        self._config_entry = config_entry
+        self._ssid_data = ssid_data
+        self._network_id = ssid_data["networkId"]
+        self._ssid_number = ssid_data["number"]
+        self._ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+
+        self.entity_description = SelectEntityDescription(
+            key=f"rf_profile_{self._network_id}_{self._ssid_number}",
+            name="RF Profile",
+            icon="mdi:wifi-cog",
+        )
+
+        self._attr_unique_id = f"meraki-ssid-{self._network_id}-{self._ssid_number}-rf-profile"
+        self._attr_options = []
+        self._update_internal_state()
+
+    # ### Entity Logic
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device information to link this entity to the SSID 'device'."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"meraki_ssid_{self._network_id}_{self._ssid_number}")},
+            name=f"SSID {self._ssid_name}",
+            manufacturer="Cisco Meraki",
+            via_device=(DOMAIN, self._network_id),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return super().available and self.coordinator.data is not None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_internal_state()
+        self.async_write_ha_state()
+
+    def _update_internal_state(self) -> None:
+        """Update the internal state of the select entity."""
+        # ### Data Mapping
+        options = ["None"]
+        current_option = "None"
+
+        if self.coordinator.data:
+            # Get available RF profiles for this network
+            rf_profiles = self.coordinator.data.get("rf_profiles", {}).get(
+                self._network_id, []
+            )
+            profile_map = {p["name"]: p["id"] for p in rf_profiles if "name" in p and "id" in p}
+            options.extend(sorted(profile_map.keys()))
+
+            # Get current RF profile for this SSID
+            # We need to find the SSID in the latest coordinator data
+            current_ssid = self.coordinator.get_ssid(self._network_id, int(self._ssid_number))
+            if current_ssid:
+                current_profile_id = current_ssid.get("rfProfileId")
+                if current_profile_id:
+                    # Find name from ID
+                    for name, prof_id in profile_map.items():
+                        if prof_id == current_profile_id:
+                            current_option = name
+                            break
+
+        self._attr_current_option = current_option
+        self._attr_options = options
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        # ### Data Mapping
+        rf_profiles = self.coordinator.data.get("rf_profiles", {}).get(
+            self._network_id, []
+        )
+        profile_id = None
+        if option != "None":
+            profile_id = next(
+                (p["id"] for p in rf_profiles if p.get("name") == option), None
+            )
+
+        try:
+            # Preparing update call
+            update_params = {"rfProfileId": profile_id}
+            await self._meraki_client.wireless.update_network_wireless_ssid(
+                network_id=self._network_id,
+                number=self._ssid_number,
+                **update_params,
+            )
+            self._attr_current_option = option
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
+        except Exception as e:
+            _LOGGER.error(
+                "Failed to set RF profile to '%s' for SSID %s on network %s: %s",
+                option,
+                self._ssid_number,
+                self._network_id,
+                e,
+            )
+            raise HomeAssistantError(
+                f"Failed to set RF profile to '{option}': {e}"
+            ) from e

--- a/custom_components/meraki_ha/meraki_select/vpn.py
+++ b/custom_components/meraki_ha/meraki_select/vpn.py
@@ -45,7 +45,10 @@ class MerakiVpnSelect(CoordinatorEntity, SelectEntity):
         )
 
         self._attr_unique_id = f"meraki-network-{self._network_id}-vpn"
+        self._attr_options = []
         self._update_internal_state()
+
+    # ### Entity Logic
 
     @property
     def device_info(self) -> DeviceInfo | None:
@@ -68,14 +71,18 @@ class MerakiVpnSelect(CoordinatorEntity, SelectEntity):
 
     def _update_internal_state(self) -> None:
         """Update the internal state of the select entity."""
+        # ### Data Mapping
+        options = []
+        current_option = None
+
         if self.coordinator.data and self.coordinator.data.get("vpn_status"):
             vpn_status = self.coordinator.data["vpn_status"].get(self._network_id)
             if vpn_status and isinstance(vpn_status, MerakiVpn):
-                self._attr_current_option = vpn_status.mode
-                self._attr_options = ["none", "spoke", "hub"]
-        else:
-            self._attr_current_option = None
-            self._attr_options = []
+                current_option = vpn_status.mode
+                options = ["none", "spoke", "hub"]
+
+        self._attr_current_option = current_option
+        self._attr_options = options
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/meraki_ha/translations/en.json
+++ b/custom_components/meraki_ha/translations/en.json
@@ -203,6 +203,17 @@
       "meraki_ssid_name": {
         "name": "SSID Name"
       }
+    },
+    "select": {
+      "rf_profile": {
+        "name": "RF Profile"
+      },
+      "content_filtering": {
+        "name": "Content Filtering Policy"
+      },
+      "vpn_mode": {
+        "name": "VPN Mode"
+      }
     }
   }
 }

--- a/tests/meraki_select/test_rf_profile_select.py
+++ b/tests/meraki_select/test_rf_profile_select.py
@@ -1,0 +1,143 @@
+"""Test the Meraki RF Profile select entity."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.const_conf import CONF_ENABLE_SSID_SENSORS
+from tests.const import MOCK_NETWORK
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Fixture for a mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        options={CONF_ENABLE_SSID_SENSORS: True},
+        entry_id="test_entry",
+    )
+
+
+@pytest.fixture
+def mock_meraki_client() -> MagicMock:
+    """Fixture for a mocked MerakiAPIClient."""
+    client = MagicMock()
+    # Mock the wireless object
+    client.wireless = MagicMock()
+    client.wireless.update_network_wireless_ssid = AsyncMock()
+    client.unregister_webhook = AsyncMock(return_value=None)
+    client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
+        return_value={"categories": []}
+    )
+
+    return client
+
+
+@pytest.fixture
+def mock_data_fetch_manager() -> AsyncMock:
+    """Fixture for a mocked DataFetchManager."""
+    manager = AsyncMock()
+    manager.get_all_data = AsyncMock(
+        return_value={
+            "devices": [],
+            "networks": [MOCK_NETWORK],
+            "ssids": [
+                {
+                    "networkId": MOCK_NETWORK.id,
+                    "number": 1,
+                    "name": "Test SSID",
+                    "rfProfileId": "p1",
+                }
+            ],
+            "rf_profiles": {
+                MOCK_NETWORK.id: [
+                    {"id": "p1", "name": "Profile 1"},
+                    {"id": "p2", "name": "Profile 2"},
+                ]
+            },
+            "vpn_status": {},
+            "clients": [],
+            "vlans": {},
+            "appliance_uplink_statuses": [],
+            "appliance_traffic": {},
+            "content_filtering": {},
+        }
+    )
+    return manager
+
+
+async def test_rf_profile_select_entity(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_meraki_client: AsyncMock,
+    mock_data_fetch_manager: AsyncMock,
+) -> None:
+    """Test the RF Profile select entity is created and functional."""
+    assert await async_setup_component(hass, "http", {})
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.meraki_ha.coordinator.ApiClient",
+            return_value=mock_meraki_client,
+        ),
+        patch(
+            "custom_components.meraki_ha.coordinator.DataFetchManager",
+            return_value=mock_data_fetch_manager,
+        ),
+        patch("custom_components.meraki_ha.async_register_webhook", return_value=None),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Find the entity by searching the registry
+        entity_registry = er.async_get(hass)
+        entity_id = entity_registry.async_get_entity_id(
+            "select", DOMAIN, f"meraki-ssid-{MOCK_NETWORK.id}-1-rf-profile"
+        )
+
+        assert entity_id is not None
+
+        # Verify state
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == "Profile 1"
+        assert "Profile 1" in state.attributes["options"]
+        assert "Profile 2" in state.attributes["options"]
+        assert "None" in state.attributes["options"]
+
+        # Test selection
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "Profile 2"},
+            blocking=True,
+        )
+
+        # Verify API called
+        mock_meraki_client.wireless.update_network_wireless_ssid.assert_called_with(
+            network_id=MOCK_NETWORK.id,
+            number=1,
+            rfProfileId="p2",
+        )
+
+        # Test selection of "None"
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": entity_id, "option": "None"},
+            blocking=True,
+        )
+
+        # Verify API called with None
+        mock_meraki_client.wireless.update_network_wireless_ssid.assert_called_with(
+            network_id=MOCK_NETWORK.id,
+            number=1,
+            rfProfileId=None,
+        )


### PR DESCRIPTION
This PR addresses the issue of missing options in `SelectEntity` entities and implements a new `MerakiRFProfileSelect` entity for wireless networks.

Key changes:
- Safeguarded `MerakiContentFilteringSelect` and `MerakiVpnSelect` by initializing `_attr_options` in `__init__`.
- Robustified `_update_internal_state` to ensure options are always populated from coordinator data.
- Added `MerakiRFProfileSelect` which allows users to select an RF Profile for each SSID.
- Refactored the `meraki_select` platform to use a discovery-based approach, consistent with other platforms in the integration.
- Added comprehensive unit tests for the new RF Profile select entity.
- Updated `en.json` translations to include the new select entities.

Fixes #1791

---
*PR created automatically by Jules for task [1650272511551206777](https://jules.google.com/task/1650272511551206777) started by @brewmarsh*