### PR TITLE
fix: resolve OPTIONS_SCHEMA import and usage in config_flow

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -27,7 +27,7 @@ from .const_conf import (
 )
 from .core.errors import MerakiAuthenticationError, MerakiConnectionError
 from .helpers.schema import get_filtered_schema, populate_schema_defaults
-from .schemas import CONFIG_SCHEMA, OPTIONS_SCHEMA
+from .schemas import CONFIG_SCHEMA, OPTIONS_SCHEMA_GENERAL
 
 if TYPE_CHECKING:
     from .coordinator import MerakiDataUpdateCoordinator
@@ -193,7 +193,7 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignor
         # Filter schema based on discovered hardware
         filtered_schema = get_filtered_schema(
             coordinator.data.get("devices", []),
-            OPTIONS_SCHEMA,
+            OPTIONS_SCHEMA_GENERAL,
         )
 
         schema_with_defaults = populate_schema_defaults(

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "config": {
     "step": {
       "user": {


### PR DESCRIPTION
This change fixes the broken import and usage of `OPTIONS_SCHEMA` in `custom_components/meraki_ha/config_flow.py`. The monolithic `OPTIONS_SCHEMA` was recently removed and split into sectioned schemas. This update ensures `config_flow.py` uses the new `OPTIONS_SCHEMA_GENERAL` schema, preventing a crash during the reconfiguration flow. Verified with unit tests for config flow and options flow.

Fixes #1953

---
*PR created automatically by Jules for task [10614594576462871338](https://jules.google.com/task/10614594576462871338) started by @brewmarsh*