### PR TITLE
Fix switch discovery tests and unknown model fallback verification

### DIFF
--- a/tests/discovery/handlers/test_switch.py
+++ b/tests/discovery/handlers/test_switch.py
@@ -4,11 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from custom_components.meraki_ha.const_conf import CONF_ENABLE_PORT_SENSORS
 from custom_components.meraki_ha.core.models.device import MerakiDevice
 from custom_components.meraki_ha.discovery.handlers.switch import SwitchHandler
 from custom_components.meraki_ha.sensor.device.switch_client_count import (
     MerakiSwitchClientCountSensor,
 )
+from custom_components.meraki_ha.switch.switch_port import MerakiSwitchPortSwitch
 
 
 @pytest.fixture
@@ -30,6 +32,9 @@ def mock_config_entry():
 @pytest.mark.asyncio
 async def test_switch_handler_exclusion_logic(mock_coordinator, mock_config_entry):
     """Test that SwitchHandler excludes appliances and Z3 devices."""
+    # Disable port sensors to simplify entity count assertion
+    mock_config_entry.options = {CONF_ENABLE_PORT_SENSORS: False}
+
     # Define devices with ports to satisfy reviewer concern
     mx_appliance = MerakiDevice(
         serial="MX_SERIAL",
@@ -98,6 +103,46 @@ async def test_switch_handler_exclusion_logic(mock_coordinator, mock_config_entr
         assert "MX_SERIAL" in skip_calls
         assert "Z3_SERIAL" in skip_calls
         assert "MX_SWITCH_SERIAL" in skip_calls
+
+
+@pytest.mark.asyncio
+async def test_switch_handler_unknown_model_fallback(mock_coordinator, mock_config_entry):
+    """Test that an unknown switch model (e.g. MS390) gets switch_ports capability."""
+    # Ensure port sensors are enabled
+    mock_config_entry.options = {CONF_ENABLE_PORT_SENSORS: True}
+
+    # MS390 is not in DEVICE_CAPABILITIES usually, but product_type="switch"
+    device = MerakiDevice(
+        serial="ms390-serial",
+        model="MS390",
+        product_type="switch",
+        ports_statuses=[{"portId": "1", "enabled": True}],
+    )
+
+    mock_coordinator.data = {
+        "devices": [device]
+    }
+
+    handler = SwitchHandler(mock_coordinator, mock_config_entry)
+
+    entities = []
+    async for entity in handler.discover_entities():
+        entities.append(entity)
+
+    # Expected entities:
+    # 1. MerakiSwitchClientCountSensor
+    # 2. SwitchPortSensor
+    # 3. MerakiSwitchPortSensor
+    # 4. MerakiSwitchPortPowerSensor
+    # 5. MerakiSwitchPortEnergySensor
+    # 6. MerakiSwitchPortSwitch
+
+    assert len(entities) == 6
+    # Check if switch port switch entity is present
+    assert any(isinstance(e, MerakiSwitchPortSwitch) for e in entities)
+    # Check if client count sensor is present
+    assert any(isinstance(e, MerakiSwitchClientCountSensor) for e in entities)
+
 
 @pytest.mark.asyncio
 async def test_switch_handler_no_data(mock_coordinator, mock_config_entry):

--- a/tests/discovery/handlers/test_universal.py
+++ b/tests/discovery/handlers/test_universal.py
@@ -217,43 +217,6 @@ async def test_universal_handler_capability_compliance(
 
 
 @pytest.mark.asyncio
-async def test_universal_handler_unknown_switch_fallback(
-    mock_coordinator,
-    mock_config_entry,
-    mock_camera_service,
-    mock_control_service,
-    mock_network_control_service,
-):
-    """Test that an unknown switch model (e.g. MS390) gets switch_ports capability."""
-    # MS390 is not in DEVICE_CAPABILITIES
-    device = MerakiDevice(
-        serial="ms390-serial",
-        model="MS390",
-        product_type="switch",
-        ports_statuses=[{"portId": "1", "enabled": True}],
-    )
-
-    handler = UniversalHandler(
-        mock_coordinator,
-        device,
-        mock_config_entry,
-        mock_camera_service,
-        mock_control_service,
-        mock_network_control_service,
-    )
-
-    entities = []
-    async for entity in handler.discover_entities():
-        entities.append(entity)
-
-    # Check if switch ports are discovered
-    has_switch_port = any(isinstance(e, MerakiSwitchPortSwitch) for e in entities)
-
-    # Assert capability was added
-    assert "switch_ports" in handler.capabilities
-    assert has_switch_port
-
-@pytest.mark.asyncio
 async def test_universal_handler_unknown_wireless_fallback(
     mock_coordinator,
     mock_config_entry,


### PR DESCRIPTION
Fixes test failures in `test_switch.py` and `test_universal.py` caused by recent refactoring of switch port discovery. The `SwitchHandler` now correctly handles unknown switch models, and the tests reflect this responsibility shift.

Summary of changes:
- `tests/discovery/handlers/test_switch.py`:
    - Updated `test_switch_handler_exclusion_logic` to disable `CONF_ENABLE_PORT_SENSORS` to simplify entity count assertions.
    - Added `test_switch_handler_unknown_model_fallback` to test fallback logic for unknown switch models.
- `tests/discovery/handlers/test_universal.py`:
    - Removed `test_universal_handler_unknown_switch_fallback`.

Test Proof:
`tests/discovery/handlers/test_switch.py` passed (3/3).
`tests/discovery/handlers/test_universal.py` passed (6/6).
All tests passed (326 passed, 1 skipped).

Manual Verification: Verified against AGENTS.md rules.

---
*PR created automatically by Jules for task [9607799814003264264](https://jules.google.com/task/9607799814003264264) started by @brewmarsh*