### PR TITLE
Optimization of Camera Sense Fetching

### DIFF
--- a/custom_components/meraki_ha/const_conf.py
+++ b/custom_components/meraki_ha/const_conf.py
@@ -52,6 +52,7 @@ CONF_ENABLE_NETWORK_SENSORS: Final = "enable_network_sensors"
 CONF_ENABLE_VLAN_SENSORS: Final = "enable_vlan_sensors"
 CONF_ENABLE_PORT_SENSORS: Final = "enable_port_sensors"
 CONF_ENABLE_SSID_SENSORS: Final = "enable_ssid_sensors"
+CONF_ENABLE_CAMERA_SENSE: Final = "enable_camera_sense"
 
 DEFAULT_ENABLED_NETWORKS: Final[list[str]] = []
 """Default value for the enabled networks list."""
@@ -86,3 +87,4 @@ DEFAULT_ENABLE_NETWORK_SENSORS: Final = True
 DEFAULT_ENABLE_VLAN_SENSORS: Final = True
 DEFAULT_ENABLE_PORT_SENSORS: Final = True
 DEFAULT_ENABLE_SSID_SENSORS: Final = True
+DEFAULT_ENABLE_CAMERA_SENSE: Final = True

--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN
 from .const_conf import (
+    CONF_ENABLE_CAMERA_SENSE,
     CONF_ENABLE_FIREWALL_RULES,
     CONF_ENABLE_TRAFFIC_SHAPING,
     CONF_ENABLE_VPN_MANAGEMENT,
@@ -21,6 +22,7 @@ from .const_conf import (
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
     CONF_SCAN_INTERVAL,
+    DEFAULT_ENABLE_CAMERA_SENSE,
     DEFAULT_ENABLE_FIREWALL_RULES,
     DEFAULT_ENABLE_TRAFFIC_SHAPING,
     DEFAULT_ENABLE_VPN_MANAGEMENT,
@@ -84,12 +86,17 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             CONF_ENABLE_TRAFFIC_SHAPING,
             entry.data.get(CONF_ENABLE_TRAFFIC_SHAPING, DEFAULT_ENABLE_TRAFFIC_SHAPING),
         )
+        enable_camera_sense = entry.options.get(
+            CONF_ENABLE_CAMERA_SENSE,
+            entry.data.get(CONF_ENABLE_CAMERA_SENSE, DEFAULT_ENABLE_CAMERA_SENSE),
+        )
 
         self.data_fetch_manager = DataFetchManager(
             client=self.api,
             enable_vpn_management=enable_vpn,
             enable_firewall_rules=enable_firewall,
             enable_traffic_shaping=enable_traffic,
+            enable_camera_sense=enable_camera_sense,
         )
         self.devices_by_serial: dict[str, MerakiDevice] = {}
         self.networks_by_id: dict[str, MerakiNetwork] = {}

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -37,12 +37,14 @@ class DataFetchManager:
         enable_vpn_management: bool = False,
         enable_firewall_rules: bool = False,
         enable_traffic_shaping: bool = False,
+        enable_camera_sense: bool = True,
     ) -> None:
         """Initialize the Data Fetch Manager."""
         self.client = client
         self.enable_vpn_management = enable_vpn_management
         self.enable_firewall_rules = enable_firewall_rules
         self.enable_traffic_shaping = enable_traffic_shaping
+        self.enable_camera_sense = enable_camera_sense
 
         self.client_fetcher = ClientFetcher(self.client)
         self._disabled_features = client._disabled_features
@@ -57,7 +59,9 @@ class DataFetchManager:
         )
         self.wireless_strategy = WirelessFetchStrategy(client, self._disabled_features)
         self.switch_strategy = SwitchFetchStrategy(client, self._disabled_features)
-        self.camera_strategy = CameraFetchStrategy(client, self._disabled_features)
+        self.camera_strategy = CameraFetchStrategy(
+            client, self._disabled_features, enable_camera_sense
+        )
 
     async def _async_gather_with_timeout(
         self,
@@ -134,6 +138,9 @@ class DataFetchManager:
         self, devices: list[MerakiDevice]
     ) -> dict[str, Any]:
         """Fetch camera analytics for all cameras in a single batch of tasks."""
+        if not self.camera_strategy.should_fetch_sense:
+            return {}
+
         camera_serials = [d.serial for d in devices if d.product_type == "camera"]
         if not camera_serials:
             return {}
@@ -237,7 +244,9 @@ class DataFetchManager:
             )
 
         previous_devices_by_serial = {
-            d["serial"]: d for d in previous_data.get("devices", []) if "serial" in d
+            d.serial: d
+            for d in previous_data.get("devices", [])
+            if hasattr(d, "serial") and d.serial
         }
 
         for device in devices:
@@ -264,6 +273,9 @@ class DataFetchManager:
         """Fetch all data for the coordinator update cycle."""
         previous_data = previous_data or {}
         _LOGGER.debug("Fetching fresh Meraki data from API")
+
+        # 0. Increment strategy poll counts
+        self.camera_strategy.increment_poll_count()
 
         # 1. Organization-level baseline
         initial_results = await self._async_fetch_initial_data()

--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -151,7 +151,7 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
         self,
         device: MerakiDevice,
         detail_data: dict[str, Any],
-        prev_device: dict[str, Any] | None,
+        prev_device: MerakiDevice | None,
     ) -> None:
         """Process appliance details."""
         if ports := detail_data.get(f"appliance_ports_{device.network_id}"):
@@ -161,11 +161,11 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                     for p in ports
                     if isinstance(p, dict)
                 ]
-        elif prev_device and "appliance_ports" in prev_device:
-            device.appliance_ports = prev_device["appliance_ports"]
+        elif prev_device and prev_device.appliance_ports:
+            device.appliance_ports = prev_device.appliance_ports
 
         if settings := detail_data.get(f"appliance_settings_{device.serial}"):
             if isinstance(settings.get("dynamicDns"), dict):
                 device.dynamic_dns = settings["dynamicDns"]
-        elif prev_device and "dynamicDns" in prev_device:
-            device.dynamic_dns = prev_device["dynamicDns"]
+        elif prev_device and prev_device.dynamic_dns:
+            device.dynamic_dns = prev_device.dynamic_dns

--- a/custom_components/meraki_ha/core/fetch_strategies/camera.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/camera.py
@@ -11,6 +11,34 @@ from .base import BaseFetchStrategy
 class CameraFetchStrategy(BaseFetchStrategy):
     """Strategy for fetching camera data."""
 
+    def __init__(
+        self,
+        client: MerakiAPIClient,
+        _disabled_features: set[str],
+        enable_camera_sense: bool = True,
+    ) -> None:
+        """Initialize the camera fetch strategy."""
+        super().__init__(client, _disabled_features)
+        self.enable_camera_sense = enable_camera_sense
+        self._poll_count = 0
+
+    def increment_poll_count(self) -> None:
+        """Increment the poll counter."""
+        self._poll_count += 1
+
+    @property
+    def should_fetch_sense(self) -> bool:
+        """Determine if sense data should be fetched this poll."""
+        if not self.enable_camera_sense:
+            return False
+        # Fetch every 5th poll (poll_count 1, 6, 11... or 0, 5, 10...)
+        # If we want the first poll to always fetch, we should start at 0 and use % 5 == 0
+        # and increment before checking, or start at 1.
+        # DataFetchManager calls increment_poll_count() before anything else.
+        # So first poll will be 1.
+        # (self._poll_count - 1) % 5 == 0 will be True for 1, 6, 11...
+        return (self._poll_count - 1) % 5 == 0
+
     def build_device_tasks(
         self,
         device: MerakiDevice,
@@ -21,24 +49,25 @@ class CameraFetchStrategy(BaseFetchStrategy):
         tasks[f"video_settings_{device.serial}"] = self.client.run_with_semaphore(
             self.client.camera.get_camera_video_settings(device.serial),
         )
-        tasks[f"sense_settings_{device.serial}"] = self.client.run_with_semaphore(
-            self.client.camera.get_camera_sense_settings(device.serial),
-        )
-
-        # Only add analytics task if not already provided in batch data
-        analytics_key = f"camera_analytics_{device.serial}"
-        if not detail_data or analytics_key not in detail_data:
-            tasks[analytics_key] = self.client.run_with_semaphore(
-                self.client.camera.get_device_camera_analytics_recent(
-                    device.serial,
-                ),
+        if self.should_fetch_sense:
+            tasks[f"sense_settings_{device.serial}"] = self.client.run_with_semaphore(
+                self.client.camera.get_camera_sense_settings(device.serial),
             )
+
+            # Only add analytics task if not already provided in batch data
+            analytics_key = f"camera_analytics_{device.serial}"
+            if not detail_data or analytics_key not in detail_data:
+                tasks[analytics_key] = self.client.run_with_semaphore(
+                    self.client.camera.get_device_camera_analytics_recent(
+                        device.serial,
+                    ),
+                )
 
     def process_device_details(
         self,
         device: MerakiDevice,
         detail_data: dict[str, Any],
-        prev_device: dict[str, Any] | None,
+        prev_device: MerakiDevice | None,
     ) -> None:
         """Process camera details."""
         if settings := detail_data.get(f"video_settings_{device.serial}"):
@@ -47,17 +76,17 @@ class CameraFetchStrategy(BaseFetchStrategy):
                 device.rtsp_url = settings.get("rtsp_url")
             else:
                 device.rtsp_url = None
-        elif prev_device and "video_settings" in prev_device:
-            device.video_settings = prev_device["video_settings"]
-            device.rtsp_url = prev_device.get("rtsp_url")
+        elif prev_device and prev_device.video_settings:
+            device.video_settings = prev_device.video_settings
+            device.rtsp_url = prev_device.rtsp_url
 
         if settings := detail_data.get(f"sense_settings_{device.serial}"):
             device.sense_settings = settings
-        elif prev_device and "sense_settings" in prev_device:
-            device.sense_settings = prev_device["sense_settings"]
+        elif prev_device and prev_device.sense_settings:
+            device.sense_settings = prev_device.sense_settings
 
         if analytics := detail_data.get(f"camera_analytics_{device.serial}"):
             if isinstance(analytics, list):
                 device.analytics = analytics
-        elif prev_device and "analytics" in prev_device:
-            device.analytics = prev_device["analytics"]
+        elif prev_device and prev_device.analytics:
+            device.analytics = prev_device.analytics

--- a/custom_components/meraki_ha/core/fetch_strategies/switch.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/switch.py
@@ -29,12 +29,12 @@ class SwitchFetchStrategy(BaseFetchStrategy):
         self,
         device: MerakiDevice,
         detail_data: dict[str, Any],
-        prev_device: dict[str, Any] | None,
+        prev_device: MerakiDevice | None,
     ) -> None:
         """Process switch details."""
         statuses_key = f"ports_statuses_{device.serial}"
         statuses = detail_data.get(statuses_key)
         if isinstance(statuses, list):
             device.ports_statuses = statuses
-        elif prev_device and "ports_statuses" in prev_device:
-            device.ports_statuses = prev_device["ports_statuses"]
+        elif prev_device and prev_device.ports_statuses:
+            device.ports_statuses = prev_device.ports_statuses

--- a/custom_components/meraki_ha/schemas.py
+++ b/custom_components/meraki_ha/schemas.py
@@ -14,6 +14,7 @@ from .const_conf import (
     CONF_ENABLE_NETWORK_SENSORS,
     CONF_ENABLE_ORG_SENSORS,
     CONF_ENABLE_PORT_SENSORS,
+    CONF_ENABLE_CAMERA_SENSE,
     CONF_ENABLE_SSID_SENSORS,
     CONF_ENABLE_TRAFFIC_SHAPING,
     CONF_ENABLE_VLAN_MANAGEMENT,
@@ -30,6 +31,7 @@ from .const_conf import (
     DEFAULT_ENABLE_NETWORK_SENSORS,
     DEFAULT_ENABLE_ORG_SENSORS,
     DEFAULT_ENABLE_PORT_SENSORS,
+    DEFAULT_ENABLE_CAMERA_SENSE,
     DEFAULT_ENABLE_SSID_SENSORS,
     DEFAULT_ENABLE_TRAFFIC_SHAPING,
     DEFAULT_ENABLE_VLAN_MANAGEMENT,
@@ -95,6 +97,9 @@ OPTIONS_SCHEMA = vol.Schema(
         ): selector.BooleanSelector(),
         vol.Required(
             CONF_ENABLE_SSID_SENSORS, default=DEFAULT_ENABLE_SSID_SENSORS
+        ): selector.BooleanSelector(),
+        vol.Required(
+            CONF_ENABLE_CAMERA_SENSE, default=DEFAULT_ENABLE_CAMERA_SENSE
         ): selector.BooleanSelector(),
         vol.Optional(
             CONF_ENABLED_NETWORKS, default=DEFAULT_ENABLED_NETWORKS

--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -12,6 +12,7 @@ from custom_components.meraki_ha.core.errors import (
 from custom_components.meraki_ha.core.fetch_strategies.appliance import (
     ApplianceFetchStrategy,
 )
+from custom_components.meraki_ha.core.models.device import MerakiAppliancePort, MerakiDevice
 
 
 @pytest.fixture
@@ -185,3 +186,22 @@ def test_process_device_details_settings(strategy):
     strategy.process_device_details(mock_device, detail_data, None)
 
     assert mock_device.dynamic_dns == {"enabled": True, "prefix": "test"}
+
+
+def test_process_device_details_fallback_to_prev(strategy):
+    """Test processing device details falls back to previous data."""
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    mock_device.network_id = "net1"
+    detail_data = {}
+    prev_device = MerakiDevice(
+        serial="SERIAL1",
+        network_id="net1",
+        appliance_ports=[MerakiAppliancePort(number=1, enabled=True)],
+        dynamic_dns={"enabled": True, "prefix": "prev"},
+    )
+
+    strategy.process_device_details(mock_device, detail_data, prev_device)
+
+    assert mock_device.appliance_ports == prev_device.appliance_ports
+    assert mock_device.dynamic_dns == prev_device.dynamic_dns

--- a/tests/core/fetch_strategies/test_camera_strategy.py
+++ b/tests/core/fetch_strategies/test_camera_strategy.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.meraki_ha.core.fetch_strategies.camera import (
     CameraFetchStrategy,
 )
+from custom_components.meraki_ha.core.models.device import MerakiDevice
 
 
 @pytest.fixture
@@ -39,6 +40,8 @@ def test_build_device_tasks(strategy):
     mock_device.serial = "SERIAL1"
     tasks = {}
 
+    # Must increment poll count so should_fetch_sense is True
+    strategy.increment_poll_count()
     strategy.build_device_tasks(mock_device, tasks)
 
     assert f"video_settings_{mock_device.serial}" in tasks
@@ -53,6 +56,8 @@ def test_build_device_tasks_skips_analytics_if_in_detail_data(strategy):
     tasks = {}
     detail_data = {f"camera_analytics_{mock_device.serial}": [{"some": "data"}]}
 
+    # Must increment poll count so should_fetch_sense is True
+    strategy.increment_poll_count()
     strategy.build_device_tasks(mock_device, tasks, detail_data=detail_data)
 
     assert f"video_settings_{mock_device.serial}" in tasks
@@ -113,16 +118,17 @@ def test_process_device_details_fallback_to_prev(strategy):
     mock_device = MagicMock()
     mock_device.serial = "SERIAL1"
     detail_data = {}
-    prev_device = {
-        "video_settings": {"rtsp_url": "rtsp://prev.com"},
-        "rtsp_url": "rtsp://prev.com",
-        "sense_settings": {"sense": "prev"},
-        "analytics": [{"prev": "data"}],
-    }
+    prev_device = MerakiDevice(
+        serial="SERIAL1",
+        video_settings={"rtsp_url": "rtsp://prev.com"},
+        rtsp_url="rtsp://prev.com",
+        sense_settings={"sense": "prev"},
+        analytics=[{"prev": "data"}],
+    )
 
     strategy.process_device_details(mock_device, detail_data, prev_device)
 
-    assert mock_device.video_settings == prev_device["video_settings"]
-    assert mock_device.rtsp_url == prev_device["rtsp_url"]
-    assert mock_device.sense_settings == prev_device["sense_settings"]
-    assert mock_device.analytics == prev_device["analytics"]
+    assert mock_device.video_settings == prev_device.video_settings
+    assert mock_device.rtsp_url == prev_device.rtsp_url
+    assert mock_device.sense_settings == prev_device.sense_settings
+    assert mock_device.analytics == prev_device.analytics

--- a/tests/core/fetch_strategies/test_switch_strategy.py
+++ b/tests/core/fetch_strategies/test_switch_strategy.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.meraki_ha.core.fetch_strategies.switch import (
     SwitchFetchStrategy,
 )
+from custom_components.meraki_ha.core.models.device import MerakiDevice
 
 
 @pytest.fixture
@@ -75,10 +76,11 @@ def test_process_device_details_fallback_to_prev(strategy):
     mock_device = MagicMock()
     mock_device.serial = "SERIAL1"
     detail_data = {}
-    prev_device = {
-        "ports_statuses": [{"portId": "1", "status": "Disconnected"}]
-    }
+    prev_device = MerakiDevice(
+        serial="SERIAL1",
+        ports_statuses=[{"portId": "1", "status": "Disconnected"}]
+    )
 
     strategy.process_device_details(mock_device, detail_data, prev_device)
 
-    assert mock_device.ports_statuses == prev_device["ports_statuses"]
+    assert mock_device.ports_statuses == prev_device.ports_statuses

--- a/tests/test_camera_optimization.py
+++ b/tests/test_camera_optimization.py
@@ -1,0 +1,87 @@
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+from custom_components.meraki_ha.core.fetch_strategies.camera import CameraFetchStrategy
+from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import DataFetchManager
+
+@pytest.mark.asyncio
+async def test_camera_modulo_fetch():
+    client = MagicMock()
+    # Mock run_with_semaphore to just return the coro
+    client.run_with_semaphore.side_effect = lambda x: x
+
+    # Strategy with sense enabled
+    strategy = CameraFetchStrategy(client, set(), enable_camera_sense=True)
+
+    device = MerakiDevice(serial="Q123", product_type="camera")
+
+    # Poll 1
+    strategy.increment_poll_count()
+    assert strategy.should_fetch_sense is True
+    tasks = {}
+    strategy.build_device_tasks(device, tasks)
+    assert f"sense_settings_{device.serial}" in tasks
+
+    # Poll 2
+    strategy.increment_poll_count()
+    assert strategy.should_fetch_sense is False
+    tasks = {}
+    strategy.build_device_tasks(device, tasks)
+    assert f"sense_settings_{device.serial}" not in tasks
+
+    # Poll 3, 4, 5
+    strategy.increment_poll_count() # 3
+    strategy.increment_poll_count() # 4
+    strategy.increment_poll_count() # 5
+    assert strategy.should_fetch_sense is False
+
+    # Poll 6
+    strategy.increment_poll_count()
+    assert strategy.should_fetch_sense is True
+    tasks = {}
+    strategy.build_device_tasks(device, tasks)
+    assert f"sense_settings_{device.serial}" in tasks
+
+@pytest.mark.asyncio
+async def test_camera_sense_disabled():
+    client = MagicMock()
+    # Strategy with sense disabled
+    strategy = CameraFetchStrategy(client, set(), enable_camera_sense=False)
+
+    device = MerakiDevice(serial="Q123", product_type="camera")
+
+    # Poll 1
+    strategy.increment_poll_count()
+    assert strategy.should_fetch_sense is False
+    tasks = {}
+    strategy.build_device_tasks(device, tasks)
+    assert f"sense_settings_{device.serial}" not in tasks
+
+@pytest.mark.asyncio
+async def test_dfm_batch_analytics_modulo():
+    client = MagicMock()
+    client._disabled_features = set()
+    dfm = DataFetchManager(client, enable_camera_sense=True)
+
+    devices = [MerakiDevice(serial="Q123", product_type="camera")]
+
+    # Mock the API call
+    client.camera.get_device_camera_analytics_recent = MagicMock(return_value=AsyncMock()())
+    client.run_with_semaphore.side_effect = lambda x: x
+
+    # Poll 1
+    dfm.camera_strategy.increment_poll_count()
+    with MagicMock() as mock_gather:
+        # We need to mock _async_gather_with_timeout because it tries to await tasks
+        dfm._async_gather_with_timeout = AsyncMock(return_value={})
+        await dfm._fetch_batch_camera_analytics(devices)
+        assert dfm._async_gather_with_timeout.called
+
+    # Poll 2
+    dfm.camera_strategy.increment_poll_count()
+    dfm._async_gather_with_timeout = AsyncMock(return_value={})
+    result = await dfm._fetch_batch_camera_analytics(devices)
+    assert result == {}
+    # Check that _async_gather_with_timeout was NOT called for analytics
+    assert not dfm._async_gather_with_timeout.called


### PR DESCRIPTION
This change optimizes the Meraki integration by reducing the volume of API calls for Camera Sense and Analytics data. It implements a lazy fetching strategy (every 5th poll) and provides a user-configurable toggle to disable these features entirely if not needed. Additionally, it fixes a critical bug in data persistence between update cycles by correcting how previous device data is accessed (switching from dict indexing to object attributes).

Fixes #1807

---
*PR created automatically by Jules for task [10907797390111516302](https://jules.google.com/task/10907797390111516302) started by @brewmarsh*