### PR TITLE
Restore Port Status Sensors

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/switch.py
+++ b/custom_components/meraki_ha/discovery/handlers/switch.py
@@ -11,8 +11,9 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
-from ...const_conf import CONF_ENABLE_DEVICE_SENSORS
+from ...const_conf import CONF_ENABLE_DEVICE_SENSORS, CONF_ENABLE_PORT_SENSORS
 from ...sensor.device.switch_client_count import MerakiSwitchClientCountSensor
+from ..providers import SwitchPortProvider
 from .base import BaseHandler
 
 if TYPE_CHECKING:
@@ -51,3 +52,9 @@ class SwitchHandler(BaseHandler):
                         self._coordinator, device, self._config_entry
                     )
 
+                    # Switch Ports
+                    if self._config_entry.options.get(CONF_ENABLE_PORT_SENSORS, True):
+                        for entity in SwitchPortProvider.get_entities(
+                            self._coordinator, device, self._config_entry
+                        ):
+                            yield entity

--- a/custom_components/meraki_ha/discovery/handlers/universal.py
+++ b/custom_components/meraki_ha/discovery/handlers/universal.py
@@ -78,7 +78,6 @@ class UniversalHandler(BaseDeviceHandler):
         "uplinks": UplinkProvider,
         "performance": UplinkPerformanceProvider,
         "appliance_ports": AppliancePortProvider,
-        "switch_ports": SwitchPortProvider,
         "poe_usage": MerakiPoeUsageSensor,
         "analytics": CameraAnalyticsProvider,
         "reboot": MerakiRebootButton,
@@ -108,7 +107,6 @@ class UniversalHandler(BaseDeviceHandler):
         "uplinks": CONF_ENABLE_PORT_SENSORS,
         "performance": CONF_ENABLE_PORT_SENSORS,
         "appliance_ports": CONF_ENABLE_PORT_SENSORS,
-        "switch_ports": CONF_ENABLE_PORT_SENSORS,
         "analytics": CONF_ENABLE_CAMERA_ENTITIES,
         "camera_stream": CONF_ENABLE_CAMERA_ENTITIES,
         "status": CONF_ENABLE_DEVICE_STATUS,
@@ -132,13 +130,6 @@ class UniversalHandler(BaseDeviceHandler):
             if capabilities is not None
             else DEVICE_CAPABILITIES.get(device.model, DEFAULT_CAPS)[:]
         )
-
-        # Fallback: if model is unknown but product_type indicates switch, add switch_ports
-        if "switch_ports" not in self.capabilities:
-            if (device.product_type == "switch") or (
-                device.model and device.model.startswith("MS")
-            ):
-                self.capabilities.append("switch_ports")
 
         # Fallback: if model is unknown but product_type indicates wireless, add ssids
         if "ssids" not in self.capabilities:

--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -46,6 +46,11 @@ from ..sensor.device.network_settings import (
     MerakiDeviceIPSensor,
 )
 from ..sensor.device.rtsp_url import MerakiRtspUrlSensor
+from ..sensor.device.switch_port import (
+    MerakiSwitchPortEnergySensor,
+    MerakiSwitchPortPowerSensor,
+    MerakiSwitchPortSensor,
+)
 from ..sensor.device.wireless_radio import MerakiWirelessRadioSensor
 from ..sensor.uplink_performance import MerakiUplinkPerformanceSensor
 from ..switch.camera_controls import AnalyticsSwitch
@@ -265,6 +270,15 @@ class SwitchPortProvider:
         if device.ports_statuses:
             for port in device.ports_statuses:
                 entities.append(SwitchPortSensor(coordinator, device, port))
+                entities.append(
+                    MerakiSwitchPortSensor(coordinator, device, port, config_entry)
+                )
+                entities.append(
+                    MerakiSwitchPortPowerSensor(coordinator, device, port, config_entry)
+                )
+                entities.append(
+                    MerakiSwitchPortEnergySensor(coordinator, device, port, config_entry)
+                )
                 # RESOLVED: Updated constructor to include config_entry per beta branch
                 entities.append(
                     MerakiSwitchPortSwitch(coordinator, device, port, config_entry)

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.models.device import MerakiDevice
+from ...helpers.device_info_helpers import resolve_device_info
 
 
 class MerakiSwitchPortSensor(CoordinatorEntity, SensorEntity):
@@ -44,15 +45,13 @@ class MerakiSwitchPortSensor(CoordinatorEntity, SensorEntity):
         self._attr_has_entity_name = True
         port_id = self._port.get("portId") or self._port.get("number")
         self._attr_unique_id = f"{self._device.serial}_port_{port_id}"
-        self._attr_name = f"Port {port_id}"
+        self._attr_name = f"Port {port_id} status"
         self._attr_native_value = self._port.get("status")
 
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device.serial))},
-        )
+        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def available(self) -> bool:
@@ -116,14 +115,12 @@ class MerakiSwitchPortPowerSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = (
             f"{self._device.serial}_port_{port_id}_power"
         )
-        self._attr_name = f"Port {port_id} Power"
+        self._attr_name = f"Port {port_id} power"
 
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device.serial))},
-        )
+        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def available(self) -> bool:
@@ -185,14 +182,12 @@ class MerakiSwitchPortEnergySensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = (
             f"{self._device.serial}_port_{port_id}_energy"
         )
-        self._attr_name = f"Port {port_id} Energy"
+        self._attr_name = f"Port {port_id} energy"
 
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device.serial))},
-        )
+        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/switch/switch_port.py
+++ b/custom_components/meraki_ha/switch/switch_port.py
@@ -15,6 +15,7 @@ from ..const import DOMAIN
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.models.device import MerakiDevice
 from ..entity import MerakiEntity
+from ..helpers.device_info_helpers import resolve_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,16 +44,14 @@ class MerakiSwitchPortSwitch(MerakiEntity, SwitchEntity):
         # Standardized unique ID logic: uses the key to differentiate from sensors
         self.entity_description = SwitchEntityDescription(
             key=f"port_switch_{port_id}",
-            name=f"Port {port_id} Enabled",
+            name=f"Port {port_id} enabled",
         )
         self._update_internal_state()
 
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device.serial))},
-        )
+        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def available(self) -> bool:

--- a/tests/sensor/device/test_meraki_switch_port_sensor.py
+++ b/tests/sensor/device/test_meraki_switch_port_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.const import UnitOfEnergy, UnitOfPower
 from custom_components.meraki_ha.sensor.device.switch_port import (
     MerakiSwitchPortEnergySensor,
     MerakiSwitchPortPowerSensor,
+    MerakiSwitchPortSensor,
 )
 from custom_components.meraki_ha.types import MerakiDevice
 
@@ -89,3 +90,34 @@ def test_switch_port_energy_sensor_missing_data(mock_coordinator_and_device):
     sensor.async_write_ha_state = MagicMock()
     sensor._handle_coordinator_update()
     assert sensor.native_value == 0.0
+
+
+def test_meraki_switch_port_sensor_init(mock_coordinator_and_device):
+    """Test the Meraki switch port sensor initialization."""
+    coordinator, device = mock_coordinator_and_device
+    port = {"portId": "1", "status": "Connected"}
+    config_entry = MagicMock()
+
+    sensor = MerakiSwitchPortSensor(coordinator, device, port, config_entry)
+
+    assert sensor.unique_id == "Q234-ABCD-5678_port_1"
+    assert sensor.name == "Port 1 status"
+    assert sensor.native_value == "Connected"
+
+
+def test_meraki_switch_port_sensor_update(mock_coordinator_and_device):
+    """Test the Meraki switch port sensor update."""
+    coordinator, device = mock_coordinator_and_device
+    port = {"portId": "1", "status": "Connected"}
+    config_entry = MagicMock()
+
+    sensor = MerakiSwitchPortSensor(coordinator, device, port, config_entry)
+    sensor.async_write_ha_state = MagicMock()
+
+    # Update data
+    device.ports_statuses[0]["status"] = "Disconnected"
+    coordinator.data = {"devices": [device]}
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.native_value == "Disconnected"

--- a/tests/switch/test_meraki_switch_port_switch.py
+++ b/tests/switch/test_meraki_switch_port_switch.py
@@ -72,7 +72,7 @@ async def test_switch_port_init(
     switch.hass = hass
 
     assert switch.unique_id == "Q2AA-BB33-CC44_port_switch_1"
-    assert switch.name == "Port 1 Enabled"
+    assert switch.name == "Port 1 enabled"
     assert switch.is_on is True
 
 


### PR DESCRIPTION
This change restores missing switch port sensors by updating the `SwitchPortProvider` to include status, power, and energy sensors, and moving its discovery to the dedicated `SwitchHandler`. It also ensures that all switch port entities (sensors, binary sensors, and switches) follow Home Assistant Sentence Case naming standards and use consistent device information. Configuration options for port sensors are now correctly respected in the `SwitchHandler`.

Fixes #1920

---
*PR created automatically by Jules for task [18330342355538369362](https://jules.google.com/task/18330342355538369362) started by @brewmarsh*