### PR TITLE
Add Uplink Performance Sensors and Enhance Device Status

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/appliance/uplink.py
+++ b/custom_components/meraki_ha/core/api/endpoints/appliance/uplink.py
@@ -54,6 +54,35 @@ class ApplianceUplinkMixin:
 
     @handle_meraki_errors
     @async_timed_cache(timeout=60)
+    async def get_network_appliance_uplinks_performance(
+        self,
+        network_id: str,
+    ) -> list[dict[str, Any]]:
+        """
+        Get uplink performance for all devices in a network.
+
+        Args:
+            network_id: The network ID.
+
+        Returns
+        -------
+            A list of uplink performance metrics.
+
+        """
+        performance = await self._api_client.run_sync(
+            self._api_client.dashboard.appliance.getNetworkApplianceUplinksPerformance,
+            networkId=network_id,
+        )
+        validated = validate_response(performance)
+        if not isinstance(validated, list):
+            _LOGGER.warning(
+                "get_network_appliance_uplinks_performance did not return a list",
+            )
+            return []
+        return validated
+
+    @handle_meraki_errors
+    @async_timed_cache(timeout=60)
     async def get_organization_appliance_uplink_statuses(self) -> list[dict[str, Any]]:
         """
         Get uplink status for all appliances in the organization.

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -23,6 +23,7 @@ from ...core.fetch_strategies.wireless import WirelessFetchStrategy
 from ...core.models.device import MerakiDevice
 from ...core.models.network import MerakiNetwork
 from ...core.parsers.appliance import parse_appliance_data
+from ...core.parsers.devices import parse_device_data
 from ...core.parsers.network import parse_network_data
 from ...core.parsers.sensors import parse_sensor_data
 from .client_fetcher import ClientFetcher
@@ -180,6 +181,9 @@ class DataFetchManager:
             ),
             "appliance_uplink_statuses": self.client.run_with_semaphore(
                 self.client.appliance.get_organization_appliance_uplink_statuses(),
+            ),
+            "device_statuses": self.client.run_with_semaphore(
+                self.client.organization.get_organization_devices_statuses(),
             ),
             "sensor_readings": self.client.run_with_semaphore(
                 self.client.sensor.get_organization_sensor_readings_latest(),
@@ -357,6 +361,7 @@ class DataFetchManager:
         parse_appliance_data(
             devices_list, initial_results.get("appliance_uplink_statuses")
         )
+        parse_device_data(devices_list, initial_results.get("device_statuses") or [])
         parse_sensor_data(devices_list, initial_results.get("sensor_readings", []), [])
 
         camera_analytics = await self._fetch_batch_camera_analytics(devices_list)

--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -73,6 +73,11 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                 network_id,
             ),
         )
+        tasks[f"uplink_performance_{network_id}"] = self.client.run_with_semaphore(
+            self.client.appliance.get_network_appliance_uplinks_performance(
+                network_id,
+            ),
+        )
 
     def build_device_tasks(
         self,
@@ -174,3 +179,29 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                 device.dynamic_dns = settings["dynamicDns"]
         elif prev_device and hasattr(prev_device, "dynamic_dns"):
             device.dynamic_dns = prev_device.dynamic_dns
+
+        if performance := detail_data.get(f"uplink_performance_{device.network_id}"):
+            if isinstance(performance, list):
+                # Filter performance data for this device
+                device_perf = [
+                    p for p in performance if p.get("serial") == device.serial
+                ]
+                # Merge with existing status data in device.uplinks
+                perf_by_interface = {p.get("interface"): p for p in device_perf}
+                merged_uplinks = []
+                # Use appliance_uplink_statuses as the base for merging
+                for status_uplink in device.appliance_uplink_statuses:
+                    interface = status_uplink.get("interface")
+                    perf = perf_by_interface.get(interface, {})
+                    merged_uplinks.append({**status_uplink, **perf})
+
+                # Add any interfaces found in performance but not in status
+                status_interfaces = {
+                    u.get("interface") for u in device.appliance_uplink_statuses
+                }
+                for interface, perf in perf_by_interface.items():
+                    if interface not in status_interfaces:
+                        merged_uplinks.append(perf)
+                device.uplinks = merged_uplinks
+        elif prev_device and hasattr(prev_device, "uplinks"):
+            device.uplinks = prev_device.uplinks

--- a/custom_components/meraki_ha/core/models/device.py
+++ b/custom_components/meraki_ha/core/models/device.py
@@ -64,6 +64,7 @@ class MerakiDevice:
     public_ip: str | None = None
     network_id: str | None = None
     appliance_uplink_statuses: list[dict[str, Any]] = field(default_factory=list)
+    uplinks: list[dict[str, Any]] = field(default_factory=list)
     status: str | None = None
     firmware: str | None = None
     product_type: str | None = None
@@ -127,6 +128,7 @@ class MerakiDevice:
             "dynamicDns": self.dynamic_dns,
             "statusMessages": self.status_messages,
             "applianceUplinkStatuses": self.appliance_uplink_statuses,
+            "uplinks": self.uplinks,
             "entity_id": self.entity_id,
             "outletStatus": self.outlet_status,
         }
@@ -165,6 +167,7 @@ class MerakiDevice:
             dynamic_dns=data.get("dynamicDns"),
             status_messages=data.get("statusMessages", []),
             appliance_uplink_statuses=data.get("applianceUplinkStatuses", []),
+            uplinks=data.get("uplinks", []),
             entity_id=data.get("entity_id"),
             outlet_status=data.get("outletStatus"),
         )

--- a/custom_components/meraki_ha/core/parsers/appliance.py
+++ b/custom_components/meraki_ha/core/parsers/appliance.py
@@ -49,7 +49,10 @@ def parse_appliance_data(
         for device in devices:
             if device.serial == serial:
                 _LOGGER.debug("Matched uplink data for %s", serial)
-                device.appliance_uplink_statuses = status.get("uplinks", [])
+                uplinks = status.get("uplinks", [])
+                device.appliance_uplink_statuses = uplinks
+                # Initialize uplinks with status data; will be enriched with performance metrics later
+                device.uplinks = uplinks
                 break
 
 

--- a/custom_components/meraki_ha/discovery/handlers/universal.py
+++ b/custom_components/meraki_ha/discovery/handlers/universal.py
@@ -36,6 +36,7 @@ from ..providers import (
     CameraStreamProvider,
     MT40PowerMonitorProvider,
     SwitchPortProvider,
+    UplinkPerformanceProvider,
     UplinkProvider,
 )
 from .base import BaseDeviceHandler
@@ -73,6 +74,7 @@ class UniversalHandler(BaseDeviceHandler):
         "power_monitor": MT40PowerMonitorProvider,
         "remote_switch": MerakiMt40PowerOutlet,
         "uplinks": UplinkProvider,
+        "performance": UplinkPerformanceProvider,
         "appliance_ports": AppliancePortProvider,
         "switch_ports": SwitchPortProvider,
         "poe_usage": MerakiPoeUsageSensor,
@@ -99,6 +101,7 @@ class UniversalHandler(BaseDeviceHandler):
         "remote_switch": CONF_ENABLE_DEVICE_SENSORS,
         "poe_usage": CONF_ENABLE_DEVICE_SENSORS,
         "uplinks": CONF_ENABLE_PORT_SENSORS,
+        "performance": CONF_ENABLE_PORT_SENSORS,
         "appliance_ports": CONF_ENABLE_PORT_SENSORS,
         "switch_ports": CONF_ENABLE_PORT_SENSORS,
         "analytics": CONF_ENABLE_CAMERA_ENTITIES,

--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
@@ -29,6 +35,7 @@ from ..descriptions import (
 )
 from ..sensor.device.appliance_port import MerakiAppliancePortSensor
 from ..sensor.device.appliance_uplink import MerakiApplianceUplinkSensor
+from ..sensor.uplink_performance import MerakiUplinkPerformanceSensor
 from ..sensor.device.camera_analytics import (
     MerakiPersonCountSensor,
     MerakiVehicleCountSensor,
@@ -124,6 +131,92 @@ class UplinkProvider:
                     coordinator, device, config_entry, uplink_data
                 )
             )
+        return entities
+
+
+class UplinkPerformanceProvider:
+    """Provider for appliance uplink performance entities."""
+
+    @staticmethod
+    def get_entities(
+        coordinator: MerakiDataUpdateCoordinator,
+        device: MerakiDevice,
+        config_entry: ConfigEntry,
+        **kwargs: Any,
+    ) -> list[Entity]:
+        """Get entities."""
+        if not config_entry.options.get(CONF_ENABLE_PORT_SENSORS, True):
+            return []
+
+        if not device.serial:
+            return []
+
+        entities: list[Entity] = []
+        # Use uplinks field which contains merged status and performance data
+        if not device.uplinks:
+            return []
+
+        for uplink in device.uplinks:
+            interface = uplink.get("interface")
+            if not interface:
+                continue
+
+            # Latency Sensor
+            entities.append(
+                MerakiUplinkPerformanceSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    interface,
+                    "latencyMs",
+                    SensorEntityDescription(
+                        key=f"{interface}_latency",
+                        name=f"{interface.upper()} Latency",
+                        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+                        device_class=SensorDeviceClass.DURATION,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        icon="mdi:timer-outline",
+                    ),
+                )
+            )
+
+            # Loss Sensor
+            entities.append(
+                MerakiUplinkPerformanceSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    interface,
+                    "packetLoss",
+                    SensorEntityDescription(
+                        key=f"{interface}_packet_loss",
+                        name=f"{interface.upper()} Packet Loss",
+                        native_unit_of_measurement=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        icon="mdi:packet-loss",
+                    ),
+                )
+            )
+
+            # Jitter Sensor
+            entities.append(
+                MerakiUplinkPerformanceSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    interface,
+                    "jitter",
+                    SensorEntityDescription(
+                        key=f"{interface}_jitter",
+                        name=f"{interface.upper()} Jitter",
+                        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+                        device_class=SensorDeviceClass.DURATION,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        icon="mdi:pulse",
+                    ),
+                )
+            )
+
         return entities
 
 

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -128,10 +128,23 @@ class MerakiDeviceStatusSensor(MerakiEntity, SensorEntity):
 
         # Status is the primary value of this sensor
         device_status: str | None = current_device_data.status
-        if isinstance(device_status, str):
-            self._attr_native_value = device_status.lower()
-        else:
-            self._attr_native_value = "unknown"  # Default if status is not a string
+
+        # Determine base status
+        native_value = "unknown"
+        if isinstance(device_status, str) and device_status.lower() not in [
+            "",
+            "unknown",
+        ]:
+            native_value = device_status.lower()
+
+        # Fallback to composite state from uplinks if base status is missing/unknown
+        if native_value == "unknown" and current_device_data.uplinks:
+            if any(u.get("status") == "active" for u in current_device_data.uplinks):
+                native_value = "online"
+            elif all(u.get("status") == "failed" for u in current_device_data.uplinks):
+                native_value = "offline"
+
+        self._attr_native_value = native_value
 
         # Populate attributes from the latest device data
         self._attr_extra_state_attributes = {

--- a/custom_components/meraki_ha/sensor/uplink_performance.py
+++ b/custom_components/meraki_ha/sensor/uplink_performance.py
@@ -1,0 +1,88 @@
+"""Uplink performance sensors for Meraki appliances."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE, UnitOfTime
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from ..const import DOMAIN
+from ..entity import MerakiEntity
+
+if TYPE_CHECKING:
+    from ..coordinator import MerakiDataUpdateCoordinator
+    from ..core.models.device import MerakiDevice
+    from homeassistant.config_entries import ConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiSensor(MerakiEntity, SensorEntity):
+    """Base class for Meraki sensors."""
+
+
+class MerakiUplinkPerformanceSensor(MerakiSensor):
+    """Representation of a Meraki uplink performance sensor."""
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device: MerakiDevice,
+        config_entry: ConfigEntry,
+        interface: str,
+        metric: str,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device_serial = device.serial
+        self._interface = interface
+        self._metric = metric
+        self.entity_description = description
+
+        # Use Home Assistant Sentence Case for names
+        # Entity name will be e.g. "WAN1 Latency"
+        # Since _attr_has_entity_name is True in MerakiEntity,
+        # the final name will be "Device Name WAN1 Latency"
+
+        self._attr_unique_id = f"{self._device_serial}_{interface}_{metric}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_serial)},
+        )
+        self._update_state()
+
+    @callback
+    def _update_state(self) -> None:
+        """Update the sensor state from the coordinator data."""
+        device = self.coordinator.get_device(self._device_serial)
+        if not device or not device.uplinks:
+            self._attr_native_value = None
+            return
+
+        for uplink in device.uplinks:
+            if uplink.get("interface") == self._interface:
+                value = uplink.get(self._metric)
+                if value is not None:
+                    try:
+                        self._attr_native_value = float(value)
+                    except (ValueError, TypeError):
+                        self._attr_native_value = value
+                else:
+                    self._attr_native_value = None
+                return
+        self._attr_native_value = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -185,6 +185,15 @@
       },
       "ipv6_uplink": {
         "name": "IPv6 uplink"
+      },
+      "uplink_latency": {
+        "name": "Latency"
+      },
+      "uplink_packet_loss": {
+        "name": "Packet loss"
+      },
+      "uplink_jitter": {
+        "name": "Jitter"
       }
     },
     "switch": {


### PR DESCRIPTION
I have implemented the requested Uplink Performance Sensors for Meraki appliances. This involved updating the core data models, API endpoints, fetch strategies, and discovery providers. I also enhanced the MerakiDeviceStatusSensor to correctly handle cases where the base status is missing by calculating a composite state from the active uplinks.

Key changes:
1.  **Core Model**: Updated `MerakiDevice` in `device.py` to include an `uplinks` field that holds merged status and performance data.
2.  **API**: Added `get_network_appliance_uplinks_performance` to `uplink.py` to retrieve real-time performance metrics.
3.  **Fetch Logic**: Updated `ApplianceFetchStrategy` and `DataFetchManager` to orchestrate the fetching of performance data and ensure it's correctly associated with each device.
4.  **Sensors**: Created `MerakiUplinkPerformanceSensor` in a new `uplink_performance.py` file. This sensor handles latency, packet loss, and jitter.
5.  **Discovery**: Added `UplinkPerformanceProvider` to `providers.py` and registered it in `UniversalHandler` to enable automatic discovery for all appliance interfaces (WAN1, WAN2, Cellular).
6.  **Composite Status**: Refactored `MerakiDeviceStatusSensor` to determine the device's state (online/offline) based on uplink activity if the primary API status is 'unknown'.

I verified each step by reading the modified files and ensuring the logic aligns with the project's architectural standards.

Fixes #1824

---
*PR created automatically by Jules for task [12214281200121989110](https://jules.google.com/task/12214281200121989110) started by @brewmarsh*