### PR TITLE
fix: resolve test failures and double prefix bug from naming refactor

### DIFF
--- a/custom_components/meraki_ha/core/helpers/device_registry.py
+++ b/custom_components/meraki_ha/core/helpers/device_registry.py
@@ -56,7 +56,7 @@ def async_ensure_network_devices_exist(
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             identifiers={(DOMAIN, f"network_{network_id}")},
-            name=f"[Network] {network_name}",
+            name=network_name,
             manufacturer="Cisco Meraki",
             model="Meraki Network",
         )

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -121,7 +121,7 @@ async def test_vlan_sensor_creation(mock_coordinator):
     assert id_sensor.unique_id == "meraki_vlan_net1_1_vlan_id"
     # assert id_sensor.name == "VLAN ID" # Cannot access name without platform
     assert id_sensor.native_value == 1
-    assert id_sensor.device_info["name"] == "Test Network"
+    assert id_sensor.device_info["name"] == "[Network] Test Network"
 
     # Assertions for IPv4 Enabled Sensor
     assert ipv4_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv4_enabled"

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -29,7 +29,7 @@ async def test_network_device_creation(
     await hass.async_block_till_done()
 
     device = device_registry.async_get_device(
-        identifiers={("meraki_ha", MERAKI_TEST_NETWORK_ID)}
+        identifiers={("meraki_ha", f"network_{MERAKI_TEST_NETWORK_ID}")}
     )
     assert device is not None
-    assert device.name == "Site A"
+    assert device.name == "[Network] Site A"


### PR DESCRIPTION
Fixed test failures in `tests/sensor/network/test_vlan.py` and `tests/test_topology.py` that were caused by the recent naming convention refactor. 

Also fixed a bug in `custom_components/meraki_ha/core/helpers/device_registry.py` where network device names were being double-prefixed (e.g., `[Network] [Network] Name`).

Verified that tests pass with these changes.

---
*PR created automatically by Jules for task [3450213056295396532](https://jules.google.com/task/3450213056295396532) started by @brewmarsh*