### PR TITLE
Fix Uplink Keys and Polish Port UI

### DIFF
--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -171,7 +171,7 @@ class UplinkPerformanceProvider:
                     "latencyMs",
                     SensorEntityDescription(
                         key=f"{interface}_latency",
-                        name=f"{interface.upper()} Latency",
+                        name=f"{interface.capitalize()} latency",
                         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
                         device_class=SensorDeviceClass.DURATION,
                         state_class=SensorStateClass.MEASUREMENT,
@@ -190,7 +190,7 @@ class UplinkPerformanceProvider:
                     "packetLoss",
                     SensorEntityDescription(
                         key=f"{interface}_packet_loss",
-                        name=f"{interface.upper()} Packet Loss",
+                        name=f"{interface.capitalize()} packet loss",
                         native_unit_of_measurement=PERCENTAGE,
                         state_class=SensorStateClass.MEASUREMENT,
                         icon="mdi:packet-loss",
@@ -208,7 +208,7 @@ class UplinkPerformanceProvider:
                     "jitter",
                     SensorEntityDescription(
                         key=f"{interface}_jitter",
-                        name=f"{interface.upper()} Jitter",
+                        name=f"{interface.capitalize()} jitter",
                         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
                         device_class=SensorDeviceClass.DURATION,
                         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -41,11 +41,6 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
         self._attr_name = f"Port {self._port.number}"
 
     @property
-    def icon(self) -> str:
-        """Return the icon of the sensor."""
-        return "mdi:ethernet" if self.native_value == "connected" else "mdi:ethernet-cable-off"
-
-    @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         if self.coordinator.config_entry:
@@ -79,11 +74,15 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the state of the sensor."""
-        if not self._port.enabled:
-            return "disabled"
+        # Strictly return "connected" or "disconnected"
         if self._port.status and self._port.status.lower() == "connected":
             return "connected"
         return "disconnected"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon of the sensor."""
+        return "mdi:ethernet" if self.native_value == "connected" else "mdi:ethernet-cable-off"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -94,4 +93,6 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
             "vlan": self._port.vlan,
             "type": self._port.type,
             "access_policy": self._port.access_policy,
+            "enabled": self._port.enabled,
+            "icon_color": "green" if self.native_value == "connected" else "grey",
         }

--- a/custom_components/meraki_ha/sensor/uplink_performance.py
+++ b/custom_components/meraki_ha/sensor/uplink_performance.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
+from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -49,8 +50,19 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
             )
         self._device_serial: str = device.serial
         self._interface = interface
+        # Map keys to match Meraki API 2.0
+        if metric == "latency":
+            metric = "latencyMs"
+        elif metric == "lossPercent":
+            metric = "packetLoss"
         self._metric = metric
         self.entity_description = description
+
+        # Set units explicitly to ensure compliance
+        if self._metric in ("latencyMs", "jitter"):
+            self._attr_native_unit_of_measurement = UnitOfTime.MILLISECONDS
+        elif self._metric == "packetLoss":
+            self._attr_native_unit_of_measurement = PERCENTAGE
 
         # Use Home Assistant Sentence Case for names
         # Entity name will be e.g. "WAN1 Latency"
@@ -74,12 +86,16 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
 
         for uplink in device.uplinks:
             if uplink.get("interface") == self._interface:
+                # Look up the metric using API 2.0 keys (latencyMs, packetLoss, jitter)
                 value = uplink.get(self._metric)
                 if value is not None:
                     try:
                         self._attr_native_value = float(value)
                     except (ValueError, TypeError):
-                        self._attr_native_value = value
+                        _LOGGER.debug(
+                            "Could not convert %s to float for %s", value, self.name
+                        )
+                        self._attr_native_value = None
                 else:
                     self._attr_native_value = None
                 return

--- a/tests/sensor/device/test_appliance_port.py
+++ b/tests/sensor/device/test_appliance_port.py
@@ -78,6 +78,8 @@ def test_appliance_port_sensor(mock_device_coordinator):
     assert sensor1.extra_state_attributes["link_speed"] == "1000 Mbps"
     assert sensor1.extra_state_attributes["vlan"] == 1
     assert sensor1.extra_state_attributes["type"] == "access"
+    assert sensor1.extra_state_attributes["icon_color"] == "green"
+    assert sensor1.icon == "mdi:ethernet"
 
     # Test disconnected port
     sensor2 = MerakiAppliancePortSensor(mock_device_coordinator, device, port2)
@@ -85,9 +87,14 @@ def test_appliance_port_sensor(mock_device_coordinator):
     assert sensor2.name == "Port 2"
     assert sensor2.native_value == "disconnected"
     assert sensor2.extra_state_attributes["link_speed"] is None
+    assert sensor2.extra_state_attributes["icon_color"] == "grey"
+    assert sensor2.icon == "mdi:ethernet-cable-off"
 
     # Test disabled port
     sensor3 = MerakiAppliancePortSensor(mock_device_coordinator, device, port3)
     assert sensor3.unique_id == "dev1_port_3"
     assert sensor3.name == "Port 3"
-    assert sensor3.native_value == "disabled"
+    assert sensor3.native_value == "disconnected"
+    assert sensor3.extra_state_attributes["enabled"] is False
+    assert sensor3.extra_state_attributes["icon_color"] == "grey"
+    assert sensor3.icon == "mdi:ethernet-cable-off"

--- a/tests/sensor/test_uplink_performance.py
+++ b/tests/sensor/test_uplink_performance.py
@@ -1,0 +1,54 @@
+"""Tests for the Meraki uplink performance sensor."""
+
+from unittest.mock import MagicMock
+import pytest
+from homeassistant.const import PERCENTAGE, UnitOfTime
+from custom_components.meraki_ha.sensor.uplink_performance import MerakiUplinkPerformanceSensor
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+from homeassistant.components.sensor import SensorEntityDescription
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mocked MerakiDataUpdateCoordinator."""
+    coordinator = MagicMock()
+    return coordinator
+
+def test_uplink_performance_sensor_mapping(mock_coordinator):
+    """Test the uplink performance sensor mapping and units."""
+    device = MerakiDevice(serial="dev1", name="Appliance")
+    device.uplinks = [
+        {"interface": "wan1", "latencyMs": 10, "packetLoss": 0.5, "jitter": 2}
+    ]
+    mock_coordinator.get_device.return_value = device
+
+    # Test latency with API 2.0 key
+    desc = SensorEntityDescription(key="wan1_latency", name="Wan1 latency")
+    sensor = MerakiUplinkPerformanceSensor(mock_coordinator, device, MagicMock(), "wan1", "latencyMs", desc)
+    assert sensor.native_value == 10.0
+    assert sensor.native_unit_of_measurement == UnitOfTime.MILLISECONDS
+
+    # Test jitter unit
+    desc_jitter = SensorEntityDescription(key="wan1_jitter", name="WAN1 Jitter")
+    sensor_jitter = MerakiUplinkPerformanceSensor(mock_coordinator, device, MagicMock(), "wan1", "jitter", desc_jitter)
+    assert sensor_jitter.native_unit_of_measurement == UnitOfTime.MILLISECONDS
+
+    # Test packet loss unit
+    desc_loss = SensorEntityDescription(key="wan1_loss", name="WAN1 Loss")
+    sensor_loss = MerakiUplinkPerformanceSensor(mock_coordinator, device, MagicMock(), "wan1", "packetLoss", desc_loss)
+    assert sensor_loss.native_value == 0.5
+    assert sensor_loss.native_unit_of_measurement == PERCENTAGE
+
+def test_uplink_performance_sensor_none_handling(mock_coordinator):
+    """Test handling of None and invalid values."""
+    device = MerakiDevice(serial="dev1", name="Appliance")
+    device.uplinks = [{"interface": "wan1", "latencyMs": None}]
+    mock_coordinator.get_device.return_value = device
+
+    desc = SensorEntityDescription(key="wan1_latency", name="Wan1 latency")
+    sensor = MerakiUplinkPerformanceSensor(mock_coordinator, device, MagicMock(), "wan1", "latencyMs", desc)
+    assert sensor.native_value is None
+
+    # Invalid value
+    device.uplinks = [{"interface": "wan1", "latencyMs": "invalid"}]
+    sensor._update_state()
+    assert sensor.native_value is None


### PR DESCRIPTION
This PR fixes the data mapping for Uplink sensors to match Meraki API 2.0 and polishes the Appliance Port sensors for a better UI experience.

Key changes:
- MerakiUplinkPerformanceSensor: Now uses `latencyMs`, `packetLoss`, and `jitter` as primary keys. Includes robust `None` handling and explicit units.
- MerakiAppliancePortSensor: Now strictly returns `connected` or `disconnected`. Added `icon_color` attribute and ensured dynamic `icon` property works correctly.
- Discovery Providers: Updated uplink performance entity names to follow Home Assistant Sentence Case standards (e.g., "Wan1 latency").
- Tests: Added new tests for uplink performance mapping and updated port sensor tests.

Fixes #1836

---
*PR created automatically by Jules for task [2460527371760196179](https://jules.google.com/task/2460527371760196179) started by @brewmarsh*