### PR TITLE
fix: cleanup duplicate constants and improve typing

### DIFF
--- a/custom_components/meraki_ha/const_conf.py
+++ b/custom_components/meraki_ha/const_conf.py
@@ -52,7 +52,6 @@ CONF_ENABLE_NETWORK_SENSORS: Final = "enable_network_sensors"
 CONF_ENABLE_VLAN_SENSORS: Final = "enable_vlan_sensors"
 CONF_ENABLE_PORT_SENSORS: Final = "enable_port_sensors"
 CONF_ENABLE_SSID_SENSORS: Final = "enable_ssid_sensors"
-CONF_ENABLE_CLIENT_STATUS_SENSORS: Final = "enable_client_status_sensors"
 CONF_ENABLE_CAMERA_SENSE: Final = "enable_camera_sense"
 CONF_ENABLE_CLIENT_STATUS_SENSORS: Final = "enable_client_status_sensors"
 
@@ -89,6 +88,5 @@ DEFAULT_ENABLE_NETWORK_SENSORS: Final = True
 DEFAULT_ENABLE_VLAN_SENSORS: Final = True
 DEFAULT_ENABLE_PORT_SENSORS: Final = True
 DEFAULT_ENABLE_SSID_SENSORS: Final = True
-DEFAULT_ENABLE_CLIENT_STATUS_SENSORS: Final = False
 DEFAULT_ENABLE_CAMERA_SENSE: Final = True
 DEFAULT_ENABLE_CLIENT_STATUS_SENSORS: Final = False

--- a/custom_components/meraki_ha/sensor/client/status.py
+++ b/custom_components/meraki_ha/sensor/client/status.py
@@ -68,18 +68,19 @@ class MerakiClientStatusSensor(MerakiSensor):
             or self._client_mac
         )
 
-        via_device = None
-        if client_data.get("recentDeviceSerial"):
-            via_device = (DOMAIN, client_data.get("recentDeviceSerial"))
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._client_mac)},
             name=client_name,
             manufacturer=client_data.get("manufacturer", "Cisco Meraki"),
             model="Client",
             serial_number=self._client_mac,
-            via_device=via_device,
         )
+
+        if client_data.get("recentDeviceSerial"):
+            self._attr_device_info["via_device"] = (
+                DOMAIN,
+                str(client_data["recentDeviceSerial"]),
+            )
 
         self.entity_description = SensorEntityDescription(
             key="client_status",

--- a/custom_components/meraki_ha/switch/setup_helpers.py
+++ b/custom_components/meraki_ha/switch/setup_helpers.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
@@ -34,12 +35,12 @@ def _setup_firewall_rule_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up firewall rule switches."""
     if not config_entry.options.get(CONF_ENABLE_FIREWALL_RULES):
         return []
 
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     # Structure is {network_id: [rule1, rule2, ...]}
     rules_by_network = coordinator.data.get("l3_firewall_rules", {})
     for network_id, rules in rules_by_network.items():
@@ -67,12 +68,12 @@ def _setup_traffic_shaping_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up traffic shaping switches."""
     if not config_entry.options.get(CONF_ENABLE_TRAFFIC_SHAPING):
         return []
 
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     traffic_shaping_by_network = coordinator.data.get("traffic_shaping", {})
     for network_id, traffic_shaping in traffic_shaping_by_network.items():
         if not isinstance(traffic_shaping, MerakiTrafficShaping):
@@ -96,12 +97,12 @@ def _setup_vpn_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up VPN switches."""
     if not config_entry.options.get(CONF_ENABLE_VPN_MANAGEMENT):
         return []
 
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     vpn_status_by_network = coordinator.data.get("vpn_status", {})
     for network_id, vpn_status in vpn_status_by_network.items():
         if not isinstance(vpn_status, MerakiVpn):
@@ -127,11 +128,11 @@ def _setup_vlan_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up VLAN switches."""
     if not config_entry.options.get(CONF_ENABLE_VLAN_MANAGEMENT):
         return []
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     vlans_by_network = coordinator.data.get("vlans", {})
     for network_id, vlans in vlans_by_network.items():
         if not isinstance(vlans, list):
@@ -159,9 +160,9 @@ def _setup_ssid_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up SSID switches."""
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     ssids = coordinator.data.get("ssids", [])
     for ssid in ssids:
         ssid_number = ssid.get("number")
@@ -200,9 +201,9 @@ def _setup_camera_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up camera-specific switches."""
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     devices = coordinator.data.get("devices", [])
     for device_info in devices:
         if (device_info.product_type or "").startswith("camera"):
@@ -222,9 +223,9 @@ def _setup_mt40_switches(
     coordinator: MerakiDataUpdateCoordinator,
     added_entities: set[str],
     meraki_client: "MerakiAPIClient",
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up MT40 power outlet switches."""
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     devices = coordinator.data.get("devices", [])
     for device_info in devices:
         if (device_info.model or "").startswith("MT40"):
@@ -245,9 +246,9 @@ def async_setup_switches(
     config_entry: ConfigEntry,
     coordinator: MerakiDataUpdateCoordinator,
     meraki_client: "MerakiAPIClient",
-) -> list[Entity]:
+) -> list[SwitchEntity]:
     """Set up all switch entities from the central coordinator."""
-    entities: list[Entity] = []
+    entities: list[SwitchEntity] = []
     added_entities: set[str] = set()
 
     if not coordinator.data:


### PR DESCRIPTION
- Removed duplicate definitions of `CONF_ENABLE_CLIENT_STATUS_SENSORS` and `DEFAULT_ENABLE_CLIENT_STATUS_SENSORS` in `custom_components/meraki_ha/const_conf.py`.
- Updated `MerakiClientStatusSensor` in `custom_components/meraki_ha/sensor/client/status.py` to conditionally assign `via_device` to `DeviceInfo`, fixing a `mypy` type error.
- Updated return type annotations in `custom_components/meraki_ha/switch/setup_helpers.py` from `list[Entity]` to `list[SwitchEntity]` to match `switch` platform expectations.

---
*PR created automatically by Jules for task [12570114400091646404](https://jules.google.com/task/12570114400091646404) started by @brewmarsh*