### PR TITLE
Standardize Unique IDs for Device Sensors

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
+++ b/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
@@ -15,12 +15,12 @@ from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator as MerakiDataCoordinator
 from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
-from ...entity import MerakiEntity
+from ...entity import MerakiBinarySensor, MerakiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiMtBinarySensor(MerakiEntity, BinarySensorEntity):
+class MerakiMtBinarySensor(MerakiBinarySensor):
     """Representation of a Meraki MT binary sensor."""
 
     def __init__(
@@ -37,12 +37,6 @@ class MerakiMtBinarySensor(MerakiEntity, BinarySensorEntity):
         if self.entity_description.name is not UNDEFINED:
             self._attr_name = cast(str | None, self.entity_description.name)
 
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID that prevents platform collisions."""
-        if hasattr(self, "_device") and self._device and self._device.serial:
-            return f"{self._device.serial}{self.__class__.__name__.lower()}"
-        return getattr(self, "_attr_unique_id", None)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -1,5 +1,7 @@
 """Base entity for all Meraki entities."""
 
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import MerakiDataUpdateCoordinator
@@ -51,3 +53,51 @@ class MerakiEntity(CoordinatorEntity):
 
         # Final fallback to manually assigned _attr_unique_id
         return getattr(self, "_attr_unique_id", None)
+
+
+class MerakiSensor(MerakiEntity, SensorEntity):
+    """Base Meraki sensor entity."""
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        serial = None
+        if hasattr(self, "_device") and self._device and hasattr(self._device, "serial"):
+            serial = self._device.serial
+        elif hasattr(self, "_device_serial"):
+            serial = self._device_serial
+        elif hasattr(self, "_serial"):
+            serial = self._serial
+
+        if (
+            serial
+            and hasattr(self, "entity_description")
+            and self.entity_description
+            and self.entity_description.key
+        ):
+            return f"{serial}{self.entity_description.key}"
+        return super().unique_id
+
+
+class MerakiBinarySensor(MerakiEntity, BinarySensorEntity):
+    """Base Meraki binary sensor entity."""
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        serial = None
+        if hasattr(self, "_device") and self._device and hasattr(self._device, "serial"):
+            serial = self._device.serial
+        elif hasattr(self, "_device_serial"):
+            serial = self._device_serial
+        elif hasattr(self, "_serial"):
+            serial = self._serial
+
+        if (
+            serial
+            and hasattr(self, "entity_description")
+            and self.entity_description
+            and self.entity_description.key
+        ):
+            return f"{serial}{self.entity_description.key}"
+        return super().unique_id

--- a/custom_components/meraki_ha/sensor/device/ap_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/ap_client_count.py
@@ -6,12 +6,16 @@ import logging
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...entity import MerakiEntity
+from ...entity import MerakiSensor
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
@@ -20,7 +24,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiAPClientCountSensor(MerakiEntity, SensorEntity):
+class MerakiAPClientCountSensor(MerakiSensor):
     """Representation of a Meraki AP Client Count sensor."""
 
     _attr_icon = "mdi:account-network"
@@ -38,8 +42,10 @@ class MerakiAPClientCountSensor(MerakiEntity, SensorEntity):
         super().__init__(coordinator)
         self._device_serial: str | None = device_data.serial
         self._config_entry = config_entry
-        self._attr_unique_id = f"{self._device_serial}_ap_client_count"
-        self._attr_name = "Client Count"
+        self.entity_description = SensorEntityDescription(
+            key="ap_client_count",
+            name="Client Count",
+        )
 
         self._attr_device_info = resolve_device_info(
             entity_data=asdict(device_data),

--- a/custom_components/meraki_ha/sensor/device/connected_clients.py
+++ b/custom_components/meraki_ha/sensor/device/connected_clients.py
@@ -6,12 +6,16 @@ import logging
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...entity import MerakiEntity
+from ...entity import MerakiSensor
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
@@ -20,7 +24,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiDeviceConnectedClientsSensor(MerakiEntity, SensorEntity):
+class MerakiDeviceConnectedClientsSensor(MerakiSensor):
     """Representation of a Meraki Connected Clients sensor."""
 
     _attr_icon = "mdi:account-network"
@@ -37,8 +41,10 @@ class MerakiDeviceConnectedClientsSensor(MerakiEntity, SensorEntity):
         super().__init__(coordinator)
         self._device_serial: str | None = device_data.serial
         self._config_entry = config_entry
-        self._attr_unique_id = f"{self._device_serial}_connected_clients"
-        self._attr_name = "Connected Clients"
+        self.entity_description = SensorEntityDescription(
+            key="connected_clients",
+            name="Connected Clients",
+        )
 
         self._attr_device_info = resolve_device_info(
             entity_data=asdict(device_data),

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -23,12 +23,12 @@ from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
-from ...entity import MerakiEntity
+from ...entity import MerakiEntity, MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiDeviceStatusSensor(MerakiEntity, SensorEntity):
+class MerakiDeviceStatusSensor(MerakiSensor):
     """
     Representation of a Meraki Device Status sensor.
 
@@ -68,9 +68,6 @@ class MerakiDeviceStatusSensor(MerakiEntity, SensorEntity):
         super().__init__(coordinator)
         self._device_serial: str = cast(str, device_data.serial)  # Serial is mandatory
 
-        # Set up unique ID
-        self._attr_unique_id = f"{self._device_serial}{self.__class__.__name__.lower()}"
-
         # Set device info for linking to HA device registry
         # This uses the initial device_data for static info.
         self._attr_device_info = DeviceInfo(
@@ -98,10 +95,6 @@ class MerakiDeviceStatusSensor(MerakiEntity, SensorEntity):
         # Initial update of state and attributes
         self._update_sensor_data()
 
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID."""
-        return self._attr_unique_id
 
     @property
     def icon(self) -> str:

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -17,12 +17,12 @@ from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
-from ...entity import MerakiEntity
+from ...entity import MerakiEntity, MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiMtSensor(MerakiEntity, RestoreSensor):
+class MerakiMtSensor(MerakiSensor, RestoreSensor):
     """Representation of a Meraki MT sensor."""
 
     def __init__(
@@ -164,17 +164,6 @@ class MerakiMtSensor(MerakiEntity, RestoreSensor):
             self._update_native_value()
             self.async_write_ha_state()
 
-    @property
-    def unique_id(self) -> str | None:
-        """Return a unique ID that prevents platform collisions."""
-        if hasattr(self, "_device") and self._device and self._device.serial:
-            # Format: serial_classname_metrickey
-            # This ensures multiple sensors on the same device stay separate.
-            return (
-                f"{self._device.serial}_{self.__class__.__name__.lower()}_"
-                f"{self.entity_description.key}"
-            )
-        return getattr(self, "_attr_unique_id", None)
 
     @property
     def native_value(self) -> str | float | bool | None:

--- a/custom_components/meraki_ha/sensor/device/switch_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/switch_client_count.py
@@ -6,12 +6,16 @@ import logging
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...entity import MerakiEntity
+from ...entity import MerakiSensor
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
@@ -20,7 +24,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiSwitchClientCountSensor(MerakiEntity, SensorEntity):
+class MerakiSwitchClientCountSensor(MerakiSensor):
     """Representation of a Meraki Switch Client Count sensor."""
 
     _attr_icon = "mdi:account-network"
@@ -38,8 +42,10 @@ class MerakiSwitchClientCountSensor(MerakiEntity, SensorEntity):
         super().__init__(coordinator)
         self._device_serial: str | None = device_data.serial
         self._config_entry = config_entry
-        self._attr_unique_id = f"{self._device_serial}_switch_client_count"
-        self._attr_name = "Client Count"
+        self.entity_description = SensorEntityDescription(
+            key="switch_client_count",
+            name="Client Count",
+        )
 
         self._attr_device_info = resolve_device_info(
             entity_data=asdict(device_data),

--- a/custom_components/meraki_ha/sensor/uplink_performance.py
+++ b/custom_components/meraki_ha/sensor/uplink_performance.py
@@ -14,7 +14,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from ..const import DOMAIN
-from ..entity import MerakiEntity
+from ..entity import MerakiEntity, MerakiSensor
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiSensor(MerakiEntity, SensorEntity):
-    """Base class for Meraki sensors."""
 
 
 class MerakiUplinkPerformanceSensor(MerakiSensor):


### PR DESCRIPTION
Standardized unique_id generation for Meraki device sensors and binary sensors to prevent collisions and ensure consistency with Home Assistant best practices. Introduced MerakiSensor and MerakiBinarySensor base classes in entity.py and refactored existing sensors to inherit from them.

Fixes #1874

---
*PR created automatically by Jules for task [10366536888353199079](https://jules.google.com/task/10366536888353199079) started by @brewmarsh*