### PR TITLE
Fix "Unknown" Uplink Data (The API Patch)

### DIFF
--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -78,9 +78,7 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
             ),
         )
         tasks[f"uplink_performance_{network_id}"] = self.client.run_with_semaphore(
-            self.client.appliance.get_network_appliance_uplinks_performance(
-                network_id,
-            ),
+            self._get_uplink_performance(network_id),
         )
 
     async def _async_get_appliance_ports(self, network_id: str) -> list[dict[str, Any]]:
@@ -98,6 +96,36 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
                     _VLAN_WARNING_LOGGED = True
                 return []
             raise
+
+    async def _get_uplink_performance(self, network_id: str) -> list[dict[str, Any]]:
+        """Fetch uplink performance with robust fallback."""
+        methods = [
+            ("getNetworkApplianceUplinksUsageHistory", {"timespan": 60}),
+            ("getNetworkApplianceUplinksLossAndLatency", {}),
+            ("getNetworkApplianceUplinksPerformance", {}),
+        ]
+
+        for method_name, extra_kwargs in methods:
+            if hasattr(self.client.dashboard.appliance, method_name):
+                method = getattr(self.client.dashboard.appliance, method_name)
+                try:
+                    _LOGGER.debug(
+                        "Attempting to fetch uplink performance using %s", method_name
+                    )
+                    performance = await self.client.run_sync(
+                        method, networkId=network_id, **extra_kwargs
+                    )
+                    if isinstance(performance, list):
+                        return performance
+                except Exception as e:
+                    _LOGGER.debug(
+                        "Method %s failed for network %s: %s",
+                        method_name,
+                        network_id,
+                        e,
+                    )
+                    continue
+        return []
 
     def build_device_tasks(
         self,
@@ -215,9 +243,21 @@ class ApplianceFetchStrategy(BaseFetchStrategy):
 
         if performance := detail_data.get(f"uplink_performance_{device.network_id}"):
             if isinstance(performance, list):
+                # Normalize keys for robust mapping (loss -> lossPercent, latency -> latencyMs)
+                normalized_performance = []
+                for p in performance:
+                    if not isinstance(p, dict):
+                        continue
+                    item = p.copy()
+                    if "loss" in item and "lossPercent" not in item:
+                        item["lossPercent"] = item["loss"]
+                    if "latency" in item and "latencyMs" not in item:
+                        item["latencyMs"] = item["latency"]
+                    normalized_performance.append(item)
+
                 # Filter performance data for this device
                 device_perf = [
-                    p for p in performance if p.get("serial") == device.serial
+                    p for p in normalized_performance if p.get("serial") == device.serial
                 ]
                 # Merge with existing status data in device.uplinks
                 perf_by_interface = {p.get("interface"): p for p in device_perf}

--- a/tests/core/fetch_strategies/test_appliance_uplink_performance.py
+++ b/tests/core/fetch_strategies/test_appliance_uplink_performance.py
@@ -1,0 +1,130 @@
+"""Tests for ApplianceFetchStrategy uplink performance."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.core.fetch_strategies.appliance import (
+    ApplianceFetchStrategy,
+)
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+
+
+@pytest.fixture
+def mock_client():
+    """Fixture for a mock Meraki API client."""
+    client = MagicMock()
+    client.run_with_semaphore.side_effect = lambda x: x
+    # Mock dashboard.appliance
+    client.dashboard = MagicMock()
+    client.dashboard.appliance = MagicMock()
+
+    # Mock run_sync to execute the function directly
+    async def mock_run_sync(func, *args, **kwargs):
+        return func(*args, **kwargs)
+    client.run_sync.side_effect = mock_run_sync
+
+    return client
+
+
+@pytest.fixture
+def strategy(mock_client):
+    """Fixture for the ApplianceFetchStrategy."""
+    return ApplianceFetchStrategy(
+        client=mock_client,
+        _disabled_features=set(),
+        enable_vpn_management=False,
+        enable_firewall_rules=False,
+        enable_traffic_shaping=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_uplink_performance_usage_history(strategy, mock_client):
+    """Test fetching uplink performance via UsageHistory."""
+    mock_data = [{"serial": "SERIAL1", "interface": "wan1", "lossPercent": 0.1}]
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksUsageHistory = MagicMock(
+        return_value=mock_data
+    )
+
+    result = await strategy._get_uplink_performance("net1")
+
+    assert result == mock_data
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksUsageHistory.assert_called_once_with(
+        networkId="net1", timespan=60
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_uplink_performance_fallback(strategy, mock_client):
+    """Test fetching uplink performance with fallback."""
+    # First method fails
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksUsageHistory = MagicMock(
+        side_effect=Exception("Failed")
+    )
+    # Second method succeeds
+    mock_data = [{"serial": "SERIAL1", "interface": "wan1", "lossPercent": 0.2}]
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksLossAndLatency = MagicMock(
+        return_value=mock_data
+    )
+
+    result = await strategy._get_uplink_performance("net1")
+
+    assert result == mock_data
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksLossAndLatency.assert_called_once_with(
+        networkId="net1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_uplink_performance_legacy_fallback(strategy, mock_client):
+    """Test fetching uplink performance with legacy fallback."""
+    # First and second methods fail
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksUsageHistory = MagicMock(
+        side_effect=Exception("Failed")
+    )
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksLossAndLatency = MagicMock(
+        side_effect=Exception("Failed")
+    )
+    # Third method succeeds
+    mock_data = [{"serial": "SERIAL1", "interface": "wan1", "loss": 0.3}]
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksPerformance = MagicMock(
+        return_value=mock_data
+    )
+
+    result = await strategy._get_uplink_performance("net1")
+
+    assert result == mock_data
+    mock_client.dashboard.appliance.getNetworkApplianceUplinksPerformance.assert_called_once_with(
+        networkId="net1"
+    )
+
+
+def test_process_device_details_normalization(strategy):
+    """Test that performance data keys are normalized."""
+    mock_device = MagicMock(spec=MerakiDevice)
+    mock_device.serial = "SERIAL1"
+    mock_device.network_id = "net1"
+    mock_device.appliance_uplink_statuses = []
+
+    detail_data = {
+        "uplink_performance_net1": [
+            {
+                "serial": "SERIAL1",
+                "interface": "wan1",
+                "loss": 1.5,
+                "latency": 25,
+            }
+        ]
+    }
+
+    strategy.process_device_details(mock_device, detail_data, None)
+
+    # Check that uplinks was updated with normalized keys
+    assert len(mock_device.uplinks) == 1
+    uplink = mock_device.uplinks[0]
+    assert uplink["lossPercent"] == 1.5
+    assert uplink["latencyMs"] == 25
+    # Original keys should still be there
+    assert uplink["loss"] == 1.5
+    assert uplink["latency"] == 25


### PR DESCRIPTION
Implemented robust fallback logic for fetching appliance uplink performance in `ApplianceFetchStrategy`. 
- Added `_get_uplink_performance` with tiered API call attempts.
- Updated `build_network_tasks` to use the new method.
- Updated `process_device_details` to normalize performance data keys (`loss` -> `lossPercent`, `latency` -> `latencyMs`).
- Added unit tests in `tests/core/fetch_strategies/test_appliance_uplink_performance.py`.

Fixes #1911

---
*PR created automatically by Jules for task [14071860831386611613](https://jules.google.com/task/14071860831386611613) started by @brewmarsh*