### PR TITLE
Fix MerakiVlan object access TypeError in network_utils

### DIFF
--- a/custom_components/meraki_ha/core/utils/network_utils.py
+++ b/custom_components/meraki_ha/core/utils/network_utils.py
@@ -6,6 +6,8 @@ import ipaddress
 from typing import Any
 from urllib.parse import urlparse
 
+from ..models.network import MerakiVlan
+
 
 def calculate_network_health(data: dict[str, Any]) -> float:
     """
@@ -65,16 +67,30 @@ def get_active_vlans(network_data: dict[str, Any]) -> list[dict[str, Any]]:
         List of active VLAN dictionaries with id and subnet info.
 
     """
-    return [
-        {
-            "id": vlan.get("id"),
-            "name": vlan.get("name"),
-            "subnet": vlan.get("subnet"),
-            "applianceIp": vlan.get("applianceIp"),
-        }
-        for vlan in network_data.get("vlans", [])
-        if vlan.get("enabled")
-    ]
+    active_vlans: list[dict[str, Any]] = []
+    vlans = network_data.get("vlans", [])
+
+    for vlan in vlans:
+        if isinstance(vlan, MerakiVlan):
+            active_vlans.append(
+                {
+                    "id": vlan.id,
+                    "name": vlan.name,
+                    "subnet": vlan.subnet,
+                    "applianceIp": vlan.appliance_ip,
+                }
+            )
+        elif isinstance(vlan, dict):
+            if vlan.get("enabled"):
+                active_vlans.append(
+                    {
+                        "id": vlan.get("id"),
+                        "name": vlan.get("name"),
+                        "subnet": vlan.get("subnet"),
+                        "applianceIp": vlan.get("applianceIp"),
+                    }
+                )
+    return active_vlans
 
 
 def get_ssid_status(network_data: dict[str, Any], ssid_number: int) -> str | None:

--- a/tests/core/utils/test_network_utils.py
+++ b/tests/core/utils/test_network_utils.py
@@ -1,0 +1,66 @@
+"""Tests for network utils."""
+import pytest
+from custom_components.meraki_ha.core.utils.network_utils import get_active_vlans
+from custom_components.meraki_ha.core.models.network import MerakiVlan
+
+def test_get_active_vlans_with_dicts():
+    """Test get_active_vlans with dictionaries (legacy)."""
+    network_data = {
+        "vlans": [
+            {
+                "id": "1",
+                "name": "VLAN 1",
+                "subnet": "192.168.1.0/24",
+                "applianceIp": "192.168.1.1",
+                "enabled": True,
+            },
+            {
+                "id": "2",
+                "name": "VLAN 2",
+                "enabled": False,
+            },
+            {
+                "id": "3",
+                "name": "VLAN 3",
+                "subnet": "192.168.3.0/24",
+                "applianceIp": "192.168.3.1",
+                "enabled": True,
+            },
+        ]
+    }
+
+    active = get_active_vlans(network_data)
+    assert len(active) == 2
+    assert active[0]["id"] == "1"
+    assert active[1]["id"] == "3"
+    assert active[0]["applianceIp"] == "192.168.1.1"
+
+def test_get_active_vlans_with_objects():
+    """Test get_active_vlans with MerakiVlan objects."""
+    vlan1 = MerakiVlan(
+        id="10",
+        name="VLAN 10",
+        subnet="10.0.10.0/24",
+        appliance_ip="10.0.10.1",
+    )
+    vlan2 = MerakiVlan(
+        id="20",
+        name="VLAN 20",
+        subnet="10.0.20.0/24",
+        appliance_ip="10.0.20.1",
+    )
+
+    network_data = {
+        "vlans": [vlan1, vlan2]
+    }
+
+    # This should handle objects and assume they are active
+    active = get_active_vlans(network_data)
+
+    assert len(active) == 2
+    assert active[0]["id"] == "10"
+    assert active[0]["name"] == "VLAN 10"
+    assert active[0]["subnet"] == "10.0.10.0/24"
+    assert active[0]["applianceIp"] == "10.0.10.1"
+
+    assert active[1]["id"] == "20"


### PR DESCRIPTION
Resolved a `TypeError` in `custom_components/meraki_ha/core/utils/network_utils.py` where the `get_active_vlans` function attempted to access `MerakiVlan` objects using dictionary syntax (e.g., `vlan.get("id")`).

Changes:
- Updated `get_active_vlans` to support both `MerakiVlan` objects (via attribute access) and legacy dictionaries.
- Added a new test file `tests/core/utils/test_network_utils.py` to verify the fix and ensure backward compatibility.

---
*PR created automatically by Jules for task [6756789391007601267](https://jules.google.com/task/6756789391007601267) started by @brewmarsh*