### PR TITLE
Robust Validation for Switch Ports

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/organization.py
+++ b/custom_components/meraki_ha/core/api/endpoints/organization.py
@@ -223,8 +223,6 @@ class OrganizationEndpoints:
             organizationId=self._api_client.organization_id,
             total_pages="all",
         )
-        validated = validate_response(statuses)
-        if not isinstance(validated, list):
-            _LOGGER.warning("Organization switch ports statuses did not return a list.")
-            return []
-        return validated
+        res = validate_response(statuses)
+        # Type Normalization: Meraki sometimes returns {} instead of [] for no data
+        return [] if not res else res

--- a/custom_components/meraki_ha/core/api/endpoints/switch.py
+++ b/custom_components/meraki_ha/core/api/endpoints/switch.py
@@ -54,11 +54,9 @@ class SwitchEndpoints:
             self._api_client.dashboard.switch.getDeviceSwitchPortsStatuses,
             serial=serial,
         )
-        validated = validate_response(statuses)
-        if not isinstance(validated, list):
-            _LOGGER.warning("get_device_switch_ports_statuses did not return a list.")
-            return []
-        return validated
+        res = validate_response(statuses)
+        # Type Normalization: Meraki sometimes returns {} instead of [] for no data
+        return [] if not res else res
 
     @handle_meraki_errors
     @async_timed_cache()
@@ -78,11 +76,9 @@ class SwitchEndpoints:
         ports = await self._api_client.run_sync(
             self._api_client.dashboard.switch.getDeviceSwitchPorts, serial=serial
         )
-        validated = validate_response(ports)
-        if not isinstance(validated, list):
-            _LOGGER.warning("get_switch_ports did not return a list.")
-            return []
-        return validated
+        res = validate_response(ports)
+        # Type Normalization: Meraki sometimes returns {} instead of [] for no data
+        return [] if not res else res
 
     @handle_meraki_errors
     async def cycle_device_switch_ports(

--- a/tests/core/api/endpoints/test_switch_normalization.py
+++ b/tests/core/api/endpoints/test_switch_normalization.py
@@ -1,0 +1,58 @@
+"""Tests for Switch Port normalization."""
+
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from custom_components.meraki_ha.core.api.endpoints.organization import OrganizationEndpoints
+from custom_components.meraki_ha.core.api.endpoints.switch import SwitchEndpoints
+
+@pytest.fixture
+def mock_client():
+    """Mock the Meraki API client."""
+    client = MagicMock()
+    client.dashboard = MagicMock()
+    client.run_sync = AsyncMock()
+    client.organization_id = "org123"
+    return client
+
+@pytest.fixture
+def organization_endpoints(mock_client):
+    """Fixture for OrganizationEndpoints."""
+    return OrganizationEndpoints(mock_client)
+
+@pytest.fixture
+def switch_endpoints(mock_client):
+    """Fixture for SwitchEndpoints."""
+    return SwitchEndpoints(mock_client)
+
+@pytest.mark.asyncio
+async def test_get_organization_switch_ports_statuses_normalization(organization_endpoints, mock_client):
+    """Test that {} is normalized to [] for organization switch ports statuses."""
+    # Mock API returning empty dict
+    mock_client.run_sync.return_value = {}
+
+    result = await organization_endpoints.get_organization_switch_ports_statuses()
+
+    assert result == []
+    mock_client.run_sync.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_get_device_switch_ports_statuses_normalization(switch_endpoints, mock_client):
+    """Test that {} is normalized to [] for device switch ports statuses."""
+    # Mock API returning empty dict
+    mock_client.run_sync.return_value = {}
+
+    result = await switch_endpoints.get_device_switch_ports_statuses("serial123")
+
+    assert result == []
+    mock_client.run_sync.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_get_switch_ports_normalization(switch_endpoints, mock_client):
+    """Test that {} is normalized to [] for get_switch_ports."""
+    # Mock API returning empty dict
+    mock_client.run_sync.return_value = {}
+
+    result = await switch_endpoints.get_switch_ports("serial123")
+
+    assert result == []
+    mock_client.run_sync.assert_called_once()


### PR DESCRIPTION
Implemented robust type normalization for Meraki switch port endpoints to handle cases where the API returns `{}` instead of `[]`. This improves the resilience of the integration when no data is available or when the API returns an unexpected format. The changes target both organization-level and device-level switch port status endpoints and include a new test file to verify the normalization logic.

Fixes #1805

---
*PR created automatically by Jules for task [14029337291751284686](https://jules.google.com/task/14029337291751284686) started by @brewmarsh*