### PR TITLE
Add wireless radio and channel sensors

### DIFF
--- a/custom_components/meraki_ha/core/const.py
+++ b/custom_components/meraki_ha/core/const.py
@@ -15,6 +15,7 @@ _MX_CAPS = [
     "status",
     "physical_sensors",
     "led_control",
+    "wireless",
 ]
 
 _MR_CAPS = [
@@ -24,6 +25,7 @@ _MR_CAPS = [
     "status",
     "physical_sensors",
     "led_control",
+    "wireless",
 ]
 _MS_CAPS = [
     "switch_ports",

--- a/custom_components/meraki_ha/core/fetch_strategies/wireless.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/wireless.py
@@ -40,6 +40,12 @@ class WirelessFetchStrategy(BaseFetchStrategy):
                     self.client.devices.get_device_management_interface(device.serial),
                 )
             )
+        if "wireless" in capabilities and device.serial:
+            tasks[f"wireless_radio_settings_{device.serial}"] = (
+                self.client.run_with_semaphore(
+                    self.client.wireless.get_wireless_settings(device.serial),
+                )
+            )
 
     def process_device_details(
         self,
@@ -54,6 +60,13 @@ class WirelessFetchStrategy(BaseFetchStrategy):
                 device.management_interface = management_interface
         elif prev_device and hasattr(prev_device, "management_interface"):
             device.management_interface = prev_device.management_interface
+
+        radio_settings_key = f"wireless_radio_settings_{device.serial}"
+        if radio_settings := detail_data.get(radio_settings_key):
+            if isinstance(radio_settings, dict):
+                device.wireless_radio_settings = radio_settings
+        elif prev_device and hasattr(prev_device, "wireless_radio_settings"):
+            device.wireless_radio_settings = prev_device.wireless_radio_settings
 
     def process_network_data(
         self,

--- a/custom_components/meraki_ha/core/models/device.py
+++ b/custom_components/meraki_ha/core/models/device.py
@@ -83,6 +83,7 @@ class MerakiDevice:
     sensor_relationships: list[dict[str, Any]] = field(default_factory=list)
     dynamic_dns: dict[str, Any] | None = None
     management_interface: dict[str, Any] | None = None
+    wireless_radio_settings: dict[str, Any] | None = None
     status_messages: list[str] = field(default_factory=list)
     entity_id: str | None = None
     ambient_noise: float | None = None
@@ -128,6 +129,7 @@ class MerakiDevice:
             "sensorRelationships": self.sensor_relationships,
             "dynamicDns": self.dynamic_dns,
             "managementInterface": self.management_interface,
+            "wirelessRadioSettings": self.wireless_radio_settings,
             "statusMessages": self.status_messages,
             "applianceUplinkStatuses": self.appliance_uplink_statuses,
             "uplinks": self.uplinks,
@@ -168,6 +170,7 @@ class MerakiDevice:
             sensor_relationships=data.get("sensorRelationships", []),
             dynamic_dns=data.get("dynamicDns"),
             management_interface=data.get("managementInterface"),
+            wireless_radio_settings=data.get("wirelessRadioSettings"),
             status_messages=data.get("statusMessages", []),
             appliance_uplink_statuses=data.get("applianceUplinkStatuses", []),
             uplinks=data.get("uplinks", []),

--- a/custom_components/meraki_ha/discovery/handlers/universal.py
+++ b/custom_components/meraki_ha/discovery/handlers/universal.py
@@ -39,6 +39,7 @@ from ..providers import (
     SwitchPortProvider,
     UplinkPerformanceProvider,
     UplinkProvider,
+    WirelessRadioProvider,
 )
 from .base import BaseDeviceHandler
 
@@ -84,6 +85,7 @@ class UniversalHandler(BaseDeviceHandler):
         "status": MerakiDeviceStatusSensor,
         "physical_sensors": PhysicalSensorProvider,
         "camera_stream": CameraStreamProvider,
+        "wireless": WirelessRadioProvider,
     }
 
     # Mapping of capabilities to their configuration option toggle
@@ -110,6 +112,7 @@ class UniversalHandler(BaseDeviceHandler):
         "analytics": CONF_ENABLE_CAMERA_ENTITIES,
         "camera_stream": CONF_ENABLE_CAMERA_ENTITIES,
         "status": CONF_ENABLE_DEVICE_STATUS,
+        "wireless": CONF_ENABLE_DEVICE_SENSORS,
     }
 
     def __init__(

--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfTime
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTime
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
@@ -46,6 +46,7 @@ from ..sensor.device.network_settings import (
     MerakiDeviceIPSensor,
 )
 from ..sensor.device.rtsp_url import MerakiRtspUrlSensor
+from ..sensor.device.wireless_radio import MerakiWirelessRadioSensor
 from ..sensor.uplink_performance import MerakiUplinkPerformanceSensor
 from ..switch.camera_controls import AnalyticsSwitch
 from ..switch.switch_port import MerakiSwitchPortSwitch
@@ -268,6 +269,100 @@ class SwitchPortProvider:
                 entities.append(
                     MerakiSwitchPortSwitch(coordinator, device, port, config_entry)
                 )
+        return entities
+
+
+class WirelessRadioProvider:
+    """Provider for wireless radio entities."""
+
+    @staticmethod
+    def get_entities(
+        coordinator: MerakiDataUpdateCoordinator,
+        device: MerakiDevice,
+        config_entry: ConfigEntry,
+        **kwargs: Any,
+    ) -> list[Entity]:
+        """Get entities."""
+        if not device.serial or not device.wireless_radio_settings:
+            return []
+
+        entities: list[Entity] = []
+        settings = device.wireless_radio_settings
+
+        # 2.4GHz Channel
+        if "twoFourGhzSettings" in settings:
+            entities.append(
+                MerakiWirelessRadioSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    SensorEntityDescription(
+                        key="2.4ghz_channel",
+                        name="2.4GHz channel",
+                        icon="mdi:wifi",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    "twoFourGhzSettings",
+                    "channel",
+                )
+            )
+
+        # 5GHz Channel
+        if "fiveGhzSettings" in settings:
+            entities.append(
+                MerakiWirelessRadioSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    SensorEntityDescription(
+                        key="5ghz_channel",
+                        name="5GHz channel",
+                        icon="mdi:wifi",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    "fiveGhzSettings",
+                    "channel",
+                )
+            )
+
+        # 2.4GHz Target Power
+        if "twoFourGhzSettings" in settings:
+            entities.append(
+                MerakiWirelessRadioSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    SensorEntityDescription(
+                        key="2.4ghz_target_power",
+                        name="2.4GHz target power",
+                        native_unit_of_measurement="dBm",
+                        icon="mdi:transmission-tower",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    "twoFourGhzSettings",
+                    "targetPower",
+                )
+            )
+
+        # 5GHz Target Power (Generic "Target power" sensor for backward compatibility/requested name)
+        if "fiveGhzSettings" in settings:
+            entities.append(
+                MerakiWirelessRadioSensor(
+                    coordinator,
+                    device,
+                    config_entry,
+                    SensorEntityDescription(
+                        key="target_power",
+                        name="Target power",
+                        native_unit_of_measurement="dBm",
+                        icon="mdi:transmission-tower",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    "fiveGhzSettings",
+                    "targetPower",
+                )
+            )
+
         return entities
 
 

--- a/custom_components/meraki_ha/sensor/device/wireless_radio.py
+++ b/custom_components/meraki_ha/sensor/device/wireless_radio.py
@@ -1,0 +1,83 @@
+"""Sensors for Meraki wireless radio settings."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+
+from ...coordinator import MerakiDataUpdateCoordinator
+from ...entity import MerakiSensor
+from ...helpers.device_info_helpers import resolve_device_info
+
+if TYPE_CHECKING:
+    from ...core.models.device import MerakiDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiWirelessRadioSensor(MerakiSensor):
+    """Sensor for Meraki wireless radio settings."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device_data: MerakiDevice,
+        config_entry: ConfigEntry,
+        description: SensorEntityDescription,
+        band_key: str,
+        setting_key: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device_serial: str | None = device_data.serial
+        self._config_entry = config_entry
+        self.entity_description = description
+        self._band_key = band_key
+        self._setting_key = setting_key
+
+        self._attr_device_info = resolve_device_info(
+            entity_data=asdict(device_data),
+            config_entry=self._config_entry,
+        )
+        self._update_state()
+
+    def _get_current_device_data(self) -> MerakiDevice | None:
+        """Retrieve the latest data for this sensor's device from the coordinator."""
+        if self._device_serial:
+            return self.coordinator.get_device(self._device_serial)
+        return None
+
+    @callback
+    def _update_state(self) -> None:
+        """Update the native value of the sensor based on coordinator data."""
+        device = self._get_current_device_data()
+        if not device or not device.wireless_radio_settings:
+            self._attr_native_value = None
+            return
+
+        settings = device.wireless_radio_settings
+        band_settings = settings.get(self._band_key)
+        if isinstance(band_settings, dict):
+            self._attr_native_value = band_settings.get(self._setting_key)
+        else:
+            self._attr_native_value = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._get_current_device_data() is not None

--- a/tests/core/fetch_strategies/test_wireless_strategy.py
+++ b/tests/core/fetch_strategies/test_wireless_strategy.py
@@ -69,3 +69,37 @@ def test_process_network_data(mock_parse, strategy):
     assert processed_data["ssids"] == [{"name": "SSID1", "number": 0}]
     assert processed_data["wireless_settings"] == {"setting1": "val1"}
     assert processed_data["rf_profiles"] == {"profile1": "data1"}
+
+
+def test_build_device_tasks(strategy, mock_client):
+    """Test that build_device_tasks calls the correct client methods."""
+    device = MagicMock()
+    device.serial = "serial1"
+    tasks = {}
+    capabilities = ["wireless", "led_control"]
+
+    strategy.build_device_tasks(device, tasks, capabilities)
+
+    assert f"management_interface_{device.serial}" in tasks
+    assert f"wireless_radio_settings_{device.serial}" in tasks
+    mock_client.devices.get_device_management_interface.assert_called_once_with(
+        device.serial
+    )
+    mock_client.wireless.get_wireless_settings.assert_called_once_with(device.serial)
+
+
+def test_process_device_details(strategy):
+    """Test that process_device_details extracts and stores data."""
+    device = MagicMock()
+    device.serial = "serial1"
+    detail_data = {
+        f"management_interface_{device.serial}": {"led": "on"},
+        f"wireless_radio_settings_{device.serial}": {
+            "twoFourGhzSettings": {"channel": 1}
+        },
+    }
+
+    strategy.process_device_details(device, detail_data, None)
+
+    assert device.management_interface == {"led": "on"}
+    assert device.wireless_radio_settings == {"twoFourGhzSettings": {"channel": 1}}

--- a/tests/sensor/device/test_meraki_wireless_radio_sensor.py
+++ b/tests/sensor/device/test_meraki_wireless_radio_sensor.py
@@ -1,0 +1,68 @@
+"""Tests for Meraki Wireless Radio sensors."""
+
+from unittest.mock import MagicMock, patch
+from homeassistant.components.sensor import SensorEntityDescription
+from custom_components.meraki_ha.sensor.device.wireless_radio import MerakiWirelessRadioSensor
+from custom_components.meraki_ha.discovery.providers import WirelessRadioProvider
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+
+def test_wireless_radio_sensor_update():
+    """Test the wireless radio sensor update."""
+    coordinator = MagicMock()
+    device = MerakiDevice(
+        serial="serial1",
+        wireless_radio_settings={
+            "twoFourGhzSettings": {"channel": 6, "targetPower": 15},
+            "fiveGhzSettings": {"channel": 149, "targetPower": 18},
+        }
+    )
+    coordinator.get_device.return_value = device
+
+    config_entry = MagicMock()
+
+    description = SensorEntityDescription(
+        key="2.4ghz_channel",
+        name="2.4GHz channel",
+    )
+
+    # Mock resolve_device_info to avoid issues in test
+    with patch("custom_components.meraki_ha.sensor.device.wireless_radio.resolve_device_info", return_value={}):
+        sensor = MerakiWirelessRadioSensor(
+            coordinator,
+            device,
+            config_entry,
+            description,
+            "twoFourGhzSettings",
+            "channel"
+        )
+
+        # Mock async_write_ha_state
+        sensor.async_write_ha_state = MagicMock()
+
+        assert sensor.native_value == 6
+
+        # Test update
+        device.wireless_radio_settings["twoFourGhzSettings"]["channel"] = 11
+        sensor._update_state()
+        assert sensor.native_value == 11
+
+def test_wireless_radio_provider():
+    """Test the wireless radio provider."""
+    coordinator = MagicMock()
+    device = MerakiDevice(
+        serial="serial1",
+        wireless_radio_settings={
+            "twoFourGhzSettings": {"channel": 6, "targetPower": 15},
+            "fiveGhzSettings": {"channel": 149, "targetPower": 18},
+        }
+    )
+    config_entry = MagicMock()
+
+    with patch("custom_components.meraki_ha.sensor.device.wireless_radio.resolve_device_info", return_value={}):
+        entities = WirelessRadioProvider.get_entities(coordinator, device, config_entry)
+
+        assert len(entities) == 4
+        assert any(e.entity_description.key == "2.4ghz_channel" for e in entities)
+        assert any(e.entity_description.key == "5ghz_channel" for e in entities)
+        assert any(e.entity_description.key == "2.4ghz_target_power" for e in entities)
+        assert any(e.entity_description.key == "target_power" for e in entities)


### PR DESCRIPTION
This PR adds diagnostic sensors to Meraki wireless devices to show the 2.4GHz and 5GHz channels they are broadcasting on, as well as their target power.

Changes:
- Modified `custom_components/meraki_ha/core/models/device.py` to store radio settings.
- Updated `custom_components/meraki_ha/core/fetch_strategies/wireless.py` to fetch radio settings from the Meraki API.
- Created `custom_components/meraki_ha/sensor/device/wireless_radio.py` to implement the sensor entities.
- Updated `custom_components/meraki_ha/discovery/providers.py` to include the `WirelessRadioProvider`.
- Updated `custom_components/meraki_ha/core/const.py` and `custom_components/meraki_ha/discovery/handlers/universal.py` to enable and map the new `wireless` capability.
- Added comprehensive tests in `tests/sensor/device/test_meraki_wireless_radio_sensor.py` and updated `tests/core/fetch_strategies/test_wireless_strategy.py`.

Fixes #1918

---
*PR created automatically by Jules for task [8779686326868141100](https://jules.google.com/task/8779686326868141100) started by @brewmarsh*