### PR TITLE
Promote VLANs to Top-Level Devices

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import DeviceInfo
 
+from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from .meraki_network_entity import MerakiNetworkEntity
 
@@ -24,21 +26,26 @@ class MerakiVLANEntity(MerakiNetworkEntity):
         network = coordinator.get_network(network_id)
         if network is None:
             raise ValueError(f"Network {network_id} not found for VLAN entity")
+
+        # Set attributes needed for device_info BEFORE super().__init__
+        # because BaseMerakiEntity.__init__ logs device_info
+        self._vlan = vlan
+        self._vlan_id = vlan["id"]
+        self._vlan_data = vlan
+
         super().__init__(
             coordinator=coordinator,
             config_entry=config_entry,
             network=network,
         )
-        self._vlan = vlan
 
-        vlan_id = vlan["id"]
-        vlan_label = vlan.get("name") or ""
-        prefix = f"VLAN {vlan_id}"
-        if vlan_label:
-            prefix = f"{prefix} {vlan_label}"
-
-        current_name = getattr(self, "_attr_name", None)
-        if current_name:
-            self._attr_name = f"{prefix} {current_name}"
-        else:
-            self._attr_name = prefix
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the VLAN."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._network_id}vlan{self._vlan_id}")},
+            name=f"[VLAN {self._vlan_id}] {self._vlan_data.get('name', '')}",
+            via_device=(DOMAIN, f"network_{self._network_id}"),
+            model="Virtual Local Area Network",
+            manufacturer="Cisco Meraki",
+        )

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -92,8 +92,7 @@ async def test_vlan_sensor_creation(mock_coordinator):
     assert len(vlan_sensors) == 14
 
     # Filter for sensors of the first VLAN
-    # Note: With has_entity_name=True, the name property returns the entity name
-    vlan1_sensors = [s for s in vlan_sensors if "VLAN 1 VLAN 1" in s.name]
+    vlan1_sensors = [s for s in vlan_sensors if getattr(s, "_vlan_id", None) == 1]
     assert len(vlan1_sensors) == 7
 
     # Find the specific sensors for VLAN 1 by translation_key
@@ -121,40 +120,30 @@ async def test_vlan_sensor_creation(mock_coordinator):
     assert id_sensor.unique_id == "meraki_vlan_net1_1_vlan_id"
     # assert id_sensor.name == "VLAN ID" # Cannot access name without platform
     assert id_sensor.native_value == 1
-    assert id_sensor.device_info["name"] == "[Network] Test Network"
+    assert id_sensor.device_info["name"] == "[VLAN 1] VLAN 1"
+    assert id_sensor.device_info["identifiers"] == {("meraki_ha", "net1vlan1")}
+    assert id_sensor.device_info["via_device"] == ("meraki_ha", "network_net1")
 
     # Assertions for IPv4 Enabled Sensor
     assert ipv4_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv4_enabled"
-    # assert ipv4_enabled_sensor.name == "IPv4 Enabled"
-    # Cannot access name without platform
     assert ipv4_enabled_sensor.native_value is True
 
     # Assertions for IPv4 Interface IP Sensor
     assert ipv4_ip_sensor.unique_id == "meraki_vlan_net1_1_ipv4_interface_ip"
-    # assert ipv4_ip_sensor.name == "IPv4 Interface IP"
-    # Cannot access name without platform
     assert ipv4_ip_sensor.native_value == "192.168.1.1"
 
     # Assertions for IPv4 Uplink Sensor
     assert ipv4_uplink_sensor.unique_id == "meraki_vlan_net1_1_ipv4_uplink"
-    # assert ipv4_uplink_sensor.name == "IPv4 Uplink"
-    # Cannot access name without platform
     assert ipv4_uplink_sensor.native_value == "Any"
 
     # Assertions for IPv6 Enabled Sensor
     assert ipv6_enabled_sensor.unique_id == "meraki_vlan_net1_1_ipv6_enabled"
-    # assert ipv6_enabled_sensor.name == "IPv6 Enabled"
-    # Cannot access name without platform
     assert ipv6_enabled_sensor.native_value is True
 
     # Assertions for IPv6 Interface IP Sensor
     assert ipv6_ip_sensor.unique_id == "meraki_vlan_net1_1_ipv6_interface_ip"
-    # assert ipv6_ip_sensor.name == "IPv6 Interface IP"
-    # Cannot access name without platform
     assert ipv6_ip_sensor.native_value == "2001:db8:1::/64"
 
     # Assertions for IPv6 Uplink Sensor
     assert ipv6_uplink_sensor.unique_id == "meraki_vlan_net1_1_ipv6_uplink"
-    # assert ipv6_uplink_sensor.name == "IPv6 Uplink"
-    # Cannot access name without platform
     assert ipv6_uplink_sensor.native_value == "WAN 1, WAN 2"


### PR DESCRIPTION
This change promotes Meraki VLANs to top-level devices in Home Assistant. Previously, VLAN-related entities were directly attached to the Network device. Now, each VLAN appears as its own device, with entities such as IPv4/IPv6 interface IPs, DHCP status, etc., grouped under it. This follows Home Assistant's architectural standards for logical network segments.

Key changes:
- `MerakiVLANEntity` now overrides `device_info`.
- Identifiers follow the format `(DOMAIN, f"{network_id}vlan{vlan_id}")`.
- Parent link (`via_device`) points to the Network device.
- Removed manual name prefixing in `MerakiVLANEntity.__init__` to leverage `has_entity_name = True` for cleaner UI presentation.
- Updated `tests/sensor/network/test_vlan.py` to match the new structure.

Fixes #1891

---
*PR created automatically by Jules for task [16191694888067384067](https://jules.google.com/task/16191694888067384067) started by @brewmarsh*