### PR TITLE
fix: add missing mock for uplink performance in fetch manager tests

### DIFF
--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -39,6 +39,9 @@ async def test_appliance_features_fetching_behavior() -> None:
     mock_client.appliance.get_network_appliance_content_filtering = AsyncMock(
         return_value={}
     )
+    mock_client.appliance.get_network_appliance_uplinks_performance = AsyncMock(
+        return_value=[]
+    )
     mock_client.network.get_network_traffic = AsyncMock(return_value=[])
 
     mock_network = MerakiNetwork(id="net1", product_types=["appliance"])


### PR DESCRIPTION
Fixed failing test `test_appliance_features_fetching_behavior` by adding missing mock for `get_network_appliance_uplinks_performance`.

---
*PR created automatically by Jules for task [11988353523367514126](https://jules.google.com/task/11988353523367514126) started by @brewmarsh*