### PR TITLE
fix: resolve test failures and linting errors from refactor

### DIFF
--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -174,7 +174,10 @@ class MerakiMtSensor(CoordinatorEntity, RestoreSensor):
     def unique_id(self) -> str | None:
         """Return a unique ID."""
         if hasattr(self, "_device") and self._device and self._device.serial:
-            return f"{self._device.serial}{self.__class__.__name__.lower()}"
+            uid = f"{self._device.serial}{self.__class__.__name__.lower()}"
+            if self.__class__.__name__ == "MerakiMtSensor":
+                uid += f"_{self.entity_description.key}"
+            return uid
         return getattr(self, "_attr_unique_id", None)
 
     @property

--- a/custom_components/meraki_ha/sensor/network/base.py
+++ b/custom_components/meraki_ha/sensor/network/base.py
@@ -72,7 +72,10 @@ class MerakiSSIDBaseSensor(CoordinatorEntity, SensorEntity):
         """Return a unique ID."""
         # For SSID-based entities, the combination of network ID and SSID number
         # acts as the unique identifier for the virtual "device".
-        return f"{self._network_id}ssid{self._ssid_number}{self.__class__.__name__.lower()}"
+        return (
+            f"{self._network_id}ssid{self._ssid_number}"
+            f"{self.__class__.__name__.lower()}"
+        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/switch/camera_settings.py
+++ b/custom_components/meraki_ha/switch/camera_settings.py
@@ -95,7 +95,11 @@ class MerakiCameraSettingSwitchBase(
     @property
     def unique_id(self) -> str | None:
         """Return a unique ID."""
-        if hasattr(self, "_device_data") and self._device_data and self._device_data.serial:
+        if (
+            hasattr(self, "_device_data")
+            and self._device_data
+            and self._device_data.serial
+        ):
             return f"{self._device_data.serial}{self.__class__.__name__.lower()}"
         return getattr(self, "_attr_unique_id", None)
 

--- a/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
@@ -70,7 +70,10 @@ class MerakiSSIDBaseSwitch(CoordinatorEntity, SwitchEntity):
         """Return a unique ID."""
         # For SSID-based entities, the combination of network ID and SSID number
         # acts as the unique identifier for the virtual "device".
-        return f"{self._network_id}ssid{self._ssid_number}{self.__class__.__name__.lower()}"
+        return (
+            f"{self._network_id}ssid{self._ssid_number}"
+            f"{self.__class__.__name__.lower()}"
+        )
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
+++ b/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
@@ -73,7 +73,7 @@ def test_mt20_open_sensor(
         mock_coordinator_mt_binary, device_info, MT_DOOR_DESCRIPTION
     )
 
-    assert sensor.unique_id == "mt20-1_door"
+    assert sensor.unique_id == "mt20-1merakimtbinarysensor"
     assert sensor.name == "Door"
     assert sensor.is_on is True
     assert sensor.available is True
@@ -88,7 +88,7 @@ def test_mt12_water_sensor(
         mock_coordinator_mt_binary, device_info, MT_WATER_DESCRIPTION
     )
 
-    assert sensor.unique_id == "mt12-1_water"
+    assert sensor.unique_id == "mt12-1merakimtbinarysensor"
     assert sensor.name == "Water Leak"
     assert sensor.is_on is True
     assert sensor.available is True
@@ -103,7 +103,7 @@ def test_mt12_dry_sensor(
         mock_coordinator_mt_binary, device_info, MT_WATER_DESCRIPTION
     )
 
-    assert sensor.unique_id == "mt12-2_water"
+    assert sensor.unique_id == "mt12-2merakimtbinarysensor"
     assert sensor.name == "Water Leak"
     assert sensor.is_on is False
     assert sensor.available is True

--- a/tests/camera/test_camera.py
+++ b/tests/camera/test_camera.py
@@ -29,7 +29,7 @@ def mock_camera(
 async def test_camera_properties(mock_camera):
     """Test the properties of the camera entity."""
     assert mock_camera.name is None
-    assert mock_camera.unique_id == f"{MOCK_CAMERA_DEVICE.serial}_camera"
+    assert mock_camera.unique_id == f"{MOCK_CAMERA_DEVICE.serial}merakirtspstreamcamera"
     assert mock_camera.is_streaming is True
     assert await mock_camera.stream_source() == MOCK_CAMERA_DEVICE.rtsp_url
 

--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -39,7 +39,7 @@ async def test_appliance_features_fetching_behavior() -> None:
     mock_client.appliance.get_network_appliance_content_filtering = AsyncMock(
         return_value={}
     )
-    mock_client.appliance.get_network_appliance_uplinks_performance = AsyncMock(
+    mock_client.appliance.get_network_appliance_uplinks_loss_and_latency = AsyncMock(
         return_value=[]
     )
     mock_client.network.get_network_traffic = AsyncMock(return_value=[])

--- a/tests/event/device/test_camera_motion_event.py
+++ b/tests/event/device/test_camera_motion_event.py
@@ -35,7 +35,7 @@ async def test_camera_motion_event_initialization(
             mock_coordinator, device, mock_camera_service, mock_config_entry
         )
 
-        assert entity.unique_id == "Q2XX-XXXX-XXXX-motion-event"
+        assert entity.unique_id == "Q2XX-XXXX-XXXXmerakicameramotionevent"
         assert entity.name == "Motion Event"
         assert entity.device_class == EventDeviceClass.MOTION
         assert entity.event_types == ["motion", "person", "vehicle"]

--- a/tests/event/device/test_mt_button_event.py
+++ b/tests/event/device/test_mt_button_event.py
@@ -23,7 +23,7 @@ async def test_mt_button_event_initialization(
     ):
         entity = MerakiMtButtonEvent(mock_coordinator, device, mock_config_entry)
 
-        assert entity.unique_id == "Q2XX-XXXX-XXXX_button_event"
+        assert entity.unique_id == "Q2XX-XXXX-XXXXmerakimtbuttonevent"
         assert entity.name == "Button Press"
         assert entity.device_class == EventDeviceClass.BUTTON
         assert entity.event_types == ["short_press", "long_press"]

--- a/tests/sensor/device/test_device_status.py
+++ b/tests/sensor/device/test_device_status.py
@@ -73,7 +73,7 @@ def test_device_status_sensor(mock_device_coordinator):
     config_entry.options = {}
 
     sensor1 = MerakiDeviceStatusSensor(mock_device_coordinator, device1, config_entry)
-    assert sensor1.unique_id == "Q2XX-XXXX-XXXX_device_status"
+    assert sensor1.unique_id == "Q2XX-XXXX-XXXXmerakidevicestatussensor"
     assert sensor1.native_value == "online"
     assert sensor1.icon == "mdi:access-point-network"
     assert sensor1.extra_state_attributes["model"] == "MR56"
@@ -85,7 +85,7 @@ def test_device_status_sensor(mock_device_coordinator):
     assert sensor1.device_info["suggested_area"] == "123 Street"
 
     sensor2 = MerakiDeviceStatusSensor(mock_device_coordinator, device2, config_entry)
-    assert sensor2.unique_id == "Q2YY-YYYY-YYYY_device_status"
+    assert sensor2.unique_id == "Q2YY-YYYY-YYYYmerakidevicestatussensor"
     assert sensor2.native_value == "alerting"
     assert sensor2.icon == "mdi:access-point-network-off"
     assert sensor2.extra_state_attributes["product_type"] == "appliance"

--- a/tests/sensor/device/test_meraki_mt_base.py
+++ b/tests/sensor/device/test_meraki_mt_base.py
@@ -48,7 +48,7 @@ def test_meraki_mt_sensor_entity_id(mock_coordinator: MagicMock) -> None:
     # However, we can't easily test the full HA entity ID generation here.
     # Instead, we will check that the components we provide are correct.
 
-    assert sensor.unique_id == "Q3CA-2CG4-6LBK_temperature"
+    assert sensor.unique_id == "Q3CA-2CG4-6LBKmerakimtsensor_temperature"
     assert sensor.name == "Temperature"
     assert sensor.has_entity_name is True
     assert sensor.entity_id is None

--- a/tests/sensor/device/test_meraki_mt_sensor.py
+++ b/tests/sensor/device/test_meraki_mt_sensor.py
@@ -83,7 +83,7 @@ def test_mt10_temperature_sensor(
     )
     sensor._update_native_value()
 
-    assert sensor.unique_id == "mt10-1_temperature"
+    assert sensor.unique_id == "mt10-1merakimtsensor_temperature"
     assert sensor.name == "Temperature"
     assert sensor.native_value == 25.5
     assert sensor.device_class == SensorDeviceClass.TEMPERATURE
@@ -100,7 +100,7 @@ def test_mt10_battery_sensor(
     )
     sensor._update_native_value()
 
-    assert sensor.unique_id == "mt10-1_battery"
+    assert sensor.unique_id == "mt10-1merakimtsensor_battery"
     assert sensor.name == "Battery"
     assert sensor.native_value == 95
     assert sensor.device_class == SensorDeviceClass.BATTERY
@@ -117,7 +117,7 @@ def test_mt30_button_sensor(
     )
     sensor._update_native_value()
 
-    assert sensor.unique_id == "mt30-1_button"
+    assert sensor.unique_id == "mt30-1merakimtsensor_button"
     assert sensor.name == "Last Button Press"
     assert sensor.native_value == "short"
     assert sensor.available is True

--- a/tests/sensor/network/test_ssid_psk.py
+++ b/tests/sensor/network/test_ssid_psk.py
@@ -23,7 +23,7 @@ async def test_ssid_psk_sensor() -> None:
 
     sensor = MerakiSSIDPSKSensor(coordinator, config_entry, ssid_data_psk)
     assert sensor.name == "PSK"
-    assert sensor.unique_id == "N_123ssid0_psk"
+    assert sensor.unique_id == "N_123ssid0merakissidpsksensor"
     assert sensor.native_value == "secret123"
 
     # Test update with new PSK

--- a/tests/sensor/test_setup_mt_sensors.py
+++ b/tests/sensor/test_setup_mt_sensors.py
@@ -144,7 +144,7 @@ async def test_async_setup_mt10_sensors(
     assert "temperature" in sensors_by_key
     temp_sensor = sensors_by_key["temperature"]
     assert isinstance(temp_sensor, SensorEntity)
-    assert temp_sensor.unique_id == "mt10-1_temperature"
+    assert temp_sensor.unique_id == "mt10-1merakitemperaturesensor"
     assert temp_sensor.name == "Temperature"
     assert temp_sensor.native_value == 25.5
     assert temp_sensor.available is True
@@ -153,7 +153,7 @@ async def test_async_setup_mt10_sensors(
     assert "humidity" in sensors_by_key
     humidity_sensor = sensors_by_key["humidity"]
     assert isinstance(humidity_sensor, SensorEntity)
-    assert humidity_sensor.unique_id == "mt10-1_humidity"
+    assert humidity_sensor.unique_id == "mt10-1merakihumiditysensor"
     assert humidity_sensor.name == "Humidity"
     assert humidity_sensor.native_value == 60.0
     assert humidity_sensor.available is True
@@ -197,7 +197,7 @@ async def test_async_setup_mt15_sensors(
     temp_sensor = sensors_by_key.get("temperature")
     assert temp_sensor is not None
     assert isinstance(temp_sensor, SensorEntity)
-    assert temp_sensor.unique_id == "mt15-1_temperature"
+    assert temp_sensor.unique_id == "mt15-1merakitemperaturesensor"
     assert temp_sensor.name == "Temperature"
     assert temp_sensor.native_value == 22.1
     assert temp_sensor.available is True
@@ -206,7 +206,7 @@ async def test_async_setup_mt15_sensors(
     humidity_sensor = sensors_by_key.get("humidity")
     assert humidity_sensor is not None
     assert isinstance(humidity_sensor, SensorEntity)
-    assert humidity_sensor.unique_id == "mt15-1_humidity"
+    assert humidity_sensor.unique_id == "mt15-1merakihumiditysensor"
     assert humidity_sensor.name == "Humidity"
     assert humidity_sensor.native_value == 45.2
     assert humidity_sensor.available is True
@@ -215,7 +215,7 @@ async def test_async_setup_mt15_sensors(
     co2_sensor = sensors_by_key.get("co2")
     assert co2_sensor is not None
     assert isinstance(co2_sensor, SensorEntity)
-    assert co2_sensor.unique_id == "mt15-1_co2"
+    assert co2_sensor.unique_id == "mt15-1merakico2sensor"
     assert co2_sensor.name == "CO2"
     assert co2_sensor.native_value == 450
     assert co2_sensor.available is True
@@ -224,7 +224,7 @@ async def test_async_setup_mt15_sensors(
     tvoc_sensor = sensors_by_key.get("tvoc")
     assert tvoc_sensor is not None
     assert isinstance(tvoc_sensor, SensorEntity)
-    assert tvoc_sensor.unique_id == "mt15-1_tvoc"
+    assert tvoc_sensor.unique_id == "mt15-1merakitvocsensor"
     assert tvoc_sensor.name == "TVOC"
     assert tvoc_sensor.native_value == 150
     assert tvoc_sensor.available is True
@@ -233,7 +233,7 @@ async def test_async_setup_mt15_sensors(
     pm25_sensor = sensors_by_key.get("pm25")
     assert pm25_sensor is not None
     assert isinstance(pm25_sensor, SensorEntity)
-    assert pm25_sensor.unique_id == "mt15-1_pm25"
+    assert pm25_sensor.unique_id == "mt15-1merakipm25sensor"
     assert pm25_sensor.name == "PM2.5"
     assert pm25_sensor.native_value == 10.5
     assert pm25_sensor.available is True
@@ -242,7 +242,7 @@ async def test_async_setup_mt15_sensors(
     noise_sensor = sensors_by_key.get("noise")
     assert noise_sensor is not None
     assert isinstance(noise_sensor, SensorEntity)
-    assert noise_sensor.unique_id == "mt15-1_noise"
+    assert noise_sensor.unique_id == "mt15-1merakinoisesensor"
     assert noise_sensor.name == "Ambient Noise"
     assert noise_sensor.native_value == 35.2
     assert noise_sensor.available is True
@@ -285,7 +285,7 @@ async def test_async_setup_mt12_sensors(
     water_sensor = sensors_by_key.get("water")
     assert water_sensor is not None
     assert isinstance(water_sensor, BinarySensorEntity)
-    assert water_sensor.unique_id == "mt12-1_water"
+    assert water_sensor.unique_id == "mt12-1merakiwatersensor"
     assert water_sensor.name == "Water Leak"
     assert water_sensor.is_on is False
     assert water_sensor.available is True
@@ -331,7 +331,7 @@ async def test_async_setup_mt40_sensors(
     power_sensor = sensors_by_key.get("realPower")
     assert power_sensor is not None
     assert isinstance(power_sensor, SensorEntity)
-    assert power_sensor.unique_id == "mt40-1_realPower"
+    assert power_sensor.unique_id == "mt40-1merakimtsensor_realPower"
     # The translation key is not set in MT_POWER_DESCRIPTION, so it defaults to
     # None (or name is used)
     # assert power_sensor.translation_key == "power"
@@ -342,7 +342,7 @@ async def test_async_setup_mt40_sensors(
     voltage_sensor = sensors_by_key.get("voltage")
     assert voltage_sensor is not None
     assert isinstance(voltage_sensor, SensorEntity)
-    assert voltage_sensor.unique_id == "mt40-1_voltage"
+    assert voltage_sensor.unique_id == "mt40-1merakimtsensor_voltage"
     assert voltage_sensor.translation_key == "voltage"
     assert voltage_sensor.native_value == 120.1
     assert voltage_sensor.available is True
@@ -351,7 +351,7 @@ async def test_async_setup_mt40_sensors(
     current_sensor = sensors_by_key.get("current")
     assert current_sensor is not None
     assert isinstance(current_sensor, SensorEntity)
-    assert current_sensor.unique_id == "mt40-1_current"
+    assert current_sensor.unique_id == "mt40-1merakimtsensor_current"
     assert current_sensor.translation_key == "current"
     assert current_sensor.native_value == 1.0
     assert current_sensor.available is True
@@ -360,7 +360,7 @@ async def test_async_setup_mt40_sensors(
     pf_sensor = sensors_by_key.get("powerFactor")
     assert pf_sensor is not None
     assert isinstance(pf_sensor, SensorEntity)
-    assert pf_sensor.unique_id == "mt40-1_powerFactor"
+    assert pf_sensor.unique_id == "mt40-1merakimtsensor_powerFactor"
     assert pf_sensor.name == "Power Factor"
     assert pf_sensor.native_value == 98.0
     assert pf_sensor.available is True
@@ -369,7 +369,7 @@ async def test_async_setup_mt40_sensors(
     freq_sensor = sensors_by_key.get("frequency")
     assert freq_sensor is not None
     assert isinstance(freq_sensor, SensorEntity)
-    assert freq_sensor.unique_id == "mt40-1_frequency"
+    assert freq_sensor.unique_id == "mt40-1merakimtsensor_frequency"
     assert freq_sensor.name == "Frequency"
     assert freq_sensor.native_value == 60.0
     assert freq_sensor.available is True
@@ -378,7 +378,7 @@ async def test_async_setup_mt40_sensors(
     energy_sensor = sensors_by_key.get("energy")
     assert energy_sensor is not None
     assert isinstance(energy_sensor, SensorEntity)
-    assert energy_sensor.unique_id == "mt40-1_energy"
+    assert energy_sensor.unique_id == "mt40-1merakimtsensor_energy"
     assert energy_sensor.name == "Energy"
     assert energy_sensor.native_value == 500.0
     assert energy_sensor.available is True

--- a/tests/switch/test_camera_profiles.py
+++ b/tests/switch/test_camera_profiles.py
@@ -48,7 +48,7 @@ async def test_camera_sense_switch(hass, mock_device_coordinator, mock_api_clien
     switch.entity_id = "switch.mv_sense"
     switch.async_write_ha_state = MagicMock()
 
-    assert switch.unique_id == "cam1_sense_enabled"
+    assert switch.unique_id == "cam1merakicamerasenseswitch"
     assert switch.name == "MV Sense"
     assert switch.is_on is True
 
@@ -86,7 +86,7 @@ async def test_camera_audio_detection_switch(
     switch.entity_id = "switch.audio_detection"
     switch.async_write_ha_state = MagicMock()
 
-    assert switch.unique_id == "cam1_audio_detection"
+    assert switch.unique_id == "cam1merakicameraaudiodetectionswitch"
     assert switch.name == "Audio Detection"
     assert switch.is_on is True
 


### PR DESCRIPTION
This PR addresses test failures and linting errors that arose following the "Final Stability Refactor - API and Unique IDs".

Key changes:
1.  **Test Updates:** Updated expected `unique_id` values in `test_setup_mt_sensors.py`, `test_meraki_mt_binary_sensor.py`, `test_camera.py`, etc., to align with the new `{serial}{classname.lower()}` standard.
2.  **Implementation Fix:** Modified `MerakiMtSensor.unique_id` in `meraki_mt_base.py`. For the generic `MerakiMtSensor` class (used by MT40 power monitoring), it now appends `_{entity_description.key}` to the unique ID. This prevents ID collisions when multiple sensors of the same generic class exist on a single device, while preserving the standard format for subclasses like `MerakiTemperatureSensor`.
3.  **API Mock Update:** Updated `test_data_fetch_manager_features.py` to mock `get_network_appliance_uplinks_loss_and_latency`, reflecting the API method actually used in `ApplianceFetchStrategy`.
4.  **Linting Fixes:** Resolved line length violations in `sensor/network/base.py`, `switch/camera_settings.py`, and `switch/meraki_ssid_device_switch.py`.

All 285 tests passed, and pre-commit checks (ruff, bandit, mypy) are green.

---
*PR created automatically by Jules for task [13363922973145436987](https://jules.google.com/task/13363922973145436987) started by @brewmarsh*