### PR TITLE
fix: update test mock for API silencing and resolve linting errors

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -6,8 +6,6 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-import meraki
-
 from ...core.const import DEFAULT_CAPS, DEVICE_CAPABILITIES
 
 # Import the custom errors so we can pass them to strategies
@@ -123,7 +121,8 @@ class DataFetchManager:
                     for silent_msg in SILENT_ERRORS:
                         if silent_msg in error_msg:
                             _LOGGER.debug(
-                                "Skipping %s: Configuration requirement not met in Meraki Dashboard.",
+                                "Skipping %s: Configuration requirement not met in "
+                                "Meraki Dashboard.",
                                 key,
                             )
                             is_silent = True

--- a/tests/core/coordinator_helpers/test_graceful_degradation.py
+++ b/tests/core/coordinator_helpers/test_graceful_degradation.py
@@ -29,6 +29,7 @@ class MockAPIError(meraki.APIError):
         self.test_message = message
 
     def __str__(self):
+        """Return the test message."""
         return str(self.test_message)
 
 
@@ -148,7 +149,8 @@ async def test_async_gather_with_timeout_true_failures_still_log_error(
     with patch(
         "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER"
     ) as mock_logger:
-        # result will be None because _handle_fetch_exception returns None and logs error
+        # result will be None because _handle_fetch_exception returns None
+        # and logs error
         results = await data_fetch_manager._async_gather_with_timeout(
             tasks, label="Test Failure"
         )

--- a/tests/core/utils/test_api_silencing.py
+++ b/tests/core/utils/test_api_silencing.py
@@ -50,7 +50,7 @@ class DummyEndpoint:
             MockResponse(
                 400,
                 "Bad Request",
-                {"errors": ["VLANs are not enabled"]},
+                {"errors": ["VLANs are not enabled for this network"]},
             ),
         )
 


### PR DESCRIPTION
This PR fixes a failing test in `tests/core/utils/test_api_silencing.py` by aligning the mock error message with the strict string check implemented in `api_utils.py` ("VLANs are not enabled for this network").

It also resolves several linting errors (line length, missing docstring) identified by `ruff` in `custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py` and `tests/core/coordinator_helpers/test_graceful_degradation.py`.

All tests passed successfully using `run_checks.sh`.

---
*PR created automatically by Jules for task [17344299040563977968](https://jules.google.com/task/17344299040563977968) started by @brewmarsh*