### PR TITLE
Fix Non-Existing Via Device Warning

### DIFF
--- a/custom_components/meraki_ha/coordinator.py
+++ b/custom_components/meraki_ha/coordinator.py
@@ -32,6 +32,7 @@ from .const_conf import (
 from .core.api.client import MerakiAPIClient as ApiClient
 from .core.coordinator_helpers.data_fetcher import DataFetchManager
 from .core.helpers import filter_ignored_networks, process_coordinator_data
+from .core.helpers.device_registry import async_ensure_network_devices_exist
 from .core.managers import AvailabilityTracker, PendingUpdateManager
 from .core.models.device import MerakiDevice
 from .core.models.network import MerakiNetwork
@@ -196,6 +197,12 @@ class MerakiDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.warning("API call to get_all_data returned no data.")
                 # Return cached data to prevent entities from becoming unavailable
                 return self.last_successful_data
+
+            # Ensure network devices exist in the registry before processing
+            # to avoid "referencing non-existing via_device" warnings.
+            async_ensure_network_devices_exist(
+                self.hass, self.config_entry, data.get("networks", [])
+            )
 
             # Update success history and consecutive successes
             self._consecutive_successes += 1

--- a/custom_components/meraki_ha/core/helpers/__init__.py
+++ b/custom_components/meraki_ha/core/helpers/__init__.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
-from ..const import DOMAIN
-from ..core.models.device import MerakiDevice
-from ..core.models.network import MerakiNetwork
+from ...const import DOMAIN
+from ..models.device import MerakiDevice
+from ..models.network import MerakiNetwork
 
 if TYPE_CHECKING:
     from homeassistant.helpers.device_registry import DeviceRegistry
@@ -113,22 +113,6 @@ def process_coordinator_data(
     ]
     networks_by_id = {n.id: n for n in networks if n.id}
     data["networks"] = networks
-
-    # Pre-register network devices to avoid "referencing a non existing
-    # via_device" warnings when downstream entities (like VLANs) initialize.
-    device_registry = dr.async_get(hass)
-
-    if config_entry:
-        for network in networks:
-            if not network.id:
-                continue
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry.entry_id,
-                identifiers={(DOMAIN, cast(str, network.id))},
-                name=network.name,
-                manufacturer="Cisco Meraki",
-                model="Network",
-            )
 
     ssids_by_network_and_number = {
         (cast(str, s.get("networkId")), int(s.get("number"))): s

--- a/custom_components/meraki_ha/core/helpers/device_registry.py
+++ b/custom_components/meraki_ha/core/helpers/device_registry.py
@@ -1,0 +1,54 @@
+"""Helper functions for managing the Home Assistant device registry."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers import device_registry as dr
+
+from ...const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+    from ..models.network import MerakiNetwork
+
+
+def async_ensure_network_devices_exist(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    networks: list[MerakiNetwork | dict[str, Any]],
+) -> None:
+    """Pre-register network devices in the device registry.
+
+    This ensures that entities linking to these networks via via_device
+    don't trigger warnings about non-existing devices.
+
+    Args:
+    ----
+        hass: The Home Assistant instance.
+        config_entry: The config entry.
+        networks: The list of networks (as objects or dicts) to ensure exist.
+
+    """
+    device_registry = dr.async_get(hass)
+
+    for network in networks:
+        if isinstance(network, dict):
+            network_id = network.get("id")
+            network_name = network.get("name")
+        else:
+            network_id = network.id
+            network_name = network.name
+
+        if not network_id:
+            continue
+
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, f"network_{network_id}")},
+            name=network_name,
+            manufacturer="Cisco Meraki",
+            model="Network",
+        )


### PR DESCRIPTION
Implemented a mechanism to pre-register "Network" devices in the Home Assistant Device Registry to avoid "Non-Existing Via Device" warnings when entities attempt to link to them. This involved creating a new helper module, refactoring existing helpers into a package, and updating the coordinator to call the registration function with the correct identifier format.

Fixes #1822

---
*PR created automatically by Jules for task [1461334237518941044](https://jules.google.com/task/1461334237518941044) started by @brewmarsh*