### PR TITLE
Force Camera Entity Creation & Fix RTSP Logic

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -10,7 +10,7 @@ from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
-from .const_conf import CONF_RTSP_STREAM_ENABLED
+from .const_conf import CONF_ENABLE_CAMERA_ENTITIES, CONF_RTSP_STREAM_ENABLED
 from .entity import MerakiEntity
 from .helpers.device_info_helpers import resolve_device_info
 
@@ -42,32 +42,8 @@ async def async_setup_entry(
     camera_entities: list[MerakiRTSPStreamCamera] = []
 
     for device in devices:
-        if device.product_type != "camera":
-            continue
-
-        # If configured, ensure the RTSP stream is enabled for cameras
-        if (
-            config_entry.options.get(CONF_RTSP_STREAM_ENABLED, False)
-            and not device.rtsp_url
-        ):
-            try:
-                _LOGGER.debug(
-                    "RTSP stream is defaulted to on, enabling for camera %s",
-                    device.serial,
-                )
-                await camera_service.async_set_rtsp_stream_enabled(
-                    str(device.serial), True
-                )
-            except Exception as e:
-                _LOGGER.warning(
-                    "Could not enable RTSP stream for %s: %s", device.serial, e
-                )
-                coordinator.add_status_message(
-                    str(device.serial), f"Could not enable RTSP stream: {e}"
-                )
-
-        if device.rtsp_url:
-            _LOGGER.debug("Found camera with RTSP URL: %s", device.serial)
+        if device.product_type == "camera":
+            _LOGGER.debug("Found camera device: %s", device.serial)
             camera_entities.append(
                 MerakiRTSPStreamCamera(
                     coordinator,
@@ -135,6 +111,27 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         """Return device information."""
         return resolve_device_info(self.device_data, self._config_entry)
 
+    async def async_added_to_hass(self) -> None:
+        """Handle when entity is added to hass."""
+        await super().async_added_to_hass()
+
+        if (
+            self._config_entry.options.get(CONF_ENABLE_CAMERA_ENTITIES, True)
+            and not self.device_data.rtsp_url
+        ):
+            try:
+                _LOGGER.debug(
+                    "RTSP stream is missing, enabling for camera %s",
+                    self._device_serial,
+                )
+                await self._camera_service.async_set_rtsp_stream_enabled(
+                    self._device_serial, True
+                )
+            except Exception as e:
+                _LOGGER.warning(
+                    "Could not enable RTSP stream for %s: %s", self._device_serial, e
+                )
+
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
@@ -160,10 +157,14 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
     @property
     def is_streaming(self) -> bool:
         """Return True if the camera is streaming."""
-        return self.device_data.rtsp_url is not None
+        if self.device_data.rtsp_url is None:
+            return False
+        return True
 
     async def stream_source(self) -> str | None:
         """Return the source of the stream."""
+        if self.device_data.rtsp_url is None:
+            return None
         return self.device_data.rtsp_url
 
     @property

--- a/tests/camera/test_camera_auto_stream.py
+++ b/tests/camera/test_camera_auto_stream.py
@@ -1,0 +1,107 @@
+"""Tests for the Meraki RTSP stream camera auto-enablement."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.meraki_ha.camera import MerakiRTSPStreamCamera
+from custom_components.meraki_ha.const_conf import CONF_ENABLE_CAMERA_ENTITIES
+from tests.const import MOCK_CAMERA_DEVICE
+
+
+@pytest.fixture
+def mock_camera(
+    mock_coordinator: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_camera_service: AsyncMock,
+) -> MerakiRTSPStreamCamera:
+    """Create a mock MerakiRTSPStreamCamera entity."""
+    mock_coordinator.get_device.return_value = MOCK_CAMERA_DEVICE
+    return MerakiRTSPStreamCamera(
+        coordinator=mock_coordinator,
+        device=MOCK_CAMERA_DEVICE,
+        camera_service=mock_camera_service,
+        config_entry=mock_config_entry,
+    )
+
+
+@pytest.mark.asyncio
+async def test_camera_auto_enables_stream(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+    mock_coordinator: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_camera_service: AsyncMock,
+) -> None:
+    """Test that the camera auto-enables RTSP stream when missing."""
+    # Arrange
+    mock_camera.hass = hass
+    # Set device data to have no RTSP URL
+    # We need to make sure the property returns this
+    from unittest.mock import PropertyMock
+    with patch.object(MerakiRTSPStreamCamera, "device_data", new_callable=PropertyMock) as mock_device_data:
+        # Create a copy with None rtsp_url
+        import dataclasses
+        device_no_rtsp = dataclasses.replace(MOCK_CAMERA_DEVICE, rtsp_url=None)
+        mock_device_data.return_value = device_no_rtsp
+
+        # Enable camera entities option
+        mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: True}
+
+        # Act
+        await mock_camera.async_added_to_hass()
+
+        # Assert
+        mock_camera_service.async_set_rtsp_stream_enabled.assert_awaited_once_with(
+            MOCK_CAMERA_DEVICE.serial, True
+        )
+
+
+@pytest.mark.asyncio
+async def test_camera_does_not_auto_enable_if_already_streaming(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+    mock_coordinator: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_camera_service: AsyncMock,
+) -> None:
+    """Test that the camera does not auto-enable if RTSP URL is already present."""
+    # Arrange
+    mock_camera.hass = hass
+    # device_data already has rtsp_url from MOCK_CAMERA_DEVICE
+    mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: True}
+
+    # Act
+    await mock_camera.async_added_to_hass()
+
+    # Assert
+    mock_camera_service.async_set_rtsp_stream_enabled.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_camera_does_not_auto_enable_if_option_disabled(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+    mock_coordinator: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_camera_service: AsyncMock,
+) -> None:
+    """Test that the camera does not auto-enable if option is disabled."""
+    # Arrange
+    mock_camera.hass = hass
+    # Set device data to have no RTSP URL
+    from unittest.mock import PropertyMock
+    with patch.object(MerakiRTSPStreamCamera, "device_data", new_callable=PropertyMock) as mock_device_data:
+        import dataclasses
+        device_no_rtsp = dataclasses.replace(MOCK_CAMERA_DEVICE, rtsp_url=None)
+        mock_device_data.return_value = device_no_rtsp
+
+        # Disable camera entities option
+        mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: False}
+
+        # Act
+        await mock_camera.async_added_to_hass()
+
+        # Assert
+        mock_camera_service.async_set_rtsp_stream_enabled.assert_not_called()


### PR DESCRIPTION
This change ensures that Meraki camera entities are always created in Home Assistant if the hardware is present, even if the RTSP stream isn't enabled yet. The entity will now appear as 'Idle' and automatically request the RTSP URL in the background if configured to do so. This improves the user experience by making entities immediately available and self-healing.

Fixes #1899

---
*PR created automatically by Jules for task [14648005004131302249](https://jules.google.com/task/14648005004131302249) started by @brewmarsh*