### PR TITLE
Implement SafeDict Sanitization in DataFetcher

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -76,7 +76,27 @@ class DataFetchManager:
                 asyncio.gather(*tasks.values(), return_exceptions=True),
                 timeout=timeout,
             )
-            return dict(zip(tasks.keys(), results, strict=True))
+            # <SanitizationLogic>
+            # After asyncio.gather returns, iterate through the results.
+            # If an item is an instance of Exception, log it and replace it with None.
+            # Implements a "Type Filter" that only permits dict, list, or None.
+            sanitized_results = {}
+            for key, result in zip(tasks.keys(), results, strict=True):
+                if isinstance(result, Exception):
+                    _LOGGER.error("Error fetching %s during %s: %s", key, label, result)
+                    sanitized_results[key] = None
+                elif isinstance(result, (dict, list)) or result is None:
+                    sanitized_results[key] = result
+                else:
+                    _LOGGER.debug(
+                        "Filtering out unexpected type %s for %s during %s",
+                        type(result),
+                        key,
+                        label,
+                    )
+                    sanitized_results[key] = None
+            return sanitized_results
+            # </SanitizationLogic>
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout during %s. Potential semaphore deadlock.", label)
             # Log specific keys to identify which strategy is hanging
@@ -108,7 +128,7 @@ class DataFetchManager:
                 self.client.organization.get_organization_switch_ports_statuses(),
             ),
         }
-        return await self._async_gather_with_timeout(tasks, label="Initial Batch")
+        return await self._async_gather_with_timeout(tasks, label="Initial batch")
 
     async def _fetch_batch_camera_analytics(
         self, devices: list[MerakiDevice]
@@ -127,7 +147,7 @@ class DataFetchManager:
             if serial
         }
 
-        return await self._async_gather_with_timeout(tasks, label="Camera Analytics")
+        return await self._async_gather_with_timeout(tasks, label="Camera analytics")
 
     def _distribute_batch_data(
         self,
@@ -249,12 +269,15 @@ class DataFetchManager:
         initial_results = await self._async_fetch_initial_data()
 
         # 2. Convert to Models
+        # Ensure results are iterable by using 'or []' in case they were sanitized to None
         networks_list = [
-            MerakiNetwork.from_dict(n) for n in initial_results.get("networks", [])
-            if not isinstance(n, Exception)
+            MerakiNetwork.from_dict(n)
+            for n in (initial_results.get("networks") or [])
+            if isinstance(n, dict)
         ]
         devices_list = [
-            MerakiDevice.from_dict(d) for d in initial_results.get("devices", [])
+            MerakiDevice.from_dict(d)
+            for d in (initial_results.get("devices") or [])
             if isinstance(d, dict)
         ]
 
@@ -276,7 +299,7 @@ class DataFetchManager:
             networks_list, devices_list, detail_data_dict
         )
         fetched_detail_data = await self._async_gather_with_timeout(
-            detail_tasks, label="Detailed Device Data"
+            detail_tasks, label="Detailed device data"
         )
         detail_data_dict.update(fetched_detail_data)
 
@@ -287,7 +310,7 @@ class DataFetchManager:
             )
         }
         client_results = await self._async_gather_with_timeout(
-            client_tasks, label="Client Data"
+            client_tasks, label="Client data"
         )
         network_clients = client_results.get("network_clients", [])
         if not isinstance(network_clients, list):

--- a/tests/core/coordinator_helpers/test_data_fetcher_sanitization.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher_sanitization.py
@@ -1,0 +1,111 @@
+"""Tests for the Data Fetch Manager sanitization logic."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
+    DataFetchManager,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Mock the Meraki API client."""
+    client = MagicMock()
+    client._disabled_features = set()
+    client.has_dashboard = True
+    return client
+
+
+@pytest.fixture
+def data_fetch_manager(mock_client):
+    """Fixture for DataFetchManager."""
+    return DataFetchManager(mock_client)
+
+
+@pytest.mark.asyncio
+async def test_async_gather_with_timeout_sanitization(data_fetch_manager):
+    """Test that _async_gather_with_timeout sanitizes exceptions and types."""
+
+    async def success_coro():
+        return {"data": "ok"}
+
+    async def error_coro():
+        raise ValueError("API Error")
+
+    async def invalid_type_coro():
+        return "not a dict or list"
+
+    tasks = {
+        "success": success_coro(),
+        "error": error_coro(),
+        "invalid": invalid_type_coro(),
+        "none": asyncio.sleep(0, result=None),
+    }
+
+    # Act
+    with patch(
+        "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER"
+    ) as mock_logger:
+        results = await data_fetch_manager._async_gather_with_timeout(
+            tasks, label="Test Batch"
+        )
+
+    # Assert
+    assert results["success"] == {"data": "ok"}
+    assert results["error"] is None
+    assert results["invalid"] is None
+    assert results["none"] is None
+
+    # Verify logging
+    mock_logger.error.assert_called()
+    mock_logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_get_all_data_resilience_to_none(data_fetch_manager, mock_client):
+    """Test that get_all_data handles None values for networks and devices."""
+
+    # Simulate sanitization returning None for networks and devices
+    data_fetch_manager._async_fetch_initial_data = AsyncMock(
+        return_value={
+            "networks": None,
+            "devices": None,
+            "organization": {"name": "Test Org"},
+        }
+    )
+
+    data_fetch_manager._fetch_batch_camera_analytics = AsyncMock(
+        return_value={}
+    )
+
+    # Use regular MagicMock to return a string/None instead of a coroutine
+    # since we'll mock _async_gather_with_timeout anyway.
+    data_fetch_manager.client_fetcher.async_fetch_network_clients = MagicMock(
+        return_value="mock_task"
+    )
+
+    data_fetch_manager.client_fetcher.derive_device_clients = MagicMock(return_value={})
+
+    # Act
+    with (
+        patch(
+            "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_appliance_data"
+        ),
+        patch(
+            "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_sensor_data"
+        ),
+        patch.object(data_fetch_manager, "_async_gather_with_timeout", new_callable=AsyncMock) as mock_gather,
+    ):
+        # We need mock_gather to return a dict for the client_results call
+        mock_gather.return_value = {}
+
+        result = await data_fetch_manager.get_all_data()
+
+    # Assert
+    assert result["org_name"] == "Test Org"
+    assert result["networks"] == []
+    assert result["devices"] == []
+    assert result["clients"] == []

--- a/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
@@ -39,7 +39,7 @@ async def test_fetch_initial_data_timeout(data_fetch_manager, mock_client):
             with pytest.raises(asyncio.TimeoutError):
                 await data_fetch_manager._async_fetch_initial_data()
             mock_log_error.assert_called_with(
-                "Timeout during %s. Potential semaphore deadlock.", "Initial Batch"
+                    "Timeout during %s. Potential semaphore deadlock.", "Initial batch"
             )
 
 
@@ -66,7 +66,7 @@ async def test_get_all_data_detailed_timeout(data_fetch_manager, mock_client):
             # It might be called for detailed data first
             mock_log_error.assert_any_call(
                 "Timeout during %s. Potential semaphore deadlock.",
-                "Detailed Device Data",
+                    "Detailed device data",
             )
 
 
@@ -88,5 +88,5 @@ async def test_get_all_data_client_timeout(data_fetch_manager, mock_client):
             with pytest.raises(asyncio.TimeoutError):
                 await data_fetch_manager.get_all_data()
             mock_log_error.assert_called_with(
-                "Timeout during %s. Potential semaphore deadlock.", "Client Data"
+                    "Timeout during %s. Potential semaphore deadlock.", "Client data"
             )


### PR DESCRIPTION
Implemented SafeDict sanitization in `DataFetchManager` to ensure data integrity and prevent crashes from unexpected API response types or exceptions. The solution centralizes sanitization in `_async_gather_with_timeout`, replaces all `Exception` instances with `None` (while logging them), and implements a strict type filter that only permits `dict`, `list`, or `None`. `get_all_data` was updated to be resilient to these `None` values. Additionally, data fetch labels and log messages were updated to follow Home Assistant Sentence Case standards. Verified with new and existing unit tests.

Fixes #1798

---
*PR created automatically by Jules for task [9808599068437484979](https://jules.google.com/task/9808599068437484979) started by @brewmarsh*