### PR TITLE
Implement Task Batching in DataFetcher

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+BATCH_SIZE = 5
+
 
 class DataFetchManager:
     """Class to manage data fetching for the coordinator."""
@@ -60,22 +62,40 @@ class DataFetchManager:
         self.camera_strategy = CameraFetchStrategy(client, self._disabled_features)
 
     async def _async_gather_with_timeout(
-        self,
-        tasks: dict[str, Any],
-        timeout: int = 25,
-        label: str = "Tasks"
+        self, tasks: dict[str, Any], timeout: int = 25, label: str = "Tasks"
     ) -> dict[str, Any]:
-        """Gather tasks with a hard timeout to prevent deadlocks."""
+        """Gather tasks with a hard timeout and batching to prevent API overloading."""
         if not tasks:
             return {}
 
-        _LOGGER.debug("Starting %s: %s items", label, len(tasks))
+        _LOGGER.debug(
+            "Starting %s: %s items in batches of %s", label, len(tasks), BATCH_SIZE
+        )
+
+        async def _execute_batches() -> list[Any]:
+            """Inner coroutine to handle chunked execution."""
+            task_items = list(tasks.items())
+            all_results = []
+            for i in range(0, len(task_items), BATCH_SIZE):
+                if i > 0:
+                    _LOGGER.debug("Cooling down for 1s between %s batches...", label)
+                    await asyncio.sleep(1)
+
+                chunk = dict(task_items[i : i + BATCH_SIZE])
+                _LOGGER.debug(
+                    "Executing %s batch: items %d to %d",
+                    label,
+                    i + 1,
+                    min(i + BATCH_SIZE, len(task_items)),
+                )
+                chunk_results = await asyncio.gather(
+                    *chunk.values(), return_exceptions=True
+                )
+                all_results.extend(chunk_results)
+            return all_results
 
         try:
-            results = await asyncio.wait_for(
-                asyncio.gather(*tasks.values(), return_exceptions=True),
-                timeout=timeout,
-            )
+            results = await asyncio.wait_for(_execute_batches(), timeout=timeout)
             # <SanitizationLogic>
             # After asyncio.gather returns, iterate through the results.
             # If an item is an instance of Exception, log it and replace it with None.

--- a/tests/core/coordinator_helpers/test_data_fetcher.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher.py
@@ -1,5 +1,6 @@
 """Tests for the Data Fetch Manager."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -63,3 +64,27 @@ async def test_get_all_data_includes_switch_ports(data_fetch_manager, mock_clien
     assert result["devices"][0].ports_statuses == [
         {"portId": "1", "status": "Connected"}
     ]
+
+@pytest.mark.asyncio
+async def test_async_gather_with_timeout_batching(data_fetch_manager):
+    """Test that tasks are executed in batches."""
+
+    # Create 12 tasks
+    tasks = {f"task_{i}": AsyncMock(return_value={"id": i})() for i in range(12)}
+
+    # We want to verify that there are sleeps between batches
+    # BATCH_SIZE = 5, so 12 tasks = 3 batches (5, 5, 2)
+    # Expected sleeps: 2 (one after batch 1, one after batch 2)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        results = await data_fetch_manager._async_gather_with_timeout(
+            tasks, label="Test Batching"
+        )
+
+        assert len(results) == 12
+        for i in range(12):
+            assert results[f"task_{i}"] == {"id": i}
+
+        # Verify batching logic
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(1)


### PR DESCRIPTION
Implemented task batching in the `DataFetchManager` to optimize async throughput and prevent Meraki API overloading. Tasks are now executed in chunks of 5 with a 1-second delay between batches. Verified with new and existing tests.

Fixes #1804

---
*PR created automatically by Jules for task [5734253136050851018](https://jules.google.com/task/5734253136050851018) started by @brewmarsh*