### PR TITLE
Add Missing Port Controls for MX Appliances

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/appliance/settings.py
+++ b/custom_components/meraki_ha/core/api/endpoints/appliance/settings.py
@@ -103,6 +103,38 @@ class ApplianceSettingsMixin:
         return validated
 
     @handle_meraki_errors
+    async def update_network_appliance_port(
+        self,
+        network_id: str,
+        port_id: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """
+        Update an appliance port.
+
+        Args:
+            network_id: The ID of the network.
+            port_id: The ID of the port.
+            **kwargs: Additional arguments.
+
+        Returns
+        -------
+            The updated port.
+
+        """
+        port = await self._api_client.run_sync(
+            self._api_client.dashboard.appliance.updateNetworkAppliancePort,
+            networkId=network_id,
+            portId=port_id,
+            **kwargs,
+        )
+        validated = validate_response(port)
+        if not isinstance(validated, dict):
+            _LOGGER.warning("update_network_appliance_port did not return a dict")
+            return {}
+        return validated
+
+    @handle_meraki_errors
     @async_timed_cache()
     async def get_appliance_ports(self, network_id: str) -> list[dict[str, Any]]:
         """

--- a/custom_components/meraki_ha/discovery/providers.py
+++ b/custom_components/meraki_ha/discovery/providers.py
@@ -55,7 +55,7 @@ from ..sensor.device.switch_port import (
 from ..sensor.device.wireless_radio import MerakiWirelessRadioSensor
 from ..sensor.uplink_performance import MerakiUplinkPerformanceSensor
 from ..switch.camera_controls import AnalyticsSwitch
-from ..switch.switch_port import MerakiSwitchPortToggle
+from ..switch.switch_port import MerakiAppliancePortSwitch, MerakiSwitchPortToggle
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -251,6 +251,9 @@ class AppliancePortProvider:
             for port in device.appliance_ports:
                 entities.append(MerakiAppliancePortSensor(coordinator, device, port))
                 entities.append(AppliancePortBinarySensor(coordinator, device, port))
+                entities.append(
+                    MerakiAppliancePortSwitch(coordinator, device, port, config_entry)
+                )
         return entities
 
 

--- a/custom_components/meraki_ha/switch/switch_port.py
+++ b/custom_components/meraki_ha/switch/switch_port.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from ..const import DOMAIN
 from ..coordinator import MerakiDataUpdateCoordinator
-from ..core.models.device import MerakiDevice
+from ..core.models.device import MerakiAppliancePort, MerakiDevice
 from ..entity import MerakiEntity
 from ..helpers.device_info_helpers import resolve_device_info
 
@@ -133,6 +133,102 @@ class MerakiSwitchPortToggle(MerakiEntity, SwitchEntity):
             )
         except Exception:
             # Revert state on failure
+            self._attr_is_on = True
+            if self.unique_id:
+                self.coordinator.cancel_pending_update(self.unique_id)
+            self.async_write_ha_state()
+            raise
+
+
+class MerakiAppliancePortSwitch(MerakiSwitchPortToggle):
+    """Representation of a Meraki Appliance Port toggle entity."""
+
+    def __init__(
+        self,
+        coordinator: MerakiDataUpdateCoordinator,
+        device: MerakiDevice,
+        port: MerakiAppliancePort,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the Meraki Appliance Port toggle entity."""
+        super().__init__(coordinator, device, port.to_dict(), config_entry)
+        self._appliance_port = port
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if not self._device.serial:
+            return
+        device = self.coordinator.get_device(self._device.serial)
+        if device:
+            self._device = device
+            for port in device.appliance_ports:
+                if port.number == self._appliance_port.number:
+                    self._appliance_port = port
+                    self._port = port.to_dict()
+                    break
+
+        self._update_internal_state()
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on (enable the port)."""
+        if (
+            not self._device.serial
+            or not self._device.network_id
+            or self._appliance_port.number is None
+        ):
+            _LOGGER.error(
+                "Cannot enable port: Missing serial, network ID or port number."
+            )
+            return
+
+        # Optimistic update
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+        if self.unique_id:
+            self.coordinator.register_pending_update(self.unique_id)
+
+        try:
+            await self.coordinator.api.appliance.update_network_appliance_port(
+                network_id=self._device.network_id,
+                port_id=str(self._appliance_port.number),
+                enabled=True,
+            )
+        except Exception:
+            self._attr_is_on = False
+            if self.unique_id:
+                self.coordinator.cancel_pending_update(self.unique_id)
+            self.async_write_ha_state()
+            raise
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off (disable the port)."""
+        if (
+            not self._device.serial
+            or not self._device.network_id
+            or self._appliance_port.number is None
+        ):
+            _LOGGER.error(
+                "Cannot disable port: Missing serial, network ID or port number."
+            )
+            return
+
+        # Optimistic update
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+        if self.unique_id:
+            self.coordinator.register_pending_update(self.unique_id)
+
+        try:
+            await self.coordinator.api.appliance.update_network_appliance_port(
+                network_id=self._device.network_id,
+                port_id=str(self._appliance_port.number),
+                enabled=False,
+            )
+        except Exception:
             self._attr_is_on = True
             if self.unique_id:
                 self.coordinator.cancel_pending_update(self.unique_id)

--- a/tests/switch/test_meraki_appliance_port_switch.py
+++ b/tests/switch/test_meraki_appliance_port_switch.py
@@ -1,0 +1,161 @@
+"""Tests for Meraki Appliance Port switch."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.meraki_ha.switch.switch_port import MerakiAppliancePortSwitch
+from custom_components.meraki_ha.core.models.device import MerakiAppliancePort
+
+
+@pytest.fixture
+def mock_meraki_client():
+    """Mock the Meraki API client."""
+    client = MagicMock()
+    client.dashboard = MagicMock()
+    client.run_sync = AsyncMock()
+    # Mock the appliance endpoints wrapper
+    client.appliance = MagicMock()
+    client.appliance.update_network_appliance_port = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_coordinator(hass, mock_meraki_client):
+    """Mock the Meraki Data Coordinator."""
+    coordinator = MagicMock()
+    coordinator.hass = hass
+    coordinator.api = mock_meraki_client
+    coordinator.data = {
+        "devices": [],
+    }
+    coordinator.is_pending = MagicMock(return_value=False)
+    coordinator.register_pending_update = MagicMock()
+    coordinator.get_device = MagicMock()
+    return coordinator
+
+
+@pytest.fixture
+def mock_device():
+    """Mock a MerakiDevice."""
+    device = MagicMock()
+    device.serial = "Q2AA-BB33-CC44"
+    device.network_id = "N_12345"
+    device.status = "online"
+    device.appliance_ports = [
+        MerakiAppliancePort(number=1, enabled=True),
+        MerakiAppliancePort(number=2, enabled=False),
+    ]
+    return device
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Mock a ConfigEntry."""
+    entry = MagicMock()
+    entry.options = {}
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_appliance_port_switch_init(
+    hass: HomeAssistant,
+    mock_coordinator,
+    mock_device,
+    mock_config_entry,
+):
+    """Test initialization of the appliance port switch."""
+    port = MerakiAppliancePort(number=1, enabled=True)
+    switch = MerakiAppliancePortSwitch(
+        mock_coordinator, mock_device, port, mock_config_entry
+    )
+    switch.hass = hass
+
+    assert switch.unique_id == "Q2AA-BB33-CC44_port_switch_1"
+    assert switch.name == "Port 1 enabled"
+    assert switch.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_appliance_port_switch_turn_off(
+    hass: HomeAssistant,
+    mock_coordinator,
+    mock_device,
+    mock_config_entry,
+):
+    """Test turning the appliance port switch off."""
+    port = MerakiAppliancePort(number=1, enabled=True)
+    switch = MerakiAppliancePortSwitch(
+        mock_coordinator, mock_device, port, mock_config_entry
+    )
+    switch.hass = hass
+    switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await switch.async_turn_off()
+
+    # Verify API call
+    mock_coordinator.api.appliance.update_network_appliance_port.assert_called_once_with(
+        network_id="N_12345",
+        port_id="1",
+        enabled=False,
+    )
+
+    # Verify optimistic update
+    assert switch.is_on is False
+    mock_coordinator.register_pending_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_appliance_port_switch_turn_on(
+    hass: HomeAssistant,
+    mock_coordinator,
+    mock_device,
+    mock_config_entry,
+):
+    """Test turning the appliance port switch on."""
+    port = MerakiAppliancePort(number=2, enabled=False)
+    switch = MerakiAppliancePortSwitch(
+        mock_coordinator, mock_device, port, mock_config_entry
+    )
+    switch.hass = hass
+    switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await switch.async_turn_on()
+
+    # Verify API call
+    mock_coordinator.api.appliance.update_network_appliance_port.assert_called_once_with(
+        network_id="N_12345",
+        port_id="2",
+        enabled=True,
+    )
+
+    # Verify optimistic update
+    assert switch.is_on is True
+    mock_coordinator.register_pending_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_appliance_port_switch_update(
+    hass: HomeAssistant,
+    mock_coordinator,
+    mock_device,
+    mock_config_entry,
+):
+    """Test updating the appliance port switch from coordinator data."""
+    port = MerakiAppliancePort(number=1, enabled=True)
+    switch = MerakiAppliancePortSwitch(
+        mock_coordinator, mock_device, port, mock_config_entry
+    )
+    switch.hass = hass
+    switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    # Simulate update with new data (disabled)
+    new_device = MagicMock()
+    new_device.serial = "Q2AA-BB33-CC44"
+    new_device.appliance_ports = [MerakiAppliancePort(number=1, enabled=False)]
+    mock_coordinator.get_device.return_value = new_device
+
+    switch._handle_coordinator_update()
+
+    assert switch.is_on is False


### PR DESCRIPTION
Implemented missing port controls (Enable/Disable Ports) for Meraki MX Appliances. 
This involved:
1. Adding a new API method `update_network_appliance_port` to handle appliance-specific port updates.
2. Implementing `MerakiAppliancePortSwitch` as a subclass of the existing port toggle logic, tailored for MX data structures and API requirements.
3. Updating the `AppliancePortProvider` to discover and create these switch entities for MX devices.
4. Adding comprehensive unit tests in `tests/switch/test_meraki_appliance_port_switch.py`.

Fixes #1910

---
*PR created automatically by Jules for task [4984801978328451571](https://jules.google.com/task/4984801978328451571) started by @brewmarsh*