### PR TITLE
Fix MerakiVlan object access TypeError

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_vlan_entity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 
 from ...coordinator import MerakiDataUpdateCoordinator
+from ..models.network import MerakiVlan
 from .meraki_network_entity import MerakiNetworkEntity
 
 
@@ -19,7 +20,7 @@ class MerakiVLANEntity(MerakiNetworkEntity):
         coordinator: MerakiDataUpdateCoordinator,
         config_entry: ConfigEntry,
         network_id: str,
-        vlan: dict,
+        vlan: MerakiVlan,
     ) -> None:
         """Initialize the VLAN entity."""
         network = coordinator.get_network(network_id)
@@ -28,7 +29,8 @@ class MerakiVLANEntity(MerakiNetworkEntity):
 
         # Set attributes needed for logic
         self._vlan = vlan
-        self._vlan_id = vlan["id"]
+        self._vlan_id = vlan.id
+        self._vlan_name = vlan.name
         self._vlan_data = vlan
 
         super().__init__(

--- a/custom_components/meraki_ha/core/models/network.py
+++ b/custom_components/meraki_ha/core/models/network.py
@@ -61,6 +61,9 @@ class MerakiVlan:
     appliance_ip: str | None = None
     ipv6: dict | None = None
     dhcp_handling: str | None = None
+    dns_nameservers: str | None = None
+    dhcp_lease_time: str | None = None
+    dhcp_boot_options_enabled: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MerakiVlan:
@@ -72,6 +75,9 @@ class MerakiVlan:
             appliance_ip=data.get("applianceIp"),
             ipv6=data.get("ipv6"),
             dhcp_handling=data.get("dhcpHandling"),
+            dns_nameservers=data.get("dnsNameservers"),
+            dhcp_lease_time=data.get("dhcpLeaseTime"),
+            dhcp_boot_options_enabled=data.get("dhcpBootOptionsEnabled", False),
         )
 
 

--- a/custom_components/meraki_ha/sensor/network/vlan.py
+++ b/custom_components/meraki_ha/sensor/network/vlan.py
@@ -11,6 +11,7 @@ from homeassistant.const import EntityCategory
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.entities.meraki_vlan_entity import MerakiVLANEntity
+from ...core.models.network import MerakiVlan
 from ...core.utils.entity_id_utils import get_vlan_entity_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,14 +27,14 @@ class MerakiVLANStatusSensor(MerakiVLANEntity, SensorEntity):
         coordinator: MerakiDataUpdateCoordinator,
         config_entry: ConfigEntry,
         network_id: str,
-        vlan: dict,
+        vlan: MerakiVlan,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, config_entry, network_id, vlan)
         if not self._network_id:
             raise ValueError("Network ID cannot be None for a VLAN entity")
-        vlan_id = self._vlan["id"]
-        vlan_name = self._vlan.get("name", "")
+        vlan_id = self._vlan.id
+        vlan_name = self._vlan.name or ""
 
         # Unique ID
         self._attr_unique_id = get_vlan_entity_id(self._network_id, vlan_id, "status")
@@ -47,21 +48,19 @@ class MerakiVLANStatusSensor(MerakiVLANEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the subnet (CIDR)."""
-        return self._vlan.get("subnet")
+        return self._vlan.subnet
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
-            "vlan_id": self._vlan.get("id"),
-            "name": self._vlan.get("name"),
-            "appliance_ip": self._vlan.get("applianceIp"),
-            "ipv6_enabled": self._vlan.get("ipv6", {}).get("enabled", False),
-            "ipv6_prefix": self._vlan.get("ipv6", {}).get("prefix"),
-            "dns_nameservers": self._vlan.get("dnsNameservers"),
-            "dhcp_handling": self._vlan.get("dhcpHandling"),
-            "dhcp_lease_time": self._vlan.get("dhcpLeaseTime"),
-            "dhcp_boot_options_enabled": self._vlan.get(
-                "dhcpBootOptionsEnabled", False
-            ),
+            "vlan_id": self._vlan.id,
+            "name": self._vlan.name,
+            "appliance_ip": self._vlan.appliance_ip,
+            "ipv6_enabled": (self._vlan.ipv6 or {}).get("enabled", False),
+            "ipv6_prefix": (self._vlan.ipv6 or {}).get("prefix"),
+            "dns_nameservers": self._vlan.dns_nameservers,
+            "dhcp_handling": self._vlan.dhcp_handling,
+            "dhcp_lease_time": self._vlan.dhcp_lease_time,
+            "dhcp_boot_options_enabled": self._vlan.dhcp_boot_options_enabled,
         }

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -43,8 +43,6 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         if not self._network:
             return
         vlans = self.coordinator.data.get("vlans", {}).get(self._network.id, [])
-        self._vlan_list = [
-            vlan.get("name") or f"VLAN {vlan.get('id')}" for vlan in vlans
-        ]
+        self._vlan_list = [vlan.name or f"VLAN {vlan.id}" for vlan in vlans]
         self._attr_native_value = len(vlans)
         self.async_write_ha_state()

--- a/custom_components/meraki_ha/switch/setup_helpers.py
+++ b/custom_components/meraki_ha/switch/setup_helpers.py
@@ -137,7 +137,7 @@ def _setup_vlan_switches(
         if not isinstance(vlans, list):
             continue
         for vlan in vlans:
-            vlan_id = vlan.get("id")
+            vlan_id = vlan.id
             if not vlan_id:
                 continue
 

--- a/custom_components/meraki_ha/switch/vlan_dhcp.py
+++ b/custom_components/meraki_ha/switch/vlan_dhcp.py
@@ -11,6 +11,7 @@ from homeassistant.core import callback
 
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.entities.meraki_vlan_entity import MerakiVLANEntity
+from ..core.models.network import MerakiVlan
 from ..core.utils.entity_id_utils import get_vlan_entity_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,13 +27,13 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
         coordinator: MerakiDataUpdateCoordinator,
         config_entry: ConfigEntry,
         network_id: str,
-        vlan: dict,
+        vlan: MerakiVlan,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator, config_entry, network_id, vlan)
         if not self._network_id:
             raise ValueError("Network ID cannot be None for a VLAN entity")
-        vlan_id = self._vlan["id"]
+        vlan_id = self._vlan.id
         if not vlan_id:
             raise ValueError("VLAN ID should not be None here")
         self._attr_unique_id = get_vlan_entity_id(
@@ -49,14 +50,14 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
             )
             return
 
-        self._attr_is_on = self._vlan["dhcpHandling"] == "Run a DHCP server"
+        self._attr_is_on = self._vlan.dhcp_handling == "Run a DHCP server"
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         vlans = self.coordinator.data.get("vlans", {}).get(self._network_id, [])
         for vlan in vlans:
-            if vlan["id"] == self._vlan["id"]:
+            if vlan.id == self._vlan.id:
                 self._vlan = vlan
                 break
         self._update_internal_state()
@@ -64,7 +65,7 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        vlan_id = self._vlan["id"]
+        vlan_id = self._vlan.id
         if not vlan_id:
             _LOGGER.error("Cannot turn on DHCP for VLAN without an ID")
             return
@@ -80,7 +81,7 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        vlan_id = self._vlan["id"]
+        vlan_id = self._vlan.id
         if not vlan_id:
             _LOGGER.error("Cannot turn off DHCP for VLAN without an ID")
             return

--- a/tests/sensor/network/test_vlan.py
+++ b/tests/sensor/network/test_vlan.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.core.models.network import MerakiVlan
 from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
 from custom_components.meraki_ha.sensor.network.vlan import MerakiVLANStatusSensor
 from custom_components.meraki_ha.types import MerakiNetwork
@@ -30,18 +31,18 @@ def mock_coordinator():
         product_types=["appliance"],
     )
 
-    # Create mock VLANs using dictionaries (as expected by the implementation)
-    vlan1 = {
-        "id": 1,
-        "name": "VLAN 1",
-        "subnet": "192.168.1.0/24",
-        "applianceIp": "192.168.1.1",
-        "ipv6": {
+    # Create mock VLANs using MerakiVlan objects
+    vlan1 = MerakiVlan(
+        id=1,
+        name="VLAN 1",
+        subnet="192.168.1.0/24",
+        appliance_ip="192.168.1.1",
+        ipv6={
             "enabled": True,
             "prefix": "2001:db8:1::/64",
         },
-        "dhcpHandling": "Run a DHCP server",
-    }
+        dhcp_handling="Run a DHCP server",
+    )
 
     coordinator.data = {
         "networks": [mock_network],

--- a/tests/sensor/network/test_vlans_list.py
+++ b/tests/sensor/network/test_vlans_list.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.const import EntityCategory
 
 from custom_components.meraki_ha.const_conf import CONF_ENABLE_VLAN_MANAGEMENT
+from custom_components.meraki_ha.core.models.network import MerakiVlan
 from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
 from custom_components.meraki_ha.types import MerakiNetwork
 
@@ -25,19 +26,19 @@ def mock_coordinator():
         product_types=["appliance"],
     )
 
-    # Create mock VLANs as dictionaries
-    vlan1 = {
-        "id": "1",
-        "name": "VLAN 1",
-        "subnet": "192.168.1.0/24",
-        "applianceIp": "192.168.1.1",
-    }
-    vlan2 = {
-        "id": "2",
-        "name": "VLAN 2",
-        "subnet": "192.168.2.0/24",
-        "applianceIp": "192.168.2.1",
-    }
+    # Create mock VLANs as MerakiVlan objects
+    vlan1 = MerakiVlan(
+        id="1",
+        name="VLAN 1",
+        subnet="192.168.1.0/24",
+        appliance_ip="192.168.1.1",
+    )
+    vlan2 = MerakiVlan(
+        id="2",
+        name="VLAN 2",
+        subnet="192.168.2.0/24",
+        appliance_ip="192.168.2.1",
+    )
 
     coordinator.data = {
         "networks": [mock_network],

--- a/tests/sensor/network/test_vlans_list_unit.py
+++ b/tests/sensor/network/test_vlans_list_unit.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.const import EntityCategory
 
+from custom_components.meraki_ha.core.models.network import MerakiVlan
 from custom_components.meraki_ha.sensor.network.vlans_list import VlansListSensor
 from custom_components.meraki_ha.types import MerakiNetwork
 
@@ -24,19 +25,19 @@ def mock_coordinator():
         product_types=["appliance"],
     )
 
-    # Create mock VLANs as dictionaries
-    vlan1 = {
-        "id": 10,
-        "name": "Guest",
-        "subnet": "192.168.10.0/24",
-        "applianceIp": "192.168.10.1",
-    }
-    vlan2 = {
-        "id": 20,
-        "name": "Staff",
-        "subnet": "192.168.20.0/24",
-        "applianceIp": "192.168.20.1",
-    }
+    # Create mock VLANs as MerakiVlan objects
+    vlan1 = MerakiVlan(
+        id=10,
+        name="Guest",
+        subnet="192.168.10.0/24",
+        appliance_ip="192.168.10.1",
+    )
+    vlan2 = MerakiVlan(
+        id=20,
+        name="Staff",
+        subnet="192.168.20.0/24",
+        appliance_ip="192.168.20.1",
+    )
 
     coordinator.data = {
         "networks": [mock_network],

--- a/tests/switch/test_vlan_dhcp.py
+++ b/tests/switch/test_vlan_dhcp.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.meraki_ha.const_conf import CONF_ENABLE_VLAN_MANAGEMENT
+from custom_components.meraki_ha.core.models.network import MerakiVlan
 from custom_components.meraki_ha.switch.setup_helpers import async_setup_switches
 from custom_components.meraki_ha.switch.vlan_dhcp import MerakiVLANDHCPSwitch
 from custom_components.meraki_ha.types import MerakiNetwork
@@ -13,11 +14,11 @@ from custom_components.meraki_ha.types import MerakiNetwork
 @pytest.fixture
 def mock_coordinator_with_vlan_data(mock_coordinator: MagicMock) -> MagicMock:
     """Fixture for a mocked MerakiDataUpdateCoordinator with VLAN data."""
-    vlan1 = {
-        "id": "1",
-        "name": "VLAN 1",
-        "dhcpHandling": "Run a DHCP server",
-    }
+    vlan1 = MerakiVlan(
+        id="1",
+        name="VLAN 1",
+        dhcp_handling="Run a DHCP server",
+    )
     network = MerakiNetwork(id="net1", name="Network 1")
     mock_coordinator.data = {
         "vlans": {"net1": [vlan1]},
@@ -76,8 +77,8 @@ def test_vlan_dhcp_switch_off_state(
     mock_meraki_client: MagicMock,
 ) -> None:
     """Test the off state of the VLAN DHCP switch."""
-    # Modify the dictionary
-    mock_coordinator_with_vlan_data.data["vlans"]["net1"][0]["dhcpHandling"] = (
+    # Modify the object
+    mock_coordinator_with_vlan_data.data["vlans"]["net1"][0].dhcp_handling = (
         "Do not respond to DHCP requests"
     )
 


### PR DESCRIPTION
This change fixes a `TypeError: 'MerakiVlan' object is not subscriptable` that occurred because VLAN data was refactored into objects but some parts of the code were still treating it as a dictionary. I updated the `MerakiVlan` dataclass to include all necessary fields, switched to attribute access in all relevant entities and helpers, and updated the tests to align with the new object-oriented model.

Fixes #1993

---
*PR created automatically by Jules for task [15597995073618899842](https://jules.google.com/task/15597995073618899842) started by @brewmarsh*