### PR TITLE
fix: update tests and entities to match naming convention refactor

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/network.py
+++ b/custom_components/meraki_ha/binary_sensor/network.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from ..const import DOMAIN
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.models.network import MerakiNetwork
+from ..helpers.device_info_helpers import resolve_device_info
 
 
 async def async_setup_entry(
@@ -28,7 +29,10 @@ async def async_setup_entry(
 
     if coordinator.data.get("networks"):
         async_add_entities(
-            [MerakiNetworkStatus(network) for network in coordinator.data["networks"]]
+            [
+                MerakiNetworkStatus(coordinator, network)
+                for network in coordinator.data["networks"]
+            ]
         )
 
 
@@ -40,9 +44,11 @@ class MerakiNetworkStatus(BinarySensorEntity):
 
     def __init__(
         self,
+        coordinator: MerakiDataUpdateCoordinator,
         network: MerakiNetwork,
     ) -> None:
         """Initialize the sensor."""
+        self._coordinator = coordinator
         self._network = network
 
         # Ensure network ID is available
@@ -55,6 +61,12 @@ class MerakiNetworkStatus(BinarySensorEntity):
         """Return device information."""
         # Ensure network ID is available
         network_id = self._network.id or "unknown_network"
+
+        if info := resolve_device_info(
+            self._network.to_dict(), self._coordinator.config_entry
+        ):
+            return info
+
         return DeviceInfo(
             identifiers={(DOMAIN, network_id)},
             name=self._network.name,

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.models.network import MerakiNetwork
+from ...helpers.device_info_helpers import resolve_device_info
 from . import BaseMerakiEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,6 +55,10 @@ class MerakiNetworkEntity(BaseMerakiEntity):
             raise ValueError("Network cannot be None")
         if self._network.id is None:
             raise ValueError("Network ID cannot be None")
+
+        if info := resolve_device_info(self._network.to_dict(), self._config_entry):
+            return info
+
         return DeviceInfo(
             identifiers={(DOMAIN, self._network.id)},
             name=self._network.name or f"Network {self._network.id}",

--- a/tests/button/device/test_mt15_refresh_data.py
+++ b/tests/button/device/test_mt15_refresh_data.py
@@ -48,7 +48,7 @@ def test_mt15_button_creation(
     )
 
     assert button.unique_id == "mt15-1-refresh"
-    assert button.name == "MT15 Sensor Refresh Data"
+    assert button.name == "Refresh data"
     assert button.available is True
 
 

--- a/tests/button/device/test_switch_port_cycle.py
+++ b/tests/button/device/test_switch_port_cycle.py
@@ -59,7 +59,7 @@ async def test_button_initialization(
         mock_service, mock_device, port_info, mock_config_entry
     )
 
-    assert button.name == "Test Switch Port 1 Cycle"
+    assert button.name == "Port 1 cycle"
     assert button.unique_id == "Q2XX-XXXX-XXXX_port_1_cycle"
     assert button.icon == "mdi:restart"
     device_info = button.device_info

--- a/tests/camera/test_camera.py
+++ b/tests/camera/test_camera.py
@@ -28,7 +28,7 @@ def mock_camera(
 
 async def test_camera_properties(mock_camera):
     """Test the properties of the camera entity."""
-    assert mock_camera.name == "Stream"
+    assert mock_camera.name is None
     assert mock_camera.unique_id == f"{MOCK_CAMERA_DEVICE.serial}_camera"
     assert mock_camera.is_streaming is True
     assert await mock_camera.stream_source() == MOCK_CAMERA_DEVICE.rtsp_url

--- a/tests/core/test_entity_naming.py
+++ b/tests/core/test_entity_naming.py
@@ -43,7 +43,7 @@ def test_vlan_naming(mock_coordinator):
 
     entity = MerakiVLANEntity(mock_coordinator, config_entry, "N_12345", vlan)
 
-    assert entity.device_info["name"] == "Site A"
+    assert entity.device_info["name"] == "[Network] Site A"
     assert entity.name == "VLAN 10 VoIP"
 
 
@@ -74,7 +74,7 @@ def test_camera_naming(mock_coordinator):
     # In the refactor branch, we use has_entity_name=True and name=None 
     # so the entity is named after the device itself.
     assert entity.name is None
-    assert entity.device_info["name"] == "Front Door"
+    assert entity.device_info["name"] == "[Camera] Front Door"
 
 
 def test_network_status_naming(mock_coordinator):
@@ -91,9 +91,9 @@ def test_network_status_naming(mock_coordinator):
     )
     mock_coordinator.get_network.return_value = network
 
-    entity = MerakiNetworkStatus(network)
+    entity = MerakiNetworkStatus(mock_coordinator, network)
     entity.hass = MagicMock()
     entity.coordinator = mock_coordinator
 
     assert entity.name == "Uplink status"
-    assert entity.device_info["name"] == "Warehouse"
+    assert entity.device_info["name"] == "[Network] Warehouse"

--- a/tests/switch/test_meraki_ssid_device_switch.py
+++ b/tests/switch/test_meraki_ssid_device_switch.py
@@ -62,7 +62,7 @@ async def test_meraki_ssid_enabled_switch(
     assert switch.name == "Enabled Control"
     device_info = switch.device_info
     assert device_info is not None
-    assert device_info["name"] == "SSID 0: Test SSID"
+    assert device_info["name"] == "[SSID 0] Test SSID"
 
     switch.hass = hass
     switch.entity_id = "switch.test"
@@ -93,7 +93,7 @@ async def test_meraki_ssid_broadcast_switch(
     assert switch.name == "Broadcast Control"
     device_info = switch.device_info
     assert device_info is not None
-    assert device_info["name"] == "SSID 0: Test SSID"
+    assert device_info["name"] == "[SSID 0] Test SSID"
 
     switch.hass = hass
     switch.entity_id = "switch.test"

--- a/tests/switch/test_mt40_power_outlet.py
+++ b/tests/switch/test_mt40_power_outlet.py
@@ -67,7 +67,7 @@ def test_mt40_switch_state(
     switch.entity_id = "switch.mt40_power_controller_outlet"
 
     assert switch.unique_id == "mt40-1-outlet"
-    assert switch.name == "MT40 Power Controller Outlet"
+    assert switch.name == "Outlet"
     # Initial state might be None depending on initialization, but we check update
 
     # Simulate coordinator update

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -125,7 +125,7 @@ async def test_ssid_device_creation_and_unification(
         assert ssid_device is not None
 
         # Assert that the device has the correct name (default prefix format)
-        assert ssid_device.name == "SSID 0: Test SSID"
+        assert ssid_device.name == "[SSID 0] Test SSID"
 
         # Find all entities associated with this device by querying the entity registry
         entities = [

--- a/tests/test_naming_conventions.py
+++ b/tests/test_naming_conventions.py
@@ -46,7 +46,7 @@ async def test_naming_conventions():
     # Modern naming: The primary entity has no name of its own, 
     # so it presents as the Device Name in the UI.
     assert camera.name is None
-    assert camera.device_info["name"] == "Office Camera"
+    assert camera.device_info["name"] == "[Camera] Office Camera"
 
     # 2. Test Motion Sensor
     motion_sensor = MerakiMotionSensor(


### PR DESCRIPTION
This PR fixes test failures caused by the recent "Device and Entity Naming Convention" refactor. It updates the test expectations to match the new `[Prefix] Name` standard and fixes `MerakiNetworkEntity` and `MerakiNetworkStatus` to correctly use `resolve_device_info`, ensuring all network-related entities follow the canonical naming and identifier rules.

---
*PR created automatically by Jules for task [7817941628745834896](https://jules.google.com/task/7817941628745834896) started by @brewmarsh*