### PR TITLE
fix: resolve mypy type errors for MerakiVlan and MerakiDevice access

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -308,6 +308,8 @@ class DataFetchManager:
         for device in data.get("devices", []):
             if not isinstance(device, MerakiDevice) or not device.serial:
                 continue
+            if not device.product_type:
+                continue
             if strategy := strategies.get(device.product_type):
                 strategy.build_device_tasks(
                     device, tasks, self._get_device_capabilities(device.model), data
@@ -351,6 +353,9 @@ class DataFetchManager:
         }
         for device in data.get("devices", []):
             if not isinstance(device, MerakiDevice) or not device.serial:
+                continue
+
+            if not device.product_type:
                 continue
 
             if strategy := strategies.get(device.product_type):

--- a/custom_components/meraki_ha/sensor/network/vlan.py
+++ b/custom_components/meraki_ha/sensor/network/vlan.py
@@ -34,6 +34,8 @@ class MerakiVLANStatusSensor(MerakiVLANEntity, SensorEntity):
         if not self._network_id:
             raise ValueError("Network ID cannot be None for a VLAN entity")
         vlan_id = self._vlan.id
+        if not vlan_id:
+            raise ValueError("VLAN ID cannot be None for a VLAN sensor")
         vlan_name = self._vlan.name or ""
 
         # Unique ID


### PR DESCRIPTION
This PR addresses specific mypy type errors related to `MerakiVlan` object access and `MerakiDevice` product type handling.

Changes:
- **`sensor/network/vlan.py`**: Added validation to ensure `vlan.id` is present before creating a sensor. This prevents potential runtime issues with invalid entity IDs and satisfies mypy's type checking for `get_vlan_entity_id`.
- **`core/coordinator_helpers/data_fetcher.py`**: Added explicit checks for `device.product_type` to ensure it is not None before using it to look up fetch strategies. This resolves `Argument 1 to "get" of "dict" has incompatible type` errors reported by mypy.

This ensures better type safety and robustness against incomplete data.

---
*PR created automatically by Jules for task [17603971625985877560](https://jules.google.com/task/17603971625985877560) started by @brewmarsh*