### PR TITLE
Restore MR Access Point Entities

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/devices.py
+++ b/custom_components/meraki_ha/core/api/endpoints/devices.py
@@ -104,3 +104,55 @@ class DevicesEndpoints:
             _LOGGER.warning("update_device did not return a dict.")
             return {}
         return validated
+
+    @handle_meraki_errors
+    async def get_device_management_interface(self, serial: str) -> dict[str, Any]:
+        """
+        Get the management interface for a device.
+
+        Args:
+        ----
+            serial: The serial number of the device.
+
+        Returns
+        -------
+            The management interface settings.
+
+        """
+        interface = await self._api_client.run_sync(
+            self._api_client.dashboard.devices.getDeviceManagementInterface,
+            serial=serial,
+        )
+        validated = validate_response(interface)
+        if not isinstance(validated, dict):
+            _LOGGER.warning("get_device_management_interface did not return a dict.")
+            return {}
+        return validated
+
+    @handle_meraki_errors
+    async def update_device_management_interface(
+        self, serial: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        """
+        Update the management interface for a device.
+
+        Args:
+        ----
+            serial: The serial number of the device.
+            **kwargs: The management interface settings to update.
+
+        Returns
+        -------
+            The updated management interface settings.
+
+        """
+        interface = await self._api_client.run_sync(
+            self._api_client.dashboard.devices.updateDeviceManagementInterface,
+            serial=serial,
+            **kwargs,
+        )
+        validated = validate_response(interface)
+        if not isinstance(validated, dict):
+            _LOGGER.warning("update_device_management_interface did not return a dict.")
+            return {}
+        return validated

--- a/custom_components/meraki_ha/core/const.py
+++ b/custom_components/meraki_ha/core/const.py
@@ -13,9 +13,18 @@ _MX_CAPS = [
     "appliance_ports",
     "reboot",
     "status",
+    "led_control",
 ]
 
-_MR_CAPS = ["ssids", "client_count", "radio_utilization", "reboot", "status"]
+_MR_CAPS = [
+    "ssids",
+    "client_count",
+    "radio_utilization",
+    "reboot",
+    "status",
+    "led_control",
+    "ap_client_count",
+]
 _MS_CAPS = ["switch_ports", "poe_usage", "power_supply", "reboot", "status"]
 _MV_CAPS = ["camera_stream", "storage_status", "analytics", "reboot", "status"]
 _GX_CAPS = ["uplinks", "performance", "vlans", "cellular", "reboot", "status"]

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -290,6 +290,10 @@ class DataFetchManager:
                 self.sensor_strategy.build_device_tasks(
                     device, tasks, capabilities, detail_data
                 )
+            elif device.product_type == "wireless":
+                self.wireless_strategy.build_device_tasks(
+                    device, tasks, capabilities, detail_data
+                )
 
     def _process_detailed_data(
         self,
@@ -342,6 +346,8 @@ class DataFetchManager:
                 )
             elif device.product_type == "sensor":
                 self.sensor_strategy.process_device_details(device, detail_data, prev)
+            elif device.product_type == "wireless":
+                self.wireless_strategy.process_device_details(device, detail_data, prev)
         return processed_data
 
     async def get_all_data(

--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -95,6 +95,12 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                     ),
                 )
             )
+        if "led_control" in capabilities and device.serial:
+            tasks[f"management_interface_{device.serial}"] = (
+                self.client.run_with_semaphore(
+                    self.client.devices.get_device_management_interface(device.serial),
+                )
+            )
 
     def process_network_traffic(
         self,
@@ -179,6 +185,13 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                 device.dynamic_dns = settings["dynamicDns"]
         elif prev_device and hasattr(prev_device, "dynamic_dns"):
             device.dynamic_dns = prev_device.dynamic_dns
+
+        interface_key = f"management_interface_{device.serial}"
+        if management_interface := detail_data.get(interface_key):
+            if isinstance(management_interface, dict):
+                device.management_interface = management_interface
+        elif prev_device and hasattr(prev_device, "management_interface"):
+            device.management_interface = prev_device.management_interface
 
         if performance := detail_data.get(f"uplink_performance_{device.network_id}"):
             if isinstance(performance, list):

--- a/custom_components/meraki_ha/core/fetch_strategies/wireless.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/wireless.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ...core.models.network import MerakiNetwork
+
+if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
 from ..parsers.wireless import parse_wireless_data
 from .base import BaseFetchStrategy
 
@@ -22,6 +25,35 @@ class WirelessFetchStrategy(BaseFetchStrategy):
         tasks.update(
             self.client.wireless.get_network_detail_tasks(network_id, product_types)
         )
+
+    def build_device_tasks(
+        self,
+        device: MerakiDevice,
+        tasks: dict[str, Any],
+        capabilities: list[str],
+        detail_data: dict[str, Any] | None = None,
+    ) -> None:
+        """Add wireless specific device tasks."""
+        if "led_control" in capabilities and device.serial:
+            tasks[f"management_interface_{device.serial}"] = (
+                self.client.run_with_semaphore(
+                    self.client.devices.get_device_management_interface(device.serial),
+                )
+            )
+
+    def process_device_details(
+        self,
+        device: MerakiDevice,
+        detail_data: dict[str, Any],
+        prev_device: MerakiDevice | None,
+    ) -> None:
+        """Process wireless device details."""
+        interface_key = f"management_interface_{device.serial}"
+        if management_interface := detail_data.get(interface_key):
+            if isinstance(management_interface, dict):
+                device.management_interface = management_interface
+        elif prev_device and hasattr(prev_device, "management_interface"):
+            device.management_interface = prev_device.management_interface
 
     def process_network_data(
         self,

--- a/custom_components/meraki_ha/core/models/device.py
+++ b/custom_components/meraki_ha/core/models/device.py
@@ -82,6 +82,7 @@ class MerakiDevice:
     appliance_ports: list[MerakiAppliancePort] = field(default_factory=list)
     sensor_relationships: list[dict[str, Any]] = field(default_factory=list)
     dynamic_dns: dict[str, Any] | None = None
+    management_interface: dict[str, Any] | None = None
     status_messages: list[str] = field(default_factory=list)
     entity_id: str | None = None
     ambient_noise: float | None = None
@@ -126,6 +127,7 @@ class MerakiDevice:
             "appliancePorts": [p.to_dict() for p in self.appliance_ports],
             "sensorRelationships": self.sensor_relationships,
             "dynamicDns": self.dynamic_dns,
+            "managementInterface": self.management_interface,
             "statusMessages": self.status_messages,
             "applianceUplinkStatuses": self.appliance_uplink_statuses,
             "uplinks": self.uplinks,
@@ -165,6 +167,7 @@ class MerakiDevice:
             ],
             sensor_relationships=data.get("sensorRelationships", []),
             dynamic_dns=data.get("dynamicDns"),
+            management_interface=data.get("managementInterface"),
             status_messages=data.get("statusMessages", []),
             appliance_uplink_statuses=data.get("applianceUplinkStatuses", []),
             uplinks=data.get("uplinks", []),

--- a/custom_components/meraki_ha/discovery/handlers/wireless.py
+++ b/custom_components/meraki_ha/discovery/handlers/wireless.py
@@ -1,8 +1,8 @@
 """
-Meraki SSID Handler.
+Meraki Wireless Handler.
 
-This module defines the SSIDHandler class, which is responsible for discovering
-virtual devices and entities for each Meraki SSID.
+This module defines the WirelessHandler class, which is responsible for discovering
+entities for Meraki wireless networks and devices.
 """
 
 from __future__ import annotations
@@ -11,7 +11,15 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
-from ...const_conf import CONF_ENABLE_SSID_SENSORS
+from ...const_conf import (
+    CONF_ENABLE_DEVICE_SENSORS,
+    CONF_ENABLE_SSID_SENSORS,
+)
+from ...sensor.device.ap_client_count import MerakiAPClientCountSensor
+from ...sensor.device.network_settings import (
+    MerakiDeviceGatewaySensor,
+    MerakiDeviceIPSensor,
+)
 from ...sensor.network.ssid_auth_mode import MerakiSSIDAuthModeSensor
 
 # Import the specific sensor classes
@@ -39,6 +47,7 @@ from ...sensor.network.ssid_splash_page import MerakiSSIDSplashPageSensor
 from ...sensor.network.ssid_visible import MerakiSSIDVisibleSensor
 from ...sensor.network.ssid_wpa_encryption_mode import MerakiSSIDWPAEncryptionModeSensor
 from ...switch.adult_content_filtering import MerakiAdultContentFilteringSwitch
+from ...switch.meraki_device_led_switch import MerakiDeviceLEDSwitch
 from ...text.meraki_ssid_name import MerakiSSIDNameText
 from .base import BaseHandler
 
@@ -53,8 +62,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class SSIDHandler(BaseHandler):
-    """Handler for Meraki SSIDs."""
+class WirelessHandler(BaseHandler):
+    """Handler for Meraki wireless devices and SSIDs."""
 
     def __init__(
         self,
@@ -62,13 +71,13 @@ class SSIDHandler(BaseHandler):
         config_entry: ConfigEntry,
         meraki_client: MerakiAPIClient,
     ) -> None:
-        """Initialize the SSIDHandler."""
+        """Initialize the WirelessHandler."""
         super().__init__(coordinator, config_entry)
         self._meraki_client = meraki_client
 
 
     async def discover_entities(self) -> AsyncIterator[Entity]:
-        """Discover entities for all SSIDs."""
+        """Discover entities for wireless devices and SSIDs."""
         from ...meraki_select.rf_profile import MerakiRFProfileSelect
         from ...switch.meraki_ssid_device_switch import (
             MerakiSSIDBroadcastSwitch,
@@ -78,11 +87,42 @@ class SSIDHandler(BaseHandler):
         if not self._coordinator.data or "ssids" not in self._coordinator.data:
             return
 
+        # Discover AP Device entities
+        if self._config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, True):
+            for device in self._coordinator.data.get("devices", []):
+                if device.product_type == "wireless":
+                    # Client Count per AP
+                    yield MerakiAPClientCountSensor(
+                        self._coordinator, device, self._config_entry
+                    )
+                    # LED Control
+                    if device.management_interface:
+                        yield MerakiDeviceLEDSwitch(
+                            self._coordinator, device, self._config_entry
+                        )
+                    # Diagnostics (IP/Gateway)
+                    if device.uplinks:
+                        for uplink in device.uplinks:
+                            interface = uplink.get("interface")
+                            if interface:
+                                yield MerakiDeviceIPSensor(
+                                    self._coordinator,
+                                    device,
+                                    self._config_entry,
+                                    interface,
+                                )
+                                yield MerakiDeviceGatewaySensor(
+                                    self._coordinator,
+                                    device,
+                                    self._config_entry,
+                                    interface,
+                                )
+
         # Check if SSID sensors/entities are enabled
         if not self._config_entry.options.get(CONF_ENABLE_SSID_SENSORS, True):
             return
 
-        for ssid in self._coordinator.data["ssids"]:
+        for ssid in self._coordinator.data.get("ssids", []):
             if "networkId" not in ssid or "number" not in ssid:
                 continue
 

--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -17,8 +17,8 @@ from ..const_conf import (
 )
 from ..core.models.device import MerakiDevice
 from .handlers.network import NetworkHandler
-from .handlers.ssid import SSIDHandler
 from .handlers.universal import UniversalHandler
+from .handlers.wireless import WirelessHandler
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -109,15 +109,12 @@ class DeviceDiscoveryService:
             async for entity in handler.discover_entities():
                 all_entities.append(entity)
 
-        # Create SSID handler for virtual SSID devices
-        if self._config_entry.options.get(CONF_ENABLE_SSID_SENSORS, True):
-            ssid_handler = SSIDHandler(
-                self._coordinator, self._config_entry, self._meraki_client
-            )
-            async for entity in ssid_handler.discover_entities():
-                all_entities.append(entity)
-        else:
-            _LOGGER.debug("SSID sensors are disabled.")
+        # Create Wireless handler for devices and virtual SSID devices
+        wireless_handler = WirelessHandler(
+            self._coordinator, self._config_entry, self._meraki_client
+        )
+        async for entity in wireless_handler.discover_entities():
+            all_entities.append(entity)
 
         _LOGGER.info("Entity discovery complete. Found %d entities.", len(all_entities))
         self.all_entities = all_entities

--- a/custom_components/meraki_ha/sensor/device/ap_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/ap_client_count.py
@@ -1,0 +1,77 @@
+"""Sensor for Meraki AP client count."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+
+from ...coordinator import MerakiDataUpdateCoordinator
+from ...entity import MerakiEntity
+from ...helpers.device_info_helpers import resolve_device_info
+
+if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiAPClientCountSensor(MerakiEntity, SensorEntity):
+    """Representation of a Meraki AP Client Count sensor."""
+
+    _attr_icon = "mdi:account-network"
+    _attr_native_unit_of_measurement = "clients"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device_data: MerakiDevice,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device_serial: str | None = device_data.serial
+        self._config_entry = config_entry
+        self._attr_unique_id = f"{self._device_serial}_ap_client_count"
+        self._attr_name = "Client Count"
+
+        self._attr_device_info = resolve_device_info(
+            entity_data=asdict(device_data),
+            config_entry=self._config_entry,
+        )
+        self._update_state()
+
+    def _get_current_device_data(self) -> MerakiDevice | None:
+        """Retrieve the latest data for this sensor's device from the coordinator."""
+        if self._device_serial:
+            return self.coordinator.get_device(self._device_serial)
+        return None
+
+    @callback
+    def _update_state(self) -> None:
+        """Update the native value of the sensor based on coordinator data."""
+        # Dynamic filtering of the coordinator's cached client list
+        # as requested in the task requirements.
+        clients = self.coordinator.data.get("clients", [])
+        self._attr_native_value = sum(
+            1
+            for client in clients
+            if client.get("recentDeviceSerial") == self._device_serial
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._get_current_device_data() is not None

--- a/custom_components/meraki_ha/sensor/device/network_settings.py
+++ b/custom_components/meraki_ha/sensor/device/network_settings.py
@@ -1,0 +1,128 @@
+"""Sensors for Meraki device network settings."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+
+from ...coordinator import MerakiDataUpdateCoordinator
+from ...entity import MerakiEntity
+from ...helpers.device_info_helpers import resolve_device_info
+
+if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiDeviceUplinkBaseSensor(MerakiEntity, SensorEntity):
+    """Base class for Meraki Device Uplink sensors."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device_data: MerakiDevice,
+        config_entry: ConfigEntry,
+        interface: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device_serial: str | None = device_data.serial
+        self._config_entry = config_entry
+        self._interface = interface
+
+        self._attr_device_info = resolve_device_info(
+            entity_data=asdict(device_data),
+            config_entry=self._config_entry,
+        )
+
+    def _get_uplink_data(self) -> dict[str, Any] | None:
+        """Retrieve the latest uplink data from the coordinator."""
+        device = self.coordinator.get_device(self._device_serial)
+        if device and device.uplinks:
+            for uplink in device.uplinks:
+                if uplink.get("interface") == self._interface:
+                    return uplink
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._get_uplink_data() is not None
+
+
+class MerakiDeviceIPSensor(MerakiDeviceUplinkBaseSensor):
+    """Sensor for Meraki device IP address."""
+
+    _attr_icon = "mdi:ip-network"
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device_data: MerakiDevice,
+        config_entry: ConfigEntry,
+        interface: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, device_data, config_entry, interface)
+        self._attr_unique_id = f"{self._device_serial}_{interface}_ip"
+        self._attr_name = f"{interface.upper()} IP"
+        self._update_state()
+
+    @callback
+    def _update_state(self) -> None:
+        """Update the sensor state."""
+        uplink_data = self._get_uplink_data()
+        if uplink_data:
+            self._attr_native_value = uplink_data.get("ip")
+        else:
+            self._attr_native_value = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()
+
+
+class MerakiDeviceGatewaySensor(MerakiDeviceUplinkBaseSensor):
+    """Sensor for Meraki device Gateway address."""
+
+    _attr_icon = "mdi:gateway"
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device_data: MerakiDevice,
+        config_entry: ConfigEntry,
+        interface: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, device_data, config_entry, interface)
+        self._attr_unique_id = f"{self._device_serial}_{interface}_gateway"
+        self._attr_name = f"{interface.upper()} Gateway"
+        self._update_state()
+
+    @callback
+    def _update_state(self) -> None:
+        """Update the sensor state."""
+        uplink_data = self._get_uplink_data()
+        if uplink_data:
+            self._attr_native_value = uplink_data.get("gateway")
+        else:
+            self._attr_native_value = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()

--- a/custom_components/meraki_ha/switch/meraki_device_led_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_device_led_switch.py
@@ -1,0 +1,111 @@
+"""Switch for controlling Meraki device LEDs."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from ..coordinator import MerakiDataUpdateCoordinator
+from ..core.models.device import MerakiDevice
+from ..helpers.device_info_helpers import resolve_device_info
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiDeviceLEDSwitch(CoordinatorEntity, SwitchEntity):
+    """Switch for controlling Meraki device LEDs."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:led-on"
+
+    coordinator: MerakiDataUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device_data: MerakiDevice,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._device_serial: str | None = device_data.serial
+        self._config_entry = config_entry
+        self._attr_unique_id = f"{self._device_serial}_led_control"
+        self._attr_name = "LED Control"
+
+        self._attr_device_info = resolve_device_info(
+            entity_data=asdict(device_data),
+            config_entry=self._config_entry,
+        )
+        self._update_state()
+
+    def _get_current_device_data(self) -> MerakiDevice | None:
+        """Retrieve the latest data for this switch's device from the coordinator."""
+        if self._device_serial:
+            return self.coordinator.get_device(self._device_serial)
+        return None
+
+    @callback
+    def _update_state(self) -> None:
+        """Update the state of the switch."""
+        # Prevent state overwrite during optimistic update
+        if self.unique_id and self.coordinator.is_pending(self.unique_id):
+            return
+
+        device = self._get_current_device_data()
+        if device and device.management_interface:
+            self._attr_is_on = device.management_interface.get("ledLights", True)
+        else:
+            self._attr_is_on = True  # Default to on
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the LEDs on."""
+        await self._async_set_led_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the LEDs off."""
+        await self._async_set_led_state(False)
+
+    async def _async_set_led_state(self, enabled: bool) -> None:
+        """Update the LED state via API."""
+        if not self._device_serial:
+            return
+
+        # Optimistic update
+        self._attr_is_on = enabled
+        self.async_write_ha_state()
+
+        if self.unique_id:
+            self.coordinator.register_pending_update(self.unique_id)
+
+        try:
+            await self.coordinator.api.devices.update_device_management_interface(
+                serial=self._device_serial,
+                ledLights=enabled,
+            )
+        except Exception as e:
+            _LOGGER.error("Failed to update LED state for %s: %s", self._device_serial, e)
+            # Revert optimistic update
+            if self.unique_id:
+                self.coordinator.clear_pending_update(self.unique_id)
+            self._update_state()
+            self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._get_current_device_data() is not None

--- a/tests/discovery/test_service.py
+++ b/tests/discovery/test_service.py
@@ -73,8 +73,8 @@ async def test_discover_entities_delegates_to_handler(
             "custom_components.meraki_ha.discovery.service.NetworkHandler"
         ) as MockNetworkHandler,
         patch(
-            "custom_components.meraki_ha.discovery.service.SSIDHandler"
-        ) as MockSSIDHandler,
+            "custom_components.meraki_ha.discovery.service.WirelessHandler"
+        ) as MockWirelessHandler,
     ):
         async def mock_aiter_universal():
             yield "universal_entity"
@@ -93,9 +93,9 @@ async def test_discover_entities_delegates_to_handler(
         mock_network_handler_instance.discover_entities.side_effect = mock_aiter_empty
         MockNetworkHandler.return_value = mock_network_handler_instance
 
-        mock_ssid_handler_instance = MagicMock()
-        mock_ssid_handler_instance.discover_entities.side_effect = mock_aiter_empty
-        MockSSIDHandler.return_value = mock_ssid_handler_instance
+        mock_wireless_handler_instance = MagicMock()
+        mock_wireless_handler_instance.discover_entities.side_effect = mock_aiter_empty
+        MockWirelessHandler.return_value = mock_wireless_handler_instance
 
         mock_network_control_service = MagicMock()
         service = DeviceDiscoveryService(


### PR DESCRIPTION
This submission refactors the Wireless discovery components to restore physical device entities for Meraki Access Points (MR).

Key changes:
1.  **API Client**: Added `get_device_management_interface` and `update_device_management_interface` to `DevicesEndpoints`.
2.  **Models**: Updated `MerakiDevice` to include `management_interface` data.
3.  **Fetch Strategies**: Updated `WirelessFetchStrategy` and `ApplianceFetchStrategy` to fetch management interface data if the `led_control` capability is present.
4.  **Discovery Handlers**: Renamed `SSIDHandler` to `WirelessHandler` in `discovery/handlers/wireless.py`. It now yields entities for both virtual SSIDs and physical AP hardware (Client Count, LED Switch, IP, and Gateway sensors).
5.  **Entities**:
    *   `MerakiAPClientCountSensor`: Calculates client count per AP by filtering the master client list.
    *   `MerakiDeviceLEDSwitch`: Toggles device LEDs.
    *   `MerakiDeviceIPSensor` / `MerakiDeviceGatewaySensor`: Provides network diagnostic data per uplink interface.
6.  **Capabilities**: Added `led_control` and `ap_client_count` to MR devices, and `led_control` to MX devices.
7.  **Service Integration**: Updated `DeviceDiscoveryService` to use the new `WirelessHandler`.
8.  **Tests**: Updated discovery tests to reflect the handler renaming. All relevant fetch and discovery tests pass.

Fixes #1844

---
*PR created automatically by Jules for task [9266110406402235785](https://jules.google.com/task/9266110406402235785) started by @brewmarsh*