### PR TITLE
fix: mock get_network_appliance_uplinks_performance in feature tests

### DIFF
--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -39,6 +39,9 @@ async def test_appliance_features_fetching_behavior() -> None:
     mock_client.appliance.get_network_appliance_content_filtering = AsyncMock(
         return_value={}
     )
+    mock_client.appliance.get_network_appliance_uplinks_performance = AsyncMock(
+        return_value=[]
+    )
     mock_client.network.get_network_traffic = AsyncMock(return_value=[])
 
     mock_network = MerakiNetwork(id="net1", product_types=["appliance"])


### PR DESCRIPTION
This PR fixes a regression in `tests/core/test_data_fetch_manager_features.py` caused by the addition of the appliance uplink performance feature. The test was missing a mock for `get_network_appliance_uplinks_performance`, which caused a `TypeError` when the test tried to await the unmocked task (which was a `MagicMock` instead of a coroutine). This change adds the necessary `AsyncMock` to the test setup.

---
*PR created automatically by Jules for task [4844938342661588714](https://jules.google.com/task/4844938342661588714) started by @brewmarsh*