### PR TITLE
Fix DataFetchManager signature mismatch and update tests

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -247,11 +247,11 @@ class DataFetchManager:
             # Combined Logic: Pass BOTH detail_data (for bulk data) AND capabilities (for guarding)
             if device.product_type == "camera":
                 self.camera_strategy.build_device_tasks(
-                    device, tasks, capabilities
+                    device, tasks, capabilities, detail_data
                 )
             elif device.product_type == "switch":
                 self.switch_strategy.build_device_tasks(
-                    device, tasks, capabilities
+                    device, tasks, capabilities, detail_data
                 )
             elif device.product_type == "appliance":
                 self.appliance_strategy.build_device_tasks(device, tasks, capabilities)

--- a/tests/core/coordinator_helpers/test_consolidation.py
+++ b/tests/core/coordinator_helpers/test_consolidation.py
@@ -72,7 +72,7 @@ async def test_consolidation_switch_ports(data_fetch_manager, mock_client):
     # Ensure build_device_tasks was called with the batch data
     strategy_spy.assert_called()
     call_args = strategy_spy.call_args
-    assert f"ports_statuses_{switch_serial}" in call_args[0][2]  # detail_data parameter
+    assert f"ports_statuses_{switch_serial}" in call_args[0][3]  # detail_data parameter
 
     # Ensure the device has the ports statuses
     assert result["devices"][0].ports_statuses == switch_ports
@@ -120,7 +120,7 @@ async def test_consolidation_camera_analytics(data_fetch_manager, mock_client):
     # 3. Assertions
     strategy_spy.assert_called()
     call_args = strategy_spy.call_args
-    assert f"camera_analytics_{camera_serial}" in call_args[0][2]
+    assert f"camera_analytics_{camera_serial}" in call_args[0][3]
     assert result["devices"][0].analytics == camera_analytics
 
 

--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -109,7 +109,7 @@ def test_build_device_tasks(strategy):
     mock_device.network_id = "NET1"
     tasks = {}
 
-    strategy.build_device_tasks(mock_device, tasks)
+    strategy.build_device_tasks(mock_device, tasks, capabilities=[])
 
     assert f"appliance_settings_{mock_device.serial}" in tasks
 

--- a/tests/core/fetch_strategies/test_camera_strategy.py
+++ b/tests/core/fetch_strategies/test_camera_strategy.py
@@ -42,7 +42,7 @@ def test_build_device_tasks(strategy):
 
     # Must increment poll count so should_fetch_sense is True
     strategy.increment_poll_count()
-    strategy.build_device_tasks(mock_device, tasks)
+    strategy.build_device_tasks(mock_device, tasks, capabilities=["camera_stream", "analytics"])
 
     assert f"video_settings_{mock_device.serial}" in tasks
     assert f"sense_settings_{mock_device.serial}" in tasks
@@ -58,7 +58,7 @@ def test_build_device_tasks_skips_analytics_if_in_detail_data(strategy):
 
     # Must increment poll count so should_fetch_sense is True
     strategy.increment_poll_count()
-    strategy.build_device_tasks(mock_device, tasks, detail_data=detail_data)
+    strategy.build_device_tasks(mock_device, tasks, capabilities=["camera_stream", "analytics"], detail_data=detail_data)
 
     assert f"video_settings_{mock_device.serial}" in tasks
     assert f"sense_settings_{mock_device.serial}" in tasks

--- a/tests/core/fetch_strategies/test_switch_strategy.py
+++ b/tests/core/fetch_strategies/test_switch_strategy.py
@@ -40,7 +40,7 @@ def test_build_device_tasks(strategy):
     mock_device.serial = "SERIAL1"
     tasks = {}
 
-    strategy.build_device_tasks(mock_device, tasks)
+    strategy.build_device_tasks(mock_device, tasks, capabilities=["switch_ports"])
 
     assert f"ports_statuses_{mock_device.serial}" in tasks
 
@@ -52,7 +52,7 @@ def test_build_device_tasks_skips_if_in_detail_data(strategy):
     tasks = {}
     detail_data = {f"ports_statuses_{mock_device.serial}": [{"portId": "1"}]}
 
-    strategy.build_device_tasks(mock_device, tasks, detail_data=detail_data)
+    strategy.build_device_tasks(mock_device, tasks, capabilities=["switch_ports"], detail_data=detail_data)
 
     assert f"ports_statuses_{mock_device.serial}" not in tasks
 

--- a/tests/test_camera_optimization.py
+++ b/tests/test_camera_optimization.py
@@ -20,14 +20,14 @@ async def test_camera_modulo_fetch():
     strategy.increment_poll_count()
     assert strategy.should_fetch_sense is True
     tasks = {}
-    strategy.build_device_tasks(device, tasks)
+    strategy.build_device_tasks(device, tasks, capabilities=["camera_stream", "analytics"])
     assert f"sense_settings_{device.serial}" in tasks
 
     # Poll 2
     strategy.increment_poll_count()
     assert strategy.should_fetch_sense is False
     tasks = {}
-    strategy.build_device_tasks(device, tasks)
+    strategy.build_device_tasks(device, tasks, capabilities=["camera_stream", "analytics"])
     assert f"sense_settings_{device.serial}" not in tasks
 
     # Poll 3, 4, 5
@@ -40,7 +40,7 @@ async def test_camera_modulo_fetch():
     strategy.increment_poll_count()
     assert strategy.should_fetch_sense is True
     tasks = {}
-    strategy.build_device_tasks(device, tasks)
+    strategy.build_device_tasks(device, tasks, capabilities=["camera_stream", "analytics"])
     assert f"sense_settings_{device.serial}" in tasks
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_camera_sense_disabled():
     strategy.increment_poll_count()
     assert strategy.should_fetch_sense is False
     tasks = {}
-    strategy.build_device_tasks(device, tasks)
+    strategy.build_device_tasks(device, tasks, capabilities=["camera_stream", "analytics"])
     assert f"sense_settings_{device.serial}" not in tasks
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Pass `detail_data` to `CameraFetchStrategy` and `SwitchFetchStrategy` in `DataFetchManager`.
- Update tests to pass `capabilities` to `build_device_tasks`.
- Fix `test_consolidation.py` assertion indices.

---
*PR created automatically by Jules for task [13257783954487965933](https://jules.google.com/task/13257783954487965933) started by @brewmarsh*