### PR TITLE
Handle Port Fetch 400 Error in ApplianceFetchStrategy

### DIFF
--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+import meraki
+from meraki.exceptions import APIError
+
 from ...core.errors import (
     MerakiInformationalError,
     MerakiTrafficAnalysisError,
@@ -18,6 +21,8 @@ if TYPE_CHECKING:
     from ...core.api.client import MerakiAPIClient
 
 _LOGGER = logging.getLogger(__name__)
+
+_VLAN_WARNING_LOGGED = False
 
 
 class ApplianceFetchStrategy(BaseFetchStrategy):
@@ -66,7 +71,7 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                 self.client.appliance.get_vpn_status(network_id),
             )
         tasks[f"appliance_ports_{network_id}"] = self.client.run_with_semaphore(
-            self.client.appliance.get_appliance_ports(network_id),
+            self._async_get_appliance_ports(network_id),
         )
         tasks[f"content_filtering_{network_id}"] = self.client.run_with_semaphore(
             self.client.appliance.get_network_appliance_content_filtering(
@@ -78,6 +83,21 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                 network_id,
             ),
         )
+
+    async def _async_get_appliance_ports(self, network_id: str) -> list[dict[str, Any]]:
+        """Fetch appliance ports with graceful error handling for disabled VLANs."""
+        try:
+            return await self.client.appliance.get_appliance_ports(network_id)
+        except APIError as e:
+            if e.status == 400 and "VLANs" in str(e):
+                global _VLAN_WARNING_LOGGED
+                if not _VLAN_WARNING_LOGGED:
+                    _LOGGER.warning(
+                        "Port status/control requires VLANs to be enabled in Meraki Dashboard."
+                    )
+                    _VLAN_WARNING_LOGGED = True
+                return []
+            raise
 
     def build_device_tasks(
         self,


### PR DESCRIPTION
Refactored ApplianceFetchStrategy to gracefully handle the "VLANs not enabled" error (HTTP 400) when fetching appliance ports. The fix involves wrapping the API call in a guarded method that catches meraki.APIError, checks for the specific 400 VLAN condition, logs a one-time warning, and returns an empty list. This ensures that the integration remains resilient even when VLANs are disabled in the Meraki Dashboard, allowing other appliance sensors to continue functioning.

Fixes #1873

---
*PR created automatically by Jules for task [4015378426307717657](https://jules.google.com/task/4015378426307717657) started by @brewmarsh*