### PR TITLE
fix: resolve remaining linting violations

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -11,6 +11,7 @@ from custom_components.meraki_ha.core.utils.api_utils import (
     handle_meraki_errors,
     validate_response,
 )
+
 from ...errors import MerakiVlansDisabledError
 from ..cache import async_timed_cache
 
@@ -54,7 +55,11 @@ class NetworkEndpoints:
             **kwargs,
         )
         validated = validate_response(clients)
-        return cast(list[dict[str, Any]], validated) if isinstance(validated, list) else []
+        return (
+            cast(list[dict[str, Any]], validated)
+            if isinstance(validated, list)
+            else []
+        )
 
     @handle_meraki_errors
     @async_timed_cache(timeout=60)
@@ -69,7 +74,11 @@ class NetworkEndpoints:
             timespan=86400,  # 24 hours
         )
         validated = validate_response(traffic)
-        return cast(list[dict[str, Any]], validated) if isinstance(validated, list) else []
+        return (
+            cast(list[dict[str, Any]], validated)
+            if isinstance(validated, list)
+            else []
+        )
 
     @handle_meraki_errors
     @async_timed_cache(timeout=10)
@@ -80,7 +89,11 @@ class NetworkEndpoints:
             networkId=network_id,
         )
         validated = validate_response(webhooks)
-        return cast(list[dict[str, Any]], validated) if isinstance(validated, list) else []
+        return (
+            cast(list[dict[str, Any]], validated)
+            if isinstance(validated, list)
+            else []
+        )
 
     @handle_meraki_errors
     async def delete_webhook(self, network_id: str, webhook_id: str) -> None:
@@ -111,7 +124,7 @@ class NetworkEndpoints:
         for network in networks:
             network_id = network["id"]
             webhook_name = f"Home Assistant Webhook - {config_entry_id}"
-            
+
             existing = await self.find_webhook_by_name_and_url(
                 network_id, webhook_name, webhook_url
             )
@@ -129,22 +142,24 @@ class NetworkEndpoints:
     async def get_vlan_data(self, network_id: str) -> list[dict[str, Any]]:
         """
         Get VLAN data for a network with fallback and safety logic.
-        
-        This method uses product type verification and safe attribute lookup 
+
+        This method uses product type verification and safe attribute lookup
         to prevent AttributeError crashes and reduce 429 rate-limiting.
         """
         # 1. Product Type Guard: Only appliances (MX) support this endpoint
         networks = await self._api_client.organization.get_organization_networks()
         network = next((n for n in networks if n["id"] == network_id), None)
-        
+
         if network and "appliance" not in network.get("productTypes", []):
-            _LOGGER.debug("Skipping VLAN fetch for non-appliance network %s", network_id)
+            _LOGGER.debug(
+                "Skipping VLAN fetch for non-appliance network %s", network_id
+            )
             return []
 
         # 2. SDK Safety Guard: Check if the appliance module and method exist
         appliance = getattr(self._api_client.dashboard, "appliance", None)
         vlan_method = getattr(appliance, "getNetworkApplianceVlans", None)
-        
+
         if not vlan_method:
             _LOGGER.debug("VLAN method not found in SDK for network %s", network_id)
             return []
@@ -159,7 +174,7 @@ class NetworkEndpoints:
             # Robust extraction logic (Merged from fix/beta)
             if isinstance(validated, list):
                 return cast(list[dict[str, Any]], validated)
-            
+
             if isinstance(validated, dict):
                 # Fallback: Deep-search dictionary values for a list (Fix branch logic)
                 for value in validated.values():
@@ -168,11 +183,14 @@ class NetworkEndpoints:
                 return [validated] # Treat single dict as a list of one
 
             return []
-            
+
         except (meraki.APIError, MerakiVlansDisabledError, AttributeError) as e:
             # Handle specific 400 error indicating VLANs are disabled
             error_str = str(e).lower()
-            if "vlans are not enabled" in error_str or "vlan is not enabled" in error_str:
+            if (
+                "vlans are not enabled" in error_str
+                or "vlan is not enabled" in error_str
+            ):
                 _LOGGER.info("VLANs disabled for network %s (Status 400)", network_id)
             else:
                 _LOGGER.debug("VLAN fetch error for %s: %s", network_id, e)
@@ -187,7 +205,11 @@ class NetworkEndpoints:
             networkId=network_id,
         )
         validated = validate_response(policies)
-        return cast(list[dict[str, Any]], validated) if isinstance(validated, list) else []
+        return (
+            cast(list[dict[str, Any]], validated)
+            if isinstance(validated, list)
+            else []
+        )
 
     @handle_meraki_errors
     async def get_network_events(self, network_id: str, **kwargs) -> dict[str, Any]:

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -269,7 +269,8 @@ class DataFetchManager:
         initial_results = await self._async_fetch_initial_data()
 
         # 2. Convert to Models
-        # Ensure results are iterable by using 'or []' in case they were sanitized to None
+        # Ensure results are iterable by using 'or []' in case they were
+        # sanitized to None
         networks_list = [
             MerakiNetwork.from_dict(n)
             for n in (initial_results.get("networks") or [])

--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 from ...const_conf import (
     CONF_ENABLE_NETWORK_SENSORS,
     CONF_ENABLE_TRAFFIC_SHAPING,
-    CONF_ENABLE_VPN_MANAGEMENT,
     CONF_ENABLE_VLAN_SENSORS,
+    CONF_ENABLE_VPN_MANAGEMENT,
 )
 from ...sensor.network.network_clients import MerakiNetworkClientsSensor
 from ...sensor.network.traffic_shaping import TrafficShapingSensor

--- a/custom_components/meraki_ha/meraki_select/__init__.py
+++ b/custom_components/meraki_ha/meraki_select/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -46,7 +46,9 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
             icon="mdi:wifi-cog",
         )
 
-        self._attr_unique_id = f"meraki-ssid-{self._network_id}-{self._ssid_number}-rf-profile"
+        self._attr_unique_id = (
+            f"meraki-ssid-{self._network_id}-{self._ssid_number}-rf-profile"
+        )
         self._attr_options = []
         self._update_internal_state()
 
@@ -56,7 +58,9 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
     def device_info(self) -> DeviceInfo | None:
         """Return device information to link this entity to the SSID 'device'."""
         return DeviceInfo(
-            identifiers={(DOMAIN, f"meraki_ssid_{self._network_id}_{self._ssid_number}")},
+            identifiers={
+                (DOMAIN, f"meraki_ssid_{self._network_id}_{self._ssid_number}")
+            },
             name=f"SSID {self._ssid_name}",
             manufacturer="Cisco Meraki",
             via_device=(DOMAIN, self._network_id),
@@ -84,12 +88,16 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
             rf_profiles = self.coordinator.data.get("rf_profiles", {}).get(
                 self._network_id, []
             )
-            profile_map = {p["name"]: p["id"] for p in rf_profiles if "name" in p and "id" in p}
+            profile_map = {
+                p["name"]: p["id"] for p in rf_profiles if "name" in p and "id" in p
+            }
             options.extend(sorted(profile_map.keys()))
 
             # Get current RF profile for this SSID
             # We need to find the SSID in the latest coordinator data
-            current_ssid = self.coordinator.get_ssid(self._network_id, int(self._ssid_number))
+            current_ssid = self.coordinator.get_ssid(
+                self._network_id, int(self._ssid_number)
+            )
             if current_ssid:
                 current_profile_id = current_ssid.get("rfProfileId")
                 if current_profile_id:

--- a/tests/core/api/endpoints/test_get_vlan_data.py
+++ b/tests/core/api/endpoints/test_get_vlan_data.py
@@ -1,10 +1,12 @@
 """Tests for get_vlan_data in Network Endpoints."""
 
 from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-import meraki
+
 from custom_components.meraki_ha.core.api.endpoints.network import NetworkEndpoints
 from custom_components.meraki_ha.core.errors import MerakiVlansDisabledError
+
 
 @pytest.fixture
 def mock_client():
@@ -67,7 +69,9 @@ async def test_get_vlan_data_no_appliance_attr(network_endpoints, mock_client):
     assert result == []
 
 @pytest.mark.asyncio
-async def test_get_vlan_data_vlan_disabled_graceful_fail(network_endpoints, mock_client):
+async def test_get_vlan_data_vlan_disabled_graceful_fail(
+    network_endpoints, mock_client
+):
     """Test get_vlan_data returns empty list when VLANs are disabled."""
     network_id = "net123"
     mock_client.organization.get_organization_networks.return_value = [

--- a/tests/core/coordinator_helpers/test_data_fetcher_sanitization.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher_sanitization.py
@@ -67,7 +67,6 @@ async def test_async_gather_with_timeout_sanitization(data_fetch_manager):
 @pytest.mark.asyncio
 async def test_get_all_data_resilience_to_none(data_fetch_manager, mock_client):
     """Test that get_all_data handles None values for networks and devices."""
-
     # Simulate sanitization returning None for networks and devices
     data_fetch_manager._async_fetch_initial_data = AsyncMock(
         return_value={
@@ -97,7 +96,9 @@ async def test_get_all_data_resilience_to_none(data_fetch_manager, mock_client):
         patch(
             "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.parse_sensor_data"
         ),
-        patch.object(data_fetch_manager, "_async_gather_with_timeout", new_callable=AsyncMock) as mock_gather,
+        patch.object(
+            data_fetch_manager, "_async_gather_with_timeout", new_callable=AsyncMock
+        ) as mock_gather,
     ):
         # We need mock_gather to return a dict for the client_results call
         mock_gather.return_value = {}

--- a/tests/test_adaptive_polling.py
+++ b/tests/test_adaptive_polling.py
@@ -27,7 +27,7 @@ def coordinator(hass):
     entry.add_to_hass(hass)
     with patch("custom_components.meraki_ha.coordinator.ApiClient"), patch(
         "custom_components.meraki_ha.coordinator.DataFetchManager"
-    ) as mock_fetch_manager:
+    ):
         coord = MerakiDataCoordinator(hass=hass, entry=entry)
         # Mock get_all_data on the instance created by the mock fetch manager
         coord.data_fetch_manager.get_all_data = AsyncMock()


### PR DESCRIPTION
This PR resolves remaining linting violations in the codebase, specifically addressing `E501` (line too long) and `F401` (unused import) errors.

Changes:
- **`custom_components/meraki_ha/core/api/endpoints/network.py`**: Wrapped long lines in return statements and log messages.
- **`custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py`**: Wrapped a long comment line.
- **`custom_components/meraki_ha/meraki_select/__init__.py`**: Removed unused `Any` import.
- **`custom_components/meraki_ha/meraki_select/rf_profile.py`**: Wrapped long lines in `__init__`, `device_info`, and `_update_internal_state`.
- **`tests/core/api/endpoints/test_get_vlan_data.py`**: Wrapped long test function definition.
- **`tests/core/coordinator_helpers/test_data_fetcher_sanitization.py`**: Wrapped long `patch` context manager line.

Verification:
- ran `ruff check .` -> Passed.
- ran `python3 -m pytest` -> All 276 tests passed.

---
*PR created automatically by Jules for task [1262196053905428784](https://jules.google.com/task/1262196053905428784) started by @brewmarsh*