### PR TITLE
Implement switch_port_status binary sensors

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/__init__.py
+++ b/custom_components/meraki_ha/binary_sensor/__init__.py
@@ -2,15 +2,13 @@
 
 import logging
 
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from ..const import DOMAIN
-from .device.camera_motion import MerakiMotionSensor
 from .network import async_setup_entry as async_setup_network_entry
-from .switch_port import SwitchPortSensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,37 +19,20 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> bool:
     """Set up Meraki binary sensor entities from a config entry."""
+    from ..discovery.service import DeviceDiscoveryService
+
+    if config_entry.entry_id not in hass.data[DOMAIN]:
+        return False
+
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = entry_data["coordinator"]
-    camera_service = entry_data.get("camera_service")
+    discovery_service: DeviceDiscoveryService = entry_data["discovery_service"]
 
-    binary_sensor_entities: list[Entity] = []
-    devices = coordinator.data.get("devices", [])
-
-    # Pre-check for camera service to avoid repeated checks in the loop
-    has_camera_service = camera_service is not None
-
-    for device in devices:
-        product_type = getattr(device, "productType", "")
-        getattr(device, "model", "")
-
-        # Add motion sensors for cameras
-        if product_type.startswith("camera") and has_camera_service:
-            binary_sensor_entities.append(
-                MerakiMotionSensor(
-                    coordinator,
-                    device,
-                    camera_service,
-                    config_entry,
-                )
-            )
-
-        # Add switch port sensors
-        if product_type == "switch":
-            for port in getattr(device, "ports_statuses", []):
-                binary_sensor_entities.append(
-                    SwitchPortSensor(coordinator, device, port)
-                )
+    # Entities have already been discovered in __init__.py
+    binary_sensor_entities = [
+        entity
+        for entity in discovery_service.all_entities
+        if isinstance(entity, BinarySensorEntity)
+    ]
 
     if binary_sensor_entities:
         async_add_entities(binary_sensor_entities)

--- a/custom_components/meraki_ha/binary_sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/switch_port.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -13,13 +12,9 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ..coordinator import MerakiDataUpdateCoordinator
-from ..helpers.device_info_helpers import resolve_device_info
-
-if TYPE_CHECKING:
-    from ..core.models.device import MerakiAppliancePort, MerakiDevice
-
-_LOGGER = logging.getLogger(__name__)
+from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.models.device import MerakiDevice
+from ...helpers.device_info_helpers import resolve_device_info
 
 
 class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
@@ -27,15 +22,14 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
 
     coordinator: MerakiDataUpdateCoordinator
 
-    _attr_entity_registry_enabled_default = False
-    _attr_state_color = True
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_has_entity_name = True
 
     def __init__(
         self,
         coordinator: MerakiDataUpdateCoordinator,
         device: MerakiDevice,
-        port: dict[str, Any] | MerakiAppliancePort,
+        port: dict[str, Any] | Any,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -47,6 +41,8 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
 
         # MX appliances use 'number', MS switches use 'portId'
         port_id = self._port.get("portId") or self._port.get("number")
+
+        # Legacy Unique ID format to prevent breaking changes
         self._attr_unique_id = f"{device.serial}_{port_id}"
         self._attr_name = f"Port {port_id}"
 
@@ -79,7 +75,11 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        return self._port.get("status") == "Connected"
+        if not self._port.get("enabled", True):
+            return False
+
+        status = self._port.get("status", "")
+        return status is not None and status.lower() == "connected"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import entity_registry as er
 
 from ..binary_sensor.device.appliance_port import AppliancePortBinarySensor
 from ..binary_sensor.device.camera_motion import MerakiMotionSensor
-from ..binary_sensor.switch_port import SwitchPortSensor
+from ..binary_sensor.device.switch_port import SwitchPortSensor
 from ..button.device.camera_snapshot import MerakiSnapshotButton
 from ..const import DOMAIN
 from ..const_conf import (

--- a/tests/binary_sensor/test_switch_port.py
+++ b/tests/binary_sensor/test_switch_port.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
-from custom_components.meraki_ha.binary_sensor.switch_port import SwitchPortSensor
-from custom_components.meraki_ha.types import MerakiDevice
+from custom_components.meraki_ha.binary_sensor.device.switch_port import SwitchPortSensor
+from custom_components.meraki_ha.core.models.device import MerakiDevice
 
 
 def test_switch_port_sensor_connected():
@@ -19,7 +19,7 @@ def test_switch_port_sensor_connected():
         mac="00:11:22:33:44:55",
         product_type="switch",
     )
-    mock_port = {"portId": "p1", "status": "Connected"}
+    mock_port = {"portId": "p1", "status": "Connected", "enabled": True}
 
     sensor = SwitchPortSensor(mock_coordinator, mock_device, mock_port)
 
@@ -28,6 +28,26 @@ def test_switch_port_sensor_connected():
     assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
     assert sensor.name == "Port p1"
     assert sensor.unique_id == "s1_p1"
+    assert sensor.has_entity_name is True
+
+
+def test_switch_port_sensor_connected_lowercase():
+    """Test the sensor when the port is connected (lowercase status)."""
+    # Arrange
+    mock_coordinator = MagicMock()
+    mock_device = MerakiDevice(
+        serial="s1",
+        name="d1",
+        model="MS220",
+        mac="00:11:22:33:44:55",
+        product_type="switch",
+    )
+    mock_port = {"portId": "p1", "status": "connected", "enabled": True}
+
+    sensor = SwitchPortSensor(mock_coordinator, mock_device, mock_port)
+
+    # Assert
+    assert sensor.is_on is True
 
 
 def test_switch_port_sensor_disconnected():
@@ -41,7 +61,26 @@ def test_switch_port_sensor_disconnected():
         mac="00:11:22:33:44:55",
         product_type="switch",
     )
-    mock_port = {"portId": "p1", "status": "Disconnected"}
+    mock_port = {"portId": "p1", "status": "Disconnected", "enabled": True}
+
+    sensor = SwitchPortSensor(mock_coordinator, mock_device, mock_port)
+
+    # Assert
+    assert sensor.is_on is False
+
+
+def test_switch_port_sensor_disabled():
+    """Test the sensor when the port is disabled."""
+    # Arrange
+    mock_coordinator = MagicMock()
+    mock_device = MerakiDevice(
+        serial="s1",
+        name="d1",
+        model="MS220",
+        mac="00:11:22:33:44:55",
+        product_type="switch",
+    )
+    mock_port = {"portId": "p1", "status": "Connected", "enabled": False}
 
     sensor = SwitchPortSensor(mock_coordinator, mock_device, mock_port)
 


### PR DESCRIPTION
Implemented `switch_port_status` binary sensors by refactoring `SwitchPortSensor` to a dedicated device file, enhancing it with standard entity conventions, and integrating it via `DeviceDiscoveryService`. This ensures switch ports are correctly discovered and reported as binary sensors with proper connectivity status and attributes.

---
*PR created automatically by Jules for task [9847521915931429261](https://jules.google.com/task/9847521915931429261) started by @brewmarsh*