### PR TITLE
Fix Entity Naming for Aggregated SSID Devices

### DIFF
--- a/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
+++ b/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
@@ -40,7 +40,7 @@ class MerakiContentFilteringSelect(CoordinatorEntity, SelectEntity):
 
         self.entity_description = SelectEntityDescription(
             key=f"content_filtering_{self._network_id}",
-            name="Content Filtering Policy",
+            name="Content filtering policy",
             icon="mdi:web-filter",
         )
 

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -45,9 +45,12 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
 
         self.entity_description = SelectEntityDescription(
             key=f"{self._network_id}ssid{self._ssid_number}_rf_profile",
-            name="RF Profile",
+            name="RF profile",
             icon="mdi:wifi-cog",
         )
+
+        ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+        self._attr_name = f"{ssid_name} RF profile"
 
         self._attr_unique_id = f"{self._network_id}ssid{self._ssid_number}_rf_profile"
         self._attr_options: list[str] = []

--- a/custom_components/meraki_ha/meraki_select/vpn.py
+++ b/custom_components/meraki_ha/meraki_select/vpn.py
@@ -40,7 +40,7 @@ class MerakiVpnSelect(CoordinatorEntity, SelectEntity):
 
         self.entity_description = SelectEntityDescription(
             key=f"vpn_status_{self._network_id}",
-            name="VPN Mode",
+            name="VPN mode",
             icon="mdi:vpn",
         )
 

--- a/custom_components/meraki_ha/sensor/network/base.py
+++ b/custom_components/meraki_ha/sensor/network/base.py
@@ -34,6 +34,13 @@ class MerakiSSIDBaseSensor(MerakiEntity, SensorEntity):
 
         # Unique ID is now handled by the dynamic @property method below
         self._attr_has_entity_name = True
+        ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description
+            and self.entity_description.name
+        ):
+            self._attr_name = f"{ssid_name} {self.entity_description.name}"
 
         # SSID entities are logical children of the "Virtual SSID Device"
         self._attr_device_info = resolve_device_info(

--- a/custom_components/meraki_ha/sensor/network/ssid_auth_mode.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_auth_mode.py
@@ -16,7 +16,7 @@ class MerakiSSIDAuthModeSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="auth_mode",
-        name="Auth Mode",
+        name="auth mode",
         icon="mdi:lock",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_availability.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_availability.py
@@ -16,7 +16,7 @@ class MerakiSSIDAvailabilitySensor(MerakiSSIDBaseSensor):
 
     entity_description = SensorEntityDescription(
         key="availability",
-        name="Availability",
+        name="availability",
         icon="mdi:check-circle-outline",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_band_selection.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_band_selection.py
@@ -16,7 +16,7 @@ class MerakiSSIDBandSelectionSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="band_selection",
-        name="Band Selection",
+        name="band selection",
         icon="mdi:wifi-arrow-up-down",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_client_count.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_client_count.py
@@ -15,7 +15,7 @@ class MerakiSSIDClientCountSensor(MerakiSSIDBaseSensor):
 
     entity_description = SensorEntityDescription(
         key="client_count",
-        name="Client count",
+        name="client count",
         icon="mdi:account-multiple",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="clients",

--- a/custom_components/meraki_ha/sensor/network/ssid_details.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_details.py
@@ -43,6 +43,15 @@ class MerakiSSIDDetailSensor(MerakiEntity, SensorEntity):
             config_entry=self._config_entry,
             ssid_data=self._ssid_data,
         )
+
+        ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+        if (
+            hasattr(self, "entity_description")
+            and self.entity_description
+            and self.entity_description.name
+        ):
+            self._attr_name = f"{ssid_name} {self.entity_description.name}"
+
         self._update_state()
 
     @callback
@@ -82,7 +91,7 @@ class MerakiSSIDWalledGardenSensor(MerakiSSIDDetailSensor):
 
     entity_description = SensorEntityDescription(
         key="walled_garden",
-        name="Walled garden",
+        name="walled garden",
         icon="mdi:wall",
     )
 
@@ -111,7 +120,7 @@ class MerakiSSIDTotalUploadLimitSensor(MerakiSSIDDetailSensor):
 
     entity_description = SensorEntityDescription(
         key="total_upload_limit",
-        name="Total upload limit",
+        name="total upload limit",
         icon="mdi:upload-network",
         native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
     )
@@ -136,7 +145,7 @@ class MerakiSSIDTotalDownloadLimitSensor(MerakiSSIDDetailSensor):
 
     entity_description = SensorEntityDescription(
         key="total_download_limit",
-        name="Total download limit",
+        name="total download limit",
         icon="mdi:download-network",
         native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
     )
@@ -161,7 +170,7 @@ class MerakiSSIDMandatoryDhcpSensor(MerakiSSIDDetailSensor):
 
     entity_description = SensorEntityDescription(
         key="mandatory_dhcp",
-        name="Mandatory DHCP",
+        name="mandatory DHCP",
         icon="mdi:ip-network",
     )
 
@@ -187,7 +196,7 @@ class MerakiSSIDMinBitrate24GhzSensor(MerakiSSIDDetailSensor):
 
     entity_description = SensorEntityDescription(
         key="min_bitrate_24",
-        name="Minimum bitrate 2.4GHz",
+        name="minimum bitrate 2.4GHz",
         icon="mdi:speedometer-slow",
         native_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
     )
@@ -217,7 +226,7 @@ class MerakiSSIDMinBitrate5GhzSensor(MerakiSSIDDetailSensor):
 
     entity_description = SensorEntityDescription(
         key="min_bitrate_5",
-        name="Minimum bitrate 5GHz",
+        name="minimum bitrate 5GHz",
         icon="mdi:speedometer",
         native_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
     )

--- a/custom_components/meraki_ha/sensor/network/ssid_encryption_mode.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_encryption_mode.py
@@ -16,7 +16,7 @@ class MerakiSSIDEncryptionModeSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="encryption_mode",
-        name="Encryption Mode",
+        name="encryption mode",
         icon="mdi:shield-key",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_ip_assignment_mode.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_ip_assignment_mode.py
@@ -16,7 +16,7 @@ class MerakiSSIDIPAssignmentModeSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="ip_assignment_mode",
-        name="IP Assignment Mode",
+        name="IP assignment mode",
         icon="mdi:ip-network",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_per_client_bandwidth_limit.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_per_client_bandwidth_limit.py
@@ -11,7 +11,7 @@ from .base import MerakiSSIDBaseSensor
 
 PER_CLIENT_BANDWIDTH_LIMIT_UP = SensorEntityDescription(
     key="per_client_bandwidth_limit_up",
-    name="Per-client bandwidth limit up",
+    name="per-client bandwidth limit up",
     icon="mdi:upload-network",
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
@@ -19,7 +19,7 @@ PER_CLIENT_BANDWIDTH_LIMIT_UP = SensorEntityDescription(
 
 PER_CLIENT_BANDWIDTH_LIMIT_DOWN = SensorEntityDescription(
     key="per_client_bandwidth_limit_down",
-    name="Per-client bandwidth limit down",
+    name="per-client bandwidth limit down",
     icon="mdi:download-network",
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,

--- a/custom_components/meraki_ha/sensor/network/ssid_per_ssid_bandwidth_limit.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_per_ssid_bandwidth_limit.py
@@ -11,7 +11,7 @@ from .base import MerakiSSIDBaseSensor
 
 BANDWIDTH_LIMIT_UP = SensorEntityDescription(
     key="bandwidth_limit_up",
-    name="Per-SSID bandwidth limit up",
+    name="per-SSID bandwidth limit up",
     icon="mdi:upload-network-outline",
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
@@ -19,7 +19,7 @@ BANDWIDTH_LIMIT_UP = SensorEntityDescription(
 
 BANDWIDTH_LIMIT_DOWN = SensorEntityDescription(
     key="bandwidth_limit_down",
-    name="Per-SSID bandwidth limit down",
+    name="per-SSID bandwidth limit down",
     icon="mdi:download-network-outline",
     state_class=SensorStateClass.MEASUREMENT,
     native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,

--- a/custom_components/meraki_ha/sensor/network/ssid_splash_page.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_splash_page.py
@@ -16,7 +16,7 @@ class MerakiSSIDSplashPageSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="splash_page",
-        name="Splash Page",
+        name="splash page",
         icon="mdi:page-next",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_visible.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_visible.py
@@ -16,7 +16,7 @@ class MerakiSSIDVisibleSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="visible",
-        name="Visible",
+        name="broadcast",
         icon="mdi:eye",
     )
 

--- a/custom_components/meraki_ha/sensor/network/ssid_wpa_encryption_mode.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_wpa_encryption_mode.py
@@ -16,7 +16,7 @@ class MerakiSSIDWPAEncryptionModeSensor(MerakiSSIDBaseSensor):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = SensorEntityDescription(
         key="wpa_encryption_mode",
-        name="WPA Encryption Mode",
+        name="WPA encryption mode",
         icon="mdi:shield-key-outline",
     )
 

--- a/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
@@ -165,7 +165,8 @@ class MerakiSSIDEnabledSwitch(MerakiSSIDBaseSwitch):
             "enabled",
             "enabled",
         )
-        self._attr_name = "Enabled Control"
+        ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+        self._attr_name = f"{ssid_name} enabled"
 
     @property
     def available(self) -> bool:
@@ -194,4 +195,5 @@ class MerakiSSIDBroadcastSwitch(MerakiSSIDBaseSwitch):
             "broadcast",
             "visible",
         )
-        self._attr_name = "Broadcast Control"
+        ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+        self._attr_name = f"{ssid_name} broadcast"

--- a/custom_components/meraki_ha/text/meraki_ssid_name.py
+++ b/custom_components/meraki_ha/text/meraki_ssid_name.py
@@ -49,11 +49,14 @@ class MerakiSSIDNameText(CoordinatorEntity[MerakiDataUpdateCoordinator], TextEnt
         # EntityDescription can be used for name, icon etc.
         self.entity_description = TextEntityDescription(
             key=f"{self._network_id}ssid{self._ssid_number}_ssid_name",
-            name="SSID Name",
+            name="SSID name",
             icon="mdi:form-textbox",
             native_min=1,
             native_max=32,
         )
+
+        ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
+        self._attr_name = f"{ssid_name} SSID name"
 
         self._attr_unique_id = f"{self._network_id}ssid{self._ssid_number}_name_text"
 

--- a/tests/sensor/network/test_ssid_client_count.py
+++ b/tests/sensor/network/test_ssid_client_count.py
@@ -28,7 +28,7 @@ async def test_ssid_client_count_sensor_wireless_settings() -> None:
 
     sensor = MerakiSSIDClientCountSensor(coordinator, config_entry, ssid_data)
 
-    assert sensor.name == "Client count"
+    assert sensor.name == "Test SSID client count"
     assert sensor.native_value == 5
 
     # Test update

--- a/tests/sensor/network/test_ssid_details.py
+++ b/tests/sensor/network/test_ssid_details.py
@@ -32,7 +32,7 @@ async def test_ssid_total_upload_limit_sensor() -> None:
         coordinator, config_entry, ssid_data, None
     )
 
-    assert sensor.name == "Total upload limit"
+    assert sensor.name == "Test SSID total upload limit"
     assert sensor.native_value == 1000
     assert sensor.native_unit_of_measurement == UnitOfDataRate.KILOBITS_PER_SECOND
 
@@ -70,7 +70,7 @@ async def test_ssid_min_bitrate_24ghz_sensor() -> None:
         coordinator, config_entry, ssid_data, rf_profile
     )
 
-    assert sensor.name == "Minimum bitrate 2.4GHz"
+    assert sensor.name == "Test SSID minimum bitrate 2.4GHz"
     assert sensor.native_value == 11
 
     # Test update

--- a/tests/sensor/network/test_ssid_psk.py
+++ b/tests/sensor/network/test_ssid_psk.py
@@ -22,7 +22,7 @@ async def test_ssid_psk_sensor() -> None:
     coordinator.data = {"ssids": [ssid_data_psk]}
 
     sensor = MerakiSSIDPSKSensor(coordinator, config_entry, ssid_data_psk)
-    assert sensor.name == "PSK"
+    assert sensor.name == "PSK SSID PSK"
 
     # RESOLVED: We use the standardized Beta branch format to prevent collisions
     assert sensor.unique_id == "N_123ssid0_psk"

--- a/tests/switch/test_meraki_ssid_device_switch.py
+++ b/tests/switch/test_meraki_ssid_device_switch.py
@@ -60,7 +60,7 @@ async def test_meraki_ssid_enabled_switch(
     )
 
     assert switch.is_on is True
-    assert switch.name == "Enabled Control"
+    assert switch.name == "Test SSID enabled"
     device_info = switch.device_info
     assert device_info is not None
     # Refactor: SSID entities attach to Virtual Controller (Network Device)
@@ -94,7 +94,7 @@ async def test_meraki_ssid_broadcast_switch(
     )
 
     assert switch.is_on is True
-    assert switch.name == "Broadcast Control"
+    assert switch.name == "Test SSID broadcast"
     device_info = switch.device_info
     assert device_info is not None
     # Refactor: SSID entities attach to Virtual Controller (Network Device)

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,8 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+
+[[package]]
+name = "meraki-ha"
+version = "2.3.0b120"
+source = { virtual = "." }


### PR DESCRIPTION
Updated the naming logic for all SSID-specific entities attached to the Network/Site device. Because these entities were moved to a global Network device, Home Assistant was stripping the device name, leaving generic names like "Broadcast". 

Changes:
1. Modified base classes (`MerakiSSIDBaseSensor`, `MerakiSSIDDetailSensor`, `MerakiSSIDBaseSwitch`) to extract the SSID name from the data payload and prepend it to `_attr_name`.
2. Updated all SSID-related entity descriptions to follow Home Assistant Sentence Case (e.g., "client count" instead of "Client count", "broadcast" instead of "Visible").
3. Updated `MerakiSSIDNameText` and `MerakiRFProfileSelect` to follow the same naming convention.
4. Updated unit tests to reflect the new expected entity names.

This ensures that the UI clearly lists entities like "Guest Wi-Fi broadcast" or "IoT Network client count", eliminating ambiguity.

Fixes #1941

---
*PR created automatically by Jules for task [14120047715408187102](https://jules.google.com/task/14120047715408187102) started by @brewmarsh*