### PR TITLE
Fix agent scorecard workflow arguments

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -40,7 +40,7 @@ jobs:
           echo "Running agent scorecard against $TARGET_BRANCH..."
           # Create an initial report in case the tool fails
           echo "Agent scorecard run failed or produced no output." > readiness_report.md
-          agent-score score custom_components/meraki_ha --diff $TARGET_BRANCH --report readiness_report.md
+          agent-score score custom_components/meraki_ha --diff --diff-base $TARGET_BRANCH --report readiness_report.md
 
       - name: Upload readiness report
         if: always()

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "config": {
     "step": {
       "user": {


### PR DESCRIPTION
Fixed the agent-score invocation in .github/workflows/agent-readiness.yaml which was failing with "Got unexpected extra argument (origin/main)". Corrected the syntax to use --diff and --diff-base flags.

Fixes #1954

---
*PR created automatically by Jules for task [6576260769379070475](https://jules.google.com/task/6576260769379070475) started by @brewmarsh*