### PR TITLE
Deconstruct the device model god module

### DIFF
--- a/custom_components/meraki_ha/core/models/__init__.py
+++ b/custom_components/meraki_ha/core/models/__init__.py
@@ -1,6 +1,8 @@
 """Models package for Meraki API data structures."""
 
-from .device import MerakiAppliancePort, MerakiDevice
+from .appliance import MerakiApplianceMixin, MerakiAppliancePort
+from .camera import MerakiCameraMixin
+from .device import MerakiDevice
 from .network import (
     MerakiFirewallRule,
     MerakiNetwork,
@@ -8,13 +10,23 @@ from .network import (
     MerakiVlan,
     MerakiVpn,
 )
+from .organization import MerakiOrganization
+from .sensor import MerakiSensorMixin
+from .switch import MerakiSwitchMixin
+from .wireless import MerakiWirelessMixin
 
 __all__ = [
+    "MerakiApplianceMixin",
     "MerakiAppliancePort",
+    "MerakiCameraMixin",
     "MerakiDevice",
     "MerakiFirewallRule",
     "MerakiNetwork",
+    "MerakiOrganization",
+    "MerakiSensorMixin",
+    "MerakiSwitchMixin",
     "MerakiTrafficShaping",
     "MerakiVlan",
     "MerakiVpn",
+    "MerakiWirelessMixin",
 ]

--- a/custom_components/meraki_ha/core/models/appliance.py
+++ b/custom_components/meraki_ha/core/models/appliance.py
@@ -1,0 +1,59 @@
+"""Appliance models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(kw_only=True)
+class MerakiAppliancePort:
+    """Represents a Meraki Appliance Port."""
+
+    number: int | None = None
+    enabled: bool = False
+    type: str | None = None
+    drop_untagged_traffic: bool = False
+    vlan: int | None = None
+    access_policy: str | None = None
+    allowed_vlans: str | None = None
+    status: str | None = None
+    speed: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "number": self.number,
+            "enabled": self.enabled,
+            "type": self.type,
+            "dropUntaggedTraffic": self.drop_untagged_traffic,
+            "vlan": self.vlan,
+            "accessPolicy": self.access_policy,
+            "allowedVlans": self.allowed_vlans,
+            "status": self.status,
+            "speed": self.speed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiAppliancePort:
+        """Create a MerakiAppliancePort instance from a dictionary."""
+        return cls(
+            number=data.get("number"),
+            enabled=data.get("enabled", False),
+            type=data.get("type"),
+            drop_untagged_traffic=data.get("dropUntaggedTraffic", False),
+            vlan=data.get("vlan"),
+            access_policy=data.get("accessPolicy"),
+            allowed_vlans=data.get("allowedVlans"),
+            status=data.get("status"),
+            speed=data.get("speed"),
+        )
+
+
+@dataclass(kw_only=True)
+class MerakiApplianceMixin:
+    """Mixin for Meraki Appliance specific fields."""
+
+    appliance_uplink_statuses: list[dict[str, Any]] = field(default_factory=list)
+    appliance_ports: list[MerakiAppliancePort] = field(default_factory=list)
+    dynamic_dns: dict[str, Any] | None = None

--- a/custom_components/meraki_ha/core/models/camera.py
+++ b/custom_components/meraki_ha/core/models/camera.py
@@ -1,0 +1,16 @@
+"""Camera models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(kw_only=True)
+class MerakiCameraMixin:
+    """Mixin for Meraki Camera specific fields."""
+
+    video_settings: dict[str, Any] | None = None
+    rtsp_url: str | None = None
+    sense_settings: dict[str, Any] | None = None
+    analytics: list[dict[str, Any]] = field(default_factory=list)

--- a/custom_components/meraki_ha/core/models/device.py
+++ b/custom_components/meraki_ha/core/models/device.py
@@ -5,53 +5,21 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-
-@dataclass
-class MerakiAppliancePort:
-    """Represents a Meraki Appliance Port."""
-
-    number: int | None = None
-    enabled: bool = False
-    type: str | None = None
-    drop_untagged_traffic: bool = False
-    vlan: int | None = None
-    access_policy: str | None = None
-    allowed_vlans: str | None = None
-    status: str | None = None
-    speed: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary."""
-        return {
-            "number": self.number,
-            "enabled": self.enabled,
-            "type": self.type,
-            "dropUntaggedTraffic": self.drop_untagged_traffic,
-            "vlan": self.vlan,
-            "accessPolicy": self.access_policy,
-            "allowedVlans": self.allowed_vlans,
-            "status": self.status,
-            "speed": self.speed,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> MerakiAppliancePort:
-        """Create a MerakiAppliancePort instance from a dictionary."""
-        return cls(
-            number=data.get("number"),
-            enabled=data.get("enabled", False),
-            type=data.get("type"),
-            drop_untagged_traffic=data.get("dropUntaggedTraffic", False),
-            vlan=data.get("vlan"),
-            access_policy=data.get("accessPolicy"),
-            allowed_vlans=data.get("allowedVlans"),
-            status=data.get("status"),
-            speed=data.get("speed"),
-        )
+from .appliance import MerakiApplianceMixin, MerakiAppliancePort
+from .camera import MerakiCameraMixin
+from .sensor import MerakiSensorMixin
+from .switch import MerakiSwitchMixin
+from .wireless import MerakiWirelessMixin
 
 
-@dataclass
-class MerakiDevice:
+@dataclass(kw_only=True)
+class MerakiDevice(
+    MerakiApplianceMixin,
+    MerakiCameraMixin,
+    MerakiSensorMixin,
+    MerakiSwitchMixin,
+    MerakiWirelessMixin,
+):
     """Dataclass for a Meraki device."""
 
     serial: str | None = None
@@ -63,7 +31,6 @@ class MerakiDevice:
     wan2_ip: str | None = None
     public_ip: str | None = None
     network_id: str | None = None
-    appliance_uplink_statuses: list[dict[str, Any]] = field(default_factory=list)
     uplinks: list[dict[str, Any]] = field(default_factory=list)
     status: str | None = None
     firmware: str | None = None
@@ -73,35 +40,19 @@ class MerakiDevice:
     notes: str | None = None
     url: str | None = None
     firmware_upgrades: dict[str, Any] | None = None
-    readings: list[dict[str, Any]] = field(default_factory=list)
-    video_settings: dict[str, Any] | None = None
-    rtsp_url: str | None = None
-    sense_settings: dict[str, Any] | None = None
-    analytics: list[dict[str, Any]] = field(default_factory=list)
-    ports_statuses: list[dict[str, Any]] = field(default_factory=list)
-    appliance_ports: list[MerakiAppliancePort] = field(default_factory=list)
-    sensor_relationships: list[dict[str, Any]] = field(default_factory=list)
-    dynamic_dns: dict[str, Any] | None = None
     management_interface: dict[str, Any] | None = None
-    wireless_radio_settings: dict[str, Any] | None = None
     status_messages: list[str] = field(default_factory=list)
     entity_id: str | None = None
-    ambient_noise: float | None = None
-    pm25: float | None = None
-    real_power: float | None = None
-    power_factor: float | None = None
-    current: float | None = None
-    voltage: float | None = None
-    door_open: bool | None = None
-    water_present: bool | None = None
-    button_press: dict[str, Any] | None = None
-    frequency: float | None = None
-    energy: float | None = None
-    outlet_status: bool | None = None
+
+    @property
+    def is_online(self) -> bool:
+        """Return True if the device is online."""
+        return self.status == "online"
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
-        return {
+        # Base fields
+        data = {
             "serial": self.serial,
             "name": self.name,
             "model": self.model,
@@ -119,23 +70,58 @@ class MerakiDevice:
             "notes": self.notes,
             "url": self.url,
             "firmwareUpgrades": self.firmware_upgrades,
-            "readings": self.readings,
-            "videoSettings": self.video_settings,
-            "rtspUrl": self.rtsp_url,
-            "senseSettings": self.sense_settings,
-            "analytics": self.analytics,
-            "portsStatuses": self.ports_statuses,
-            "appliancePorts": [p.to_dict() for p in self.appliance_ports],
-            "sensorRelationships": self.sensor_relationships,
-            "dynamicDns": self.dynamic_dns,
             "managementInterface": self.management_interface,
-            "wirelessRadioSettings": self.wireless_radio_settings,
             "statusMessages": self.status_messages,
-            "applianceUplinkStatuses": self.appliance_uplink_statuses,
             "uplinks": self.uplinks,
             "entity_id": self.entity_id,
-            "outletStatus": self.outlet_status,
         }
+
+        # Appliance fields
+        data.update(
+            {
+                "applianceUplinkStatuses": self.appliance_uplink_statuses,
+                "appliancePorts": [p.to_dict() for p in self.appliance_ports],
+                "dynamicDns": self.dynamic_dns,
+            }
+        )
+
+        # Camera fields
+        data.update(
+            {
+                "videoSettings": self.video_settings,
+                "rtspUrl": self.rtsp_url,
+                "senseSettings": self.sense_settings,
+                "analytics": self.analytics,
+            }
+        )
+
+        # Switch fields
+        data.update({"portsStatuses": self.ports_statuses})
+
+        # Wireless fields
+        data.update({"wirelessRadioSettings": self.wireless_radio_settings})
+
+        # Sensor fields
+        data.update(
+            {
+                "sensorRelationships": self.sensor_relationships,
+                "readings": self.readings,
+                "outletStatus": self.outlet_status,
+                "ambientNoise": self.ambient_noise,
+                "pm25": self.pm25,
+                "realPower": self.real_power,
+                "powerFactor": self.power_factor,
+                "current": self.current,
+                "voltage": self.voltage,
+                "doorOpen": self.door_open,
+                "waterPresent": self.water_present,
+                "buttonPress": self.button_press,
+                "frequency": self.frequency,
+                "energy": self.energy,
+            }
+        )
+
+        return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MerakiDevice:
@@ -158,22 +144,38 @@ class MerakiDevice:
             notes=data.get("notes"),
             url=data.get("url"),
             firmware_upgrades=data.get("firmwareUpgrades"),
-            readings=data.get("readings", []),
+            management_interface=data.get("managementInterface"),
+            status_messages=data.get("statusMessages", []),
+            uplinks=data.get("uplinks", []),
+            entity_id=data.get("entity_id"),
+            # Appliance fields
+            appliance_uplink_statuses=data.get("applianceUplinkStatuses", []),
+            appliance_ports=[
+                MerakiAppliancePort.from_dict(p) for p in data.get("appliancePorts", [])
+            ],
+            dynamic_dns=data.get("dynamicDns"),
+            # Camera fields
             video_settings=data.get("videoSettings"),
             rtsp_url=data.get("rtspUrl"),
             sense_settings=data.get("senseSettings"),
             analytics=data.get("analytics", []),
+            # Switch fields
             ports_statuses=data.get("portsStatuses", []),
-            appliance_ports=[
-                MerakiAppliancePort.from_dict(p) for p in data.get("appliancePorts", [])
-            ],
-            sensor_relationships=data.get("sensorRelationships", []),
-            dynamic_dns=data.get("dynamicDns"),
-            management_interface=data.get("managementInterface"),
+            # Wireless fields
             wireless_radio_settings=data.get("wirelessRadioSettings"),
-            status_messages=data.get("statusMessages", []),
-            appliance_uplink_statuses=data.get("applianceUplinkStatuses", []),
-            uplinks=data.get("uplinks", []),
-            entity_id=data.get("entity_id"),
+            # Sensor fields
+            sensor_relationships=data.get("sensorRelationships", []),
+            readings=data.get("readings", []),
             outlet_status=data.get("outletStatus"),
+            ambient_noise=data.get("ambientNoise"),
+            pm25=data.get("pm25"),
+            real_power=data.get("realPower"),
+            power_factor=data.get("powerFactor"),
+            current=data.get("current"),
+            voltage=data.get("voltage"),
+            door_open=data.get("doorOpen"),
+            water_present=data.get("waterPresent"),
+            button_press=data.get("buttonPress"),
+            frequency=data.get("frequency"),
+            energy=data.get("energy"),
         )

--- a/custom_components/meraki_ha/core/models/organization.py
+++ b/custom_components/meraki_ha/core/models/organization.py
@@ -1,0 +1,44 @@
+"""Organization models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(kw_only=True)
+class MerakiOrganization:
+    """Dataclass for a Meraki organization."""
+
+    id: str | None = None
+    name: str | None = None
+    url: str | None = None
+    api: dict[str, Any] = field(default_factory=dict)
+    cloud: dict[str, Any] = field(default_factory=dict)
+    management: dict[str, Any] = field(default_factory=dict)
+    licensing: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MerakiOrganization:
+        """Create a MerakiOrganization instance from a dictionary."""
+        return cls(
+            id=data.get("id"),
+            name=data.get("name"),
+            url=data.get("url"),
+            api=data.get("api", {}),
+            cloud=data.get("cloud", {}),
+            management=data.get("management", {}),
+            licensing=data.get("licensing", {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "url": self.url,
+            "api": self.api,
+            "cloud": self.cloud,
+            "management": self.management,
+            "licensing": self.licensing,
+        }

--- a/custom_components/meraki_ha/core/models/sensor.py
+++ b/custom_components/meraki_ha/core/models/sensor.py
@@ -1,3 +1,26 @@
 """Sensor models for Meraki API data structures."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(kw_only=True)
+class MerakiSensorMixin:
+    """Mixin for Meraki Sensor specific fields."""
+
+    sensor_relationships: list[dict[str, Any]] = field(default_factory=list)
+    readings: list[dict[str, Any]] = field(default_factory=list)
+    ambient_noise: float | None = None
+    pm25: float | None = None
+    real_power: float | None = None
+    power_factor: float | None = None
+    current: float | None = None
+    voltage: float | None = None
+    door_open: bool | None = None
+    water_present: bool | None = None
+    button_press: dict[str, Any] | None = None
+    frequency: float | None = None
+    energy: float | None = None
+    outlet_status: bool | None = None

--- a/custom_components/meraki_ha/core/models/switch.py
+++ b/custom_components/meraki_ha/core/models/switch.py
@@ -1,0 +1,13 @@
+"""Switch models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(kw_only=True)
+class MerakiSwitchMixin:
+    """Mixin for Meraki Switch specific fields."""
+
+    ports_statuses: list[dict[str, Any]] = field(default_factory=list)

--- a/custom_components/meraki_ha/core/models/wireless.py
+++ b/custom_components/meraki_ha/core/models/wireless.py
@@ -1,0 +1,13 @@
+"""Wireless models for Meraki API data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(kw_only=True)
+class MerakiWirelessMixin:
+    """Mixin for Meraki Wireless specific fields."""
+
+    wireless_radio_settings: dict[str, Any] | None = None


### PR DESCRIPTION
This change deconstructs the monolithic `MerakiDevice` model in `custom_components/meraki_ha/core/models/device.py` into cohesive mixins and separate model files. This improves maintainability and follows the principle of separation of concerns.

Key changes:
- Created `organization.py`, `appliance.py`, `camera.py`, `switch.py`, `wireless.py`, and updated `sensor.py`.
- Extracted `MerakiAppliancePort` and `MerakiOrganization` into their own files.
- Defined product-specific mixins (e.g., `MerakiCameraMixin`) to hold relevant fields.
- Updated `MerakiDevice` to inherit from these mixins.
- Used `kw_only=True` to prevent positional argument issues during instantiation.
- Added an `is_online` helper property.
- Verified that all tests pass and API compatibility is maintained.

Fixes #1965

---
*PR created automatically by Jules for task [7342861125760507702](https://jules.google.com/task/7342861125760507702) started by @brewmarsh*