### PR TITLE
Add Network Alert Automation Trigger

### DIFF
--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -11,3 +11,5 @@ VERSION: Final = "2.3.0-beta.120"
 # Merged Constants - Adopting beta's explicit naming style with fix's descriptive value
 WEBHOOK_ID_FORMAT: Final = "meraki_ha_webhook_{entry_id}"
 DATA_CLIENT: Final = "meraki_client"
+
+EVENT_MERAKI_WEBHOOK_ALERT: Final = "meraki_ha_webhook_alert"

--- a/custom_components/meraki_ha/device_trigger.py
+++ b/custom_components/meraki_ha/device_trigger.py
@@ -1,0 +1,111 @@
+"""Provides device triggers for Meraki."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, EVENT_MERAKI_WEBHOOK_ALERT
+
+TRIGGER_TYPE = "meraki_alert"
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): TRIGGER_TYPE,
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device triggers for Meraki devices."""
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(device_id)
+
+    if device is None:
+        return []
+
+    # Check if this device belongs to our domain
+    is_meraki_device = False
+    for identifier in device.identifiers:
+        if identifier[0] == DOMAIN:
+            is_meraki_device = True
+            break
+
+    if not is_meraki_device:
+        return []
+
+    return [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: device_id,
+            CONF_TYPE: TRIGGER_TYPE,
+        }
+    ]
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    device_registry = dr.async_get(hass)
+    device_id = config[CONF_DEVICE_ID]
+    device = device_registry.async_get(device_id)
+
+    if device is None:
+        return lambda: None
+
+    # Extract serial from identifiers
+    serial = None
+    for identifier in device.identifiers:
+        if identifier[0] == DOMAIN:
+            serial = identifier[1]
+            break
+
+    if not serial:
+        return lambda: None
+
+    @callback
+    def handle_event(event: Event) -> None:
+        data = event.data
+        match = False
+
+        # Check for device serial match
+        if "deviceSerial" in data and data["deviceSerial"] == serial:
+            match = True
+
+        # Check for network ID match if the device is a Network device
+        elif serial.startswith("network_") and "networkId" in data:
+            network_id = serial[8:]  # remove "network_"
+            if data["networkId"] == network_id:
+                match = True
+
+        if match:
+            hass.async_run_job(
+                action,
+                {
+                    "trigger": {
+                        **config,
+                        "description": f"Meraki Alert: {data.get('alertType', 'Unknown')}",
+                        "payload": data,
+                    }
+                },
+                event.context,
+            )
+
+    return hass.bus.async_listen(EVENT_MERAKI_WEBHOOK_ALERT, handle_event)

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -283,5 +283,10 @@
         "name": "Button Press"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "meraki_alert": "Received Meraki Alert"
+    }
   }
 }

--- a/custom_components/meraki_ha/webhook.py
+++ b/custom_components/meraki_ha/webhook.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from aiohttp import web
+from homeassistant.components import webhook
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
-from .const import DOMAIN
+from .const import DOMAIN, EVENT_MERAKI_WEBHOOK_ALERT
 from .core.errors import MerakiConnectionError
 
 if TYPE_CHECKING:
@@ -119,6 +120,10 @@ async def async_register_webhook(
         entry: The config entry.
 
     """
+    webhook.async_register(
+        hass, DOMAIN, "Meraki", webhook_id, async_handle_webhook
+    )
+
     try:
         webhook_url_from_entry = entry.data.get("webhook_url") if entry else None
         webhook_url = get_webhook_url(hass, webhook_id, webhook_url_from_entry)
@@ -132,7 +137,7 @@ async def async_register_webhook(
 
 async def async_unregister_webhook(
     hass: HomeAssistant,
-    config_entry_id: str,
+    webhook_id: str,
     api_client: MerakiAPIClient,
 ) -> None:
     """
@@ -145,7 +150,8 @@ async def async_unregister_webhook(
         api_client: The Meraki API client.
 
     """
-    await api_client.unregister_webhook(config_entry_id)
+    webhook.async_unregister(hass, webhook_id)
+    await api_client.unregister_webhook(webhook_id)
 
 
 async def async_handle_webhook(
@@ -179,6 +185,9 @@ async def async_handle_webhook(
     if not secret or data.get("sharedSecret") != secret:
         _LOGGER.warning("Received webhook with invalid secret: %s", webhook_id)
         return
+
+    # Fire event for automation triggers
+    hass.bus.async_fire(EVENT_MERAKI_WEBHOOK_ALERT, data)
 
     coordinator = entry_data.get("coordinator")
     if not coordinator:

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -1,0 +1,187 @@
+"""The tests for Meraki device triggers."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_get_device_automations,
+    async_mock_service,
+)
+
+from homeassistant.components import automation
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from custom_components.meraki_ha.const import DOMAIN, EVENT_MERAKI_WEBHOOK_ALERT
+
+
+@pytest.fixture
+def device_reg(hass: HomeAssistant) -> dr.DeviceRegistry:
+    """Return an empty, loaded, registry."""
+    return dr.async_get(hass)
+
+
+@pytest.fixture
+def service_calls(hass: HomeAssistant) -> list[ServiceCall]:
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+@pytest.mark.asyncio
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_reg: dr.DeviceRegistry,
+    enable_custom_integrations: None,
+) -> None:
+    """Test we get the expected triggers from a Meraki device."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "Q234-ABCD-5678")},
+        name="Test Device",
+        manufacturer="Meraki",
+        model="MR33",
+    )
+
+    expected_trigger = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DOMAIN,
+        CONF_TYPE: "meraki_alert",
+        CONF_DEVICE_ID: device_entry.id,
+        "metadata": {},
+    }
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_entry.id
+    )
+    assert expected_trigger in triggers
+
+
+@pytest.mark.asyncio
+async def test_fire_trigger_device_alert(
+    hass: HomeAssistant,
+    device_reg: dr.DeviceRegistry,
+    enable_custom_integrations: None,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for device alert triggers firing."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "Q234-ABCD-5678")},
+    )
+
+    assert await async_setup_component(hass, "trace", {})
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_entry.id,
+                        CONF_TYPE: "meraki_alert",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "{{ trigger.payload.alertType }}"},
+                    },
+                }
+            ]
+        },
+    )
+
+    # Fire event for this device
+    hass.bus.async_fire(
+        EVENT_MERAKI_WEBHOOK_ALERT,
+        {
+            "alertType": "APs went down",
+            "deviceSerial": "Q234-ABCD-5678",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == "APs went down"
+
+    # Fire event for another device
+    hass.bus.async_fire(
+        EVENT_MERAKI_WEBHOOK_ALERT,
+        {
+            "alertType": "APs went down",
+            "deviceSerial": "OTHER-SERIAL",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1  # Should not increase
+
+
+@pytest.mark.asyncio
+async def test_fire_trigger_network_alert(
+    hass: HomeAssistant,
+    device_reg: dr.DeviceRegistry,
+    enable_custom_integrations: None,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test for network alert triggers firing."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={})
+    config_entry.add_to_hass(hass)
+    # Create a network device
+    network_id = "N_12345"
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"network_{network_id}")},
+        name="Test Network",
+        model="Meraki Network",
+    )
+
+    assert await async_setup_component(hass, "trace", {})
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_entry.id,
+                        CONF_TYPE: "meraki_alert",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {"msg": "network alert"},
+                    },
+                }
+            ]
+        },
+    )
+
+    # Fire event for this network
+    hass.bus.async_fire(
+        EVENT_MERAKI_WEBHOOK_ALERT,
+        {
+            "alertType": "Network alert",
+            "networkId": network_id,
+            # No deviceSerial for network-wide alerts typically, or irrelevant
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["msg"] == "network alert"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError
 
-from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.const import DOMAIN, EVENT_MERAKI_WEBHOOK_ALERT
 from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.types import MerakiDevice
 from custom_components.meraki_ha.webhook import async_handle_webhook, get_webhook_url
@@ -144,6 +144,39 @@ async def test_handle_webhook_unknown_alert(
 
     # Assert
     coordinator.async_update_listeners.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_fires_event(
+    mock_hass_with_webhook_data: HomeAssistant,
+) -> None:
+    """Test that a valid webhook fires an event."""
+    # Arrange
+    webhook_id = "test_webhook_id"
+    request = AsyncMock()
+    data = {
+        "sharedSecret": "test_secret",
+        "alertType": "Any alert",
+        "deviceSerial": "Q234-ABCD-5678",
+    }
+    request.json.return_value = data
+
+    events = []
+
+    def event_listener(event):
+        events.append(event)
+
+    mock_hass_with_webhook_data.bus.async_listen(
+        EVENT_MERAKI_WEBHOOK_ALERT, event_listener
+    )
+
+    # Act
+    await async_handle_webhook(mock_hass_with_webhook_data, webhook_id, request)
+    await mock_hass_with_webhook_data.async_block_till_done()
+
+    # Assert
+    assert len(events) == 1
+    assert events[0].data == data
 
 
 def test_get_webhook_url_fallback(hass: HomeAssistant) -> None:

--- a/tests/test_webhook_registration.py
+++ b/tests/test_webhook_registration.py
@@ -6,7 +6,11 @@ import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.meraki_ha.webhook import async_register_webhook
+from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.webhook import (
+    async_handle_webhook,
+    async_register_webhook,
+)
 
 
 @pytest.fixture
@@ -30,7 +34,7 @@ async def test_register_webhook_call(hass: HomeAssistant, mock_api_client):
     with patch(
         "custom_components.meraki_ha.webhook.get_webhook_url",
         return_value="https://example.com/api/webhook/test",
-    ):
+    ), patch("homeassistant.components.webhook.async_register") as mock_ha_register:
         await async_register_webhook(
             hass, "test_webhook_id", "test_secret", mock_api_client, entry=entry
         )
@@ -39,4 +43,8 @@ async def test_register_webhook_call(hass: HomeAssistant, mock_api_client):
     # entry
     mock_api_client.register_webhook.assert_called_once_with(
         "https://example.com/api/webhook/test", "test_secret", "test_entry_id"
+    )
+
+    mock_ha_register.assert_called_once_with(
+        hass, DOMAIN, "Meraki", "test_webhook_id", async_handle_webhook
     )


### PR DESCRIPTION
Implemented device automation trigger for Meraki alerts.
- **Webhook Registration**: Now registers the webhook handler with Home Assistant using `webhook.async_register` to ensure it listens for incoming requests.
- **Event Firing**: Fires `meraki_ha_webhook_alert` event when a valid webhook is received.
- **Device Trigger**: Added `meraki_alert` trigger type that filters events by device serial or network ID.
- **Testing**: Added tests for trigger execution and webhook handling.

---
*PR created automatically by Jules for task [10488329079125035570](https://jules.google.com/task/10488329079125035570) started by @brewmarsh*