### PR TITLE
Fix Duplicate Sensors (Stop Double Discovery)

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/switch.py
+++ b/custom_components/meraki_ha/discovery/handlers/switch.py
@@ -34,6 +34,17 @@ class SwitchHandler(BaseHandler):
         # Discover Switch Device entities
         if self._config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, True):
             for device in self._coordinator.data.get("devices", []):
+                # Add Exclusion Logic
+                if device.product_type == "appliance" or (
+                    device.model
+                    and (device.model.startswith("MX") or device.model.startswith("Z3"))
+                ):
+                    _LOGGER.debug(
+                        "Skipping device %s in Switch Handler (Handled by Appliance Handler)",
+                        device.serial,
+                    )
+                    continue
+
                 if device.product_type == "switch":
                     # Client Count per Switch
                     yield MerakiSwitchClientCountSensor(

--- a/tests/discovery/handlers/test_switch.py
+++ b/tests/discovery/handlers/test_switch.py
@@ -1,0 +1,112 @@
+"""Tests for the SwitchHandler."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+from custom_components.meraki_ha.discovery.handlers.switch import SwitchHandler
+from custom_components.meraki_ha.sensor.device.switch_client_count import (
+    MerakiSwitchClientCountSensor,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mock MerakiDataUpdateCoordinator."""
+    coordinator = MagicMock()
+    coordinator.data = {}
+    return coordinator
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Fixture for a mock ConfigEntry."""
+    config_entry = MagicMock()
+    config_entry.options = {}
+    return config_entry
+
+
+@pytest.mark.asyncio
+async def test_switch_handler_exclusion_logic(mock_coordinator, mock_config_entry):
+    """Test that SwitchHandler excludes appliances and Z3 devices."""
+    # Define devices with ports to satisfy reviewer concern
+    mx_appliance = MerakiDevice(
+        serial="MX_SERIAL",
+        model="MX64",
+        product_type="appliance",
+        ports_statuses=[{"portId": "1", "enabled": True}]
+    )
+    z3_appliance = MerakiDevice(
+        serial="Z3_SERIAL",
+        model="Z3",
+        product_type="appliance",
+        ports_statuses=[{"portId": "1", "enabled": True}]
+    )
+    # Some devices might have product_type="switch" but are MX models
+    mx_labeled_switch = MerakiDevice(
+        serial="MX_SWITCH_SERIAL",
+        model="MX67",
+        product_type="switch",
+        ports_statuses=[{"portId": "1", "enabled": True}]
+    )
+    normal_switch = MerakiDevice(
+        serial="MS_SERIAL",
+        model="MS120",
+        product_type="switch",
+        ports_statuses=[{"portId": "1", "enabled": True}]
+    )
+    wireless_device = MerakiDevice(
+        serial="MR_SERIAL",
+        model="MR36",
+        product_type="wireless"
+    )
+
+    mock_coordinator.data = {
+        "devices": [
+            mx_appliance,
+            z3_appliance,
+            mx_labeled_switch,
+            normal_switch,
+            wireless_device,
+        ]
+    }
+
+    handler = SwitchHandler(mock_coordinator, mock_config_entry)
+
+    with patch("custom_components.meraki_ha.discovery.handlers.switch._LOGGER") as mock_logger:
+        entities = []
+        async for entity in handler.discover_entities():
+            entities.append(entity)
+
+        # Assertions
+        # Should only have 1 entity (the normal switch's client count)
+        # Even though appliances have ports_statuses, SwitchHandler doesn't yield port sensors,
+        # and it should skip processing them entirely due to the new logic.
+        assert len(entities) == 1
+        assert isinstance(entities[0], MerakiSwitchClientCountSensor)
+        assert entities[0]._device_serial == "MS_SERIAL"
+
+        # Check debug logs for skips
+        # MX_SERIAL (product_type="appliance")
+        # Z3_SERIAL (product_type="appliance")
+        # MX_SWITCH_SERIAL (model starts with "MX")
+        assert mock_logger.debug.call_count == 3
+
+        # Verify specific skip messages
+        skip_calls = [call.args[1] for call in mock_logger.debug.call_args_list]
+        assert "MX_SERIAL" in skip_calls
+        assert "Z3_SERIAL" in skip_calls
+        assert "MX_SWITCH_SERIAL" in skip_calls
+
+@pytest.mark.asyncio
+async def test_switch_handler_no_data(mock_coordinator, mock_config_entry):
+    """Test SwitchHandler with no coordinator data."""
+    mock_coordinator.data = None
+    handler = SwitchHandler(mock_coordinator, mock_config_entry)
+
+    entities = []
+    async for entity in handler.discover_entities():
+        entities.append(entity)
+
+    assert len(entities) == 0

--- a/tests/switch/test_switch_port_entity.py
+++ b/tests/switch/test_switch_port_entity.py
@@ -15,6 +15,8 @@ from custom_components.meraki_ha.switch.switch_port import MerakiSwitchPortSwitc
 def mock_meraki_client():
     """Mock the Meraki API client."""
     client = MagicMock()
+    # Mock the switch endpoints wrapper
+    client.switch = MagicMock()
     client.switch.update_device_switch_port = AsyncMock()
     return client
 
@@ -26,6 +28,9 @@ def mock_coordinator(hass, mock_meraki_client):
     coordinator.hass = hass
     coordinator.api = mock_meraki_client
     coordinator.config_entry = MockConfigEntry(domain=DOMAIN, data={})
+    coordinator.is_pending = MagicMock(return_value=False)
+    coordinator.register_pending_update = MagicMock()
+    coordinator.cancel_pending_update = MagicMock()
 
     # Mock get_device to return updated device
     coordinator.get_device = MagicMock()
@@ -42,6 +47,7 @@ def mock_device():
     device.status = "online"
     device.model = "MS220-8P"
     device.url = "https://dashboard.meraki.com"
+    device.ports_statuses = []
     return device
 
 
@@ -51,9 +57,12 @@ async def test_switch_port_switch_init(
     """Test switch initialization."""
     port_data = {"portId": "1", "enabled": True, "status": "Connected"}
 
-    switch = MerakiSwitchPortSwitch(mock_coordinator, mock_device, port_data)
+    switch = MerakiSwitchPortSwitch(
+        mock_coordinator, mock_device, port_data, mock_coordinator.config_entry
+    )
 
-    assert switch.unique_id == "Q2AA-1111-2222_port_1_switch"
+    # Standardized format is {serial}_port_switch_{port_id}
+    assert switch.unique_id == "Q2AA-1111-2222_port_switch_1"
     assert switch.name == "Port 1 Enabled"
     assert switch.is_on is True
     assert switch.available is True
@@ -62,7 +71,9 @@ async def test_switch_port_switch_init(
 async def test_switch_port_turn_on(hass: HomeAssistant, mock_coordinator, mock_device):
     """Test turning the switch on."""
     port_data = {"portId": "1", "enabled": False}
-    switch = MerakiSwitchPortSwitch(mock_coordinator, mock_device, port_data)
+    switch = MerakiSwitchPortSwitch(
+        mock_coordinator, mock_device, port_data, mock_coordinator.config_entry
+    )
     switch.hass = hass
     switch.async_write_ha_state = MagicMock()
 
@@ -70,14 +81,16 @@ async def test_switch_port_turn_on(hass: HomeAssistant, mock_coordinator, mock_d
 
     assert switch.is_on is True
     mock_coordinator.api.switch.update_device_switch_port.assert_called_once_with(
-        "Q2AA-1111-2222", "1", enabled=True
+        serial="Q2AA-1111-2222", port_id="1", enabled=True
     )
 
 
 async def test_switch_port_turn_off(hass: HomeAssistant, mock_coordinator, mock_device):
     """Test turning the switch off."""
     port_data = {"portId": "1", "enabled": True}
-    switch = MerakiSwitchPortSwitch(mock_coordinator, mock_device, port_data)
+    switch = MerakiSwitchPortSwitch(
+        mock_coordinator, mock_device, port_data, mock_coordinator.config_entry
+    )
     switch.hass = hass
     switch.async_write_ha_state = MagicMock()
 
@@ -85,21 +98,23 @@ async def test_switch_port_turn_off(hass: HomeAssistant, mock_coordinator, mock_
 
     assert switch.is_on is False
     mock_coordinator.api.switch.update_device_switch_port.assert_called_once_with(
-        "Q2AA-1111-2222", "1", enabled=False
+        serial="Q2AA-1111-2222", port_id="1", enabled=False
     )
 
 
 async def test_switch_port_update(hass: HomeAssistant, mock_coordinator, mock_device):
     """Test updating the switch state from coordinator."""
     port_data = {"portId": "1", "enabled": True}
-    switch = MerakiSwitchPortSwitch(mock_coordinator, mock_device, port_data)
+    switch = MerakiSwitchPortSwitch(
+        mock_coordinator, mock_device, port_data, mock_coordinator.config_entry
+    )
     switch.hass = hass
     switch.async_write_ha_state = MagicMock()
 
     # Simulate update
     new_port_data = {"portId": "1", "enabled": False}
     mock_device.ports_statuses = [new_port_data]
-    mock_coordinator.get_device.return_value = mock_device
+    mock_coordinator.data = {"devices": [mock_device]}
 
     switch._handle_coordinator_update()
 
@@ -112,7 +127,9 @@ async def test_switch_port_update_error(
 ):
     """Test error handling during update."""
     port_data = {"portId": "1", "enabled": True}
-    switch = MerakiSwitchPortSwitch(mock_coordinator, mock_device, port_data)
+    switch = MerakiSwitchPortSwitch(
+        mock_coordinator, mock_device, port_data, mock_coordinator.config_entry
+    )
     switch.hass = hass
     switch.async_write_ha_state = MagicMock()
 
@@ -123,4 +140,5 @@ async def test_switch_port_update_error(
     with pytest.raises(Exception):
         await switch.async_turn_off()
 
-    assert switch.is_on is True  # Should revert to True
+    # State in UI was changed optimistically to False, but should be reverted to True on failure
+    assert switch.is_on is True


### PR DESCRIPTION
Refactored `SwitchHandler` to exclude appliances (MX and Z3 models) to prevent duplicate sensors. Fixed unrelated test failures and added a new test case for the exclusion logic.

Fixes #1909

---
*PR created automatically by Jules for task [12867194012912679926](https://jules.google.com/task/12867194012912679926) started by @brewmarsh*