### PR TITLE
Fix switch discovery tests to use MerakiSwitchPortToggle

### DIFF
--- a/tests/discovery/handlers/test_switch.py
+++ b/tests/discovery/handlers/test_switch.py
@@ -4,13 +4,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from custom_components.meraki_ha.button.device.poe_cycle import MerakiPoECycleButton
 from custom_components.meraki_ha.const_conf import CONF_ENABLE_PORT_SENSORS
 from custom_components.meraki_ha.core.models.device import MerakiDevice
 from custom_components.meraki_ha.discovery.handlers.switch import SwitchHandler
 from custom_components.meraki_ha.sensor.device.switch_client_count import (
     MerakiSwitchClientCountSensor,
 )
-from custom_components.meraki_ha.switch.switch_port import MerakiSwitchPortSwitch
+from custom_components.meraki_ha.switch.switch_port import MerakiSwitchPortToggle
 
 
 @pytest.fixture
@@ -135,13 +136,16 @@ async def test_switch_handler_unknown_model_fallback(mock_coordinator, mock_conf
     # 3. MerakiSwitchPortSensor
     # 4. MerakiSwitchPortPowerSensor
     # 5. MerakiSwitchPortEnergySensor
-    # 6. MerakiSwitchPortSwitch
+    # 6. MerakiSwitchPortToggle
+    # 7. MerakiPoECycleButton
 
-    assert len(entities) == 6
+    assert len(entities) == 7
     # Check if switch port switch entity is present
-    assert any(isinstance(e, MerakiSwitchPortSwitch) for e in entities)
+    assert any(isinstance(e, MerakiSwitchPortToggle) for e in entities)
     # Check if client count sensor is present
     assert any(isinstance(e, MerakiSwitchClientCountSensor) for e in entities)
+    # Check if PoE cycle button is present
+    assert any(isinstance(e, MerakiPoECycleButton) for e in entities)
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/handlers/test_universal.py
+++ b/tests/discovery/handlers/test_universal.py
@@ -11,7 +11,6 @@ from custom_components.meraki_ha.discovery.handlers.universal import UniversalHa
 from custom_components.meraki_ha.sensor.device.device_status import (
     MerakiDeviceStatusSensor,
 )
-from custom_components.meraki_ha.switch.switch_port import MerakiSwitchPortSwitch
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes the switch discovery tests which were failing due to the renaming of `MerakiSwitchPortSwitch` to `MerakiSwitchPortToggle` and the addition of `MerakiPoECycleButton`.

Key changes:
- Replaced references to `MerakiSwitchPortSwitch` with `MerakiSwitchPortToggle` in `tests/discovery/handlers/test_switch.py`.
- Updated the expected entity count in `test_switch_handler_unknown_model_fallback` from 6 to 7 to include `MerakiPoECycleButton`.
- Added an assertion for `MerakiPoECycleButton` in `test_switch_handler_unknown_model_fallback`.
- Removed the unused import `MerakiSwitchPortSwitch` from `tests/discovery/handlers/test_universal.py`.

These changes align the tests with the recent refactoring of switch port entities.

---
*PR created automatically by Jules for task [10096537092410865992](https://jules.google.com/task/10096537092410865992) started by @brewmarsh*