### PR TITLE
Fix missing wireless SSID processing

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -374,6 +374,36 @@ class DataFetchManager:
                     device, data, previous_devices_map.get(device.serial)
                 )
 
+    def _process_network_strategies(
+        self,
+        data: dict[str, Any],
+        current_data: dict[str, Any] | None,
+    ) -> None:
+        """Process strategy-based updates for networks."""
+        from ..models.network import MerakiNetwork
+
+        strategies = {
+            "wireless": self.wireless_strategy,
+            # Add other strategies here if they implement process_network_data
+        }
+
+        for network in data.get("networks", []):
+            if not isinstance(network, MerakiNetwork) or not network.id:
+                continue
+
+            network_id = str(network.id)
+            product_types = network.product_types or []
+
+            for product_type in product_types:
+                if strategy := strategies.get(product_type):
+                    if hasattr(strategy, "process_network_data"):
+                        strategy.process_network_data(
+                            network_id,
+                            data,
+                            current_data or {},
+                            data,
+                        )
+
     async def _fetch_client_data(self, data: dict[str, Any]) -> None:
         """Fetch client data for all networks."""
         networks = data.get("networks", [])
@@ -411,6 +441,9 @@ class DataFetchManager:
 
         # Strategy-based processing for individual devices
         self._process_device_strategies(data, previous_devices_map)
+
+        # Strategy-based processing for networks
+        self._process_network_strategies(data, current_data)
 
         # Parse aggregate network data (VLANs, SSIDs, etc.)
         network_details = parse_network_data(

--- a/custom_components/meraki_ha/core/fetch_strategies/wireless.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/wireless.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from ...core.models.network import MerakiNetwork
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
-from ..parsers.wireless import parse_wireless_data
+from ..parsers.wireless import parse_wireless_data, update_processed_wireless_data
 from .base import BaseFetchStrategy
 
 
@@ -89,31 +89,4 @@ class WirelessFetchStrategy(BaseFetchStrategy):
             clients=detail_data.get("clients"),
         )
 
-        ssids = wireless_data.get("ssids", [])
-        if ssids:
-            if "ssids" not in processed_data:
-                processed_data["ssids"] = []
-
-            # SSID Duplicates Fix & Canonical Data Population
-            existing_ids = {
-                (s.get("networkId"), s.get("number"))
-                for s in cast(list[dict[str, Any]], processed_data["ssids"])
-            }
-
-            for ssid in ssids:
-                ssid_id = (ssid.get("networkId"), ssid.get("number"))
-                if ssid_id not in existing_ids:
-                    cast(list[dict[str, Any]], processed_data["ssids"]).append(ssid)
-                    existing_ids.add(ssid_id)
-
-        wireless_settings = wireless_data.get("wireless_settings", {})
-        if wireless_settings:
-            if "wireless_settings" not in processed_data:
-                processed_data["wireless_settings"] = {}
-            processed_data["wireless_settings"].update(wireless_settings)
-
-        rf_profiles = wireless_data.get("rf_profiles")
-        if isinstance(rf_profiles, dict):
-            if "rf_profiles" not in processed_data:
-                processed_data["rf_profiles"] = {}
-            processed_data["rf_profiles"].update(rf_profiles)
+        update_processed_wireless_data(processed_data, wireless_data)

--- a/custom_components/meraki_ha/core/parsers/wireless.py
+++ b/custom_components/meraki_ha/core/parsers/wireless.py
@@ -4,7 +4,43 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing import cast
+
 from ...core.models.network import MerakiNetwork
+
+
+def update_processed_wireless_data(
+    processed_data: dict[str, Any], new_data: dict[str, Any]
+) -> None:
+    """Update processed data with new wireless data, handling duplicates."""
+    ssids = new_data.get("ssids", [])
+    if ssids:
+        if "ssids" not in processed_data:
+            processed_data["ssids"] = []
+
+        # SSID Duplicates Fix & Canonical Data Population
+        existing_ids = {
+            (s.get("networkId"), s.get("number"))
+            for s in cast(list[dict[str, Any]], processed_data["ssids"])
+        }
+
+        for ssid in ssids:
+            ssid_id = (ssid.get("networkId"), ssid.get("number"))
+            if ssid_id not in existing_ids:
+                cast(list[dict[str, Any]], processed_data["ssids"]).append(ssid)
+                existing_ids.add(ssid_id)
+
+    wireless_settings = new_data.get("wireless_settings", {})
+    if wireless_settings:
+        if "wireless_settings" not in processed_data:
+            processed_data["wireless_settings"] = {}
+        processed_data["wireless_settings"].update(wireless_settings)
+
+    rf_profiles = new_data.get("rf_profiles")
+    if isinstance(rf_profiles, dict):
+        if "rf_profiles" not in processed_data:
+            processed_data["rf_profiles"] = {}
+        processed_data["rf_profiles"].update(rf_profiles)
 
 
 def parse_wireless_data(

--- a/tests/core/coordinator_helpers/test_data_fetcher.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher.py
@@ -42,12 +42,10 @@ async def test_get_all_data_includes_switch_ports(data_fetch_manager, mock_clien
     )
 
     # Simulate detailed switch ports response
-    async def coro():
-        return [{"portId": "1", "status": "Connected"}]
+    async def mock_build_strategy_tasks(data):
+        data["switch_ports_Q123"] = [{"portId": "1", "status": "Connected"}]
 
-    data_fetch_manager._build_detail_tasks = MagicMock(
-        return_value={"switch_ports_Q123": coro()}
-    )
+    data_fetch_manager._build_strategy_tasks = AsyncMock(side_effect=mock_build_strategy_tasks)
 
     with (
         patch(

--- a/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
 from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
     DataFetchManager,
 )
@@ -84,7 +86,7 @@ async def test_get_all_data_detailed_timeout(data_fetch_manager, mock_client):
         with patch(
             "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error"
         ) as mock_log_error:
-            with pytest.raises(asyncio.TimeoutError):
+            with pytest.raises(UpdateFailed):
                 await data_fetch_manager.get_all_data()
             # It might be called for detailed data first
             mock_log_error.assert_any_call(
@@ -147,9 +149,10 @@ async def test_get_all_data_client_timeout(data_fetch_manager, mock_client):
             with patch(
                 "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher._LOGGER.error"
             ) as mock_log_error:
-                with pytest.raises(asyncio.TimeoutError):
-                    await data_fetch_manager.get_all_data()
+                # Client timeout is suppressed, so no exception raised
+                await data_fetch_manager.get_all_data()
 
+                # Verify error was logged - message changed slightly in implementation
                 mock_log_error.assert_called_with(
-                    "Timeout during %s. Potential semaphore deadlock.", "Client data"
+                    "Timeout during client data fetch"
                 )

--- a/tests/core/coordinator_helpers/test_update_processor.py
+++ b/tests/core/coordinator_helpers/test_update_processor.py
@@ -34,8 +34,6 @@ def mock_config():
 def update_processor(mock_hass, mock_config_entry, mock_polling_manager, mock_config):
     """Fixture for UpdateProcessor."""
     processor = UpdateProcessor(mock_hass, mock_config_entry, mock_polling_manager, mock_config)
-    # Mock the internal data_processor to isolate UpdateProcessor logic
-    processor.data_processor = AsyncMock()
     return processor
 
 @pytest.mark.asyncio
@@ -50,8 +48,8 @@ async def test_process_success_orchestration(update_processor):
         "ssids_by_network_and_number": {"s": 3}
     }
 
-    # Setup the mock DataProcessor to return our sample data
-    update_processor.data_processor.async_process = AsyncMock(return_value=processed_return)
+    # Setup the mock async_process to return our sample data
+    update_processor.async_process = AsyncMock(return_value=processed_return)
 
     with patch.object(update_processor, "_handle_interval_recovery", return_value=True) as mock_handle:
         result = await update_processor.process_success(data, current_data)
@@ -59,8 +57,8 @@ async def test_process_success_orchestration(update_processor):
         # Verify orchestrator called its recovery helper
         mock_handle.assert_called_once()
         
-        # Verify orchestration delegated to DataProcessor correctly
-        update_processor.data_processor.async_process.assert_awaited_once_with(data, current_data)
+        # Verify orchestration delegated to async_process correctly
+        update_processor.async_process.assert_awaited_once_with(data, current_data)
 
         # Verify the final unpacked result matches expectations
         assert result == ({"d": 1}, {"n": 2}, {"s": 3}, True)

--- a/tests/core/test_data_fetch_manager_features.py
+++ b/tests/core/test_data_fetch_manager_features.py
@@ -63,9 +63,10 @@ async def test_appliance_features_fetching_behavior() -> None:
         enable_traffic_shaping=False,
     )
     # We patch asyncio.create_task just in case, though we don't use it directly here
+    tasks_disabled: dict[str, Any] = {}
     with patch("asyncio.create_task", side_effect=lambda x: x):
-        tasks_disabled = manager_disabled._build_detail_tasks(
-            {"networks": [mock_network]}
+        manager_disabled._collect_network_tasks(
+            {"networks": [mock_network]}, tasks_disabled
         )
 
     assert "l3_firewall_rules_net1" not in tasks_disabled
@@ -81,9 +82,10 @@ async def test_appliance_features_fetching_behavior() -> None:
         enable_firewall_rules=True,
         enable_traffic_shaping=True,
     )
+    tasks_enabled: dict[str, Any] = {}
     with patch("asyncio.create_task", side_effect=lambda x: x):
-        tasks_enabled = manager_enabled._build_detail_tasks(
-            {"networks": [mock_network]}
+        manager_enabled._collect_network_tasks(
+            {"networks": [mock_network]}, tasks_enabled
         )
 
     assert "l3_firewall_rules_net1" in tasks_enabled

--- a/tests/core/test_entity_naming.py
+++ b/tests/core/test_entity_naming.py
@@ -7,7 +7,7 @@ import pytest
 from custom_components.meraki_ha.core.entities.meraki_vlan_entity import (
     MerakiVLANEntity,
 )
-from custom_components.meraki_ha.types import MerakiNetwork
+from custom_components.meraki_ha.core.models.network import MerakiNetwork, MerakiVlan
 
 
 @pytest.fixture
@@ -33,13 +33,17 @@ def test_vlan_naming(mock_coordinator):
     )
     mock_coordinator.get_network.return_value = network
 
-    vlan = {
-        "id": 10,
-        "name": "VoIP",
-        "applianceIp": "192.168.10.1",
-        "subnet": "192.168.10.0/24",
-        "ipv6": None,
-    }
+    vlan = MerakiVlan(
+        id="10",
+        name="VoIP",
+        appliance_ip="192.168.10.1",
+        subnet="192.168.10.0/24",
+        ipv6=None,
+        dhcp_handling="Run a DHCP server",
+        dns_nameservers="upstream_dns",
+        dhcp_lease_time="1 day",
+        dhcp_boot_options_enabled=False,
+    )
 
     entity = MerakiVLANEntity(mock_coordinator, config_entry, "N_12345", vlan)
 

--- a/tests/core/test_wireless_ssids.py
+++ b/tests/core/test_wireless_ssids.py
@@ -1,0 +1,67 @@
+"""Tests for Wireless SSIDs fetching and processing."""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import DataFetchManager
+from custom_components.meraki_ha.core.models.network import MerakiNetwork
+
+@pytest.fixture
+def mock_client():
+    """Mock Meraki API client."""
+    client = MagicMock()
+    client._disabled_features = set()
+    client.has_dashboard = True
+
+    # Mock run_with_semaphore to be a simple pass-through for tests
+    async def run_with_sem(coro):
+        return await coro
+    client.run_with_semaphore = run_with_sem
+
+    return client
+
+@pytest.fixture
+def data_fetch_manager(mock_client):
+    """Fixture for DataFetchManager."""
+    return DataFetchManager(mock_client)
+
+@pytest.mark.asyncio
+async def test_wireless_ssids_processing(data_fetch_manager, mock_client):
+    """Test that wireless SSIDs are correctly processed and added to data."""
+
+    # Mock initial data return
+    data_fetch_manager._async_fetch_initial_data = AsyncMock(return_value={
+        "networks": [{"id": "N_123", "name": "Test Network", "productTypes": ["wireless"]}],
+        "devices": [],
+    })
+
+    # Mock client fetcher to avoid errors
+    data_fetch_manager.client_fetcher.async_fetch_network_clients = AsyncMock(return_value=[])
+    data_fetch_manager.client_fetcher.derive_device_clients = MagicMock(return_value={})
+
+    # Mock the strategy to add a task that returns SSIDs
+    # This simulates what build_network_tasks does (adding a task to the dict)
+    async def mock_ssid_task():
+        return [{"number": 1, "name": "Test SSID", "enabled": True}]
+
+    # We need to ensure that when _build_strategy_tasks runs, it populates 'ssids_N_123'
+    # The real implementation calls strategy.build_network_tasks.
+    # We can mock strategy.build_network_tasks to add our mock task.
+
+    data_fetch_manager.wireless_strategy.build_network_tasks = MagicMock(
+        side_effect=lambda nid, pts, tks: tks.update({f"ssids_{nid}": mock_ssid_task()})
+    )
+
+    # Act
+    data = await data_fetch_manager.get_all_data()
+
+    # Assert
+    assert "ssids" in data
+    ssids = data["ssids"]
+    assert len(ssids) == 1
+    assert ssids[0]["name"] == "Test SSID"
+    assert ssids[0]["networkId"] == "N_123"
+    assert ssids[0]["number"] == 1
+
+    assert "wireless_settings" in data
+    assert "N_123" in data["wireless_settings"]
+    assert len(data["wireless_settings"]["N_123"]) == 1

--- a/tests/test_coordinator_entity_priority.py
+++ b/tests/test_coordinator_entity_priority.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.meraki_ha.core.data_processor import update_device_registry_info
+from custom_components.meraki_ha.core.coordinator_helpers.update_processor import (
+    update_device_registry_info,
+)
 
 
 async def test_update_device_registry_info_picks_camera(hass):
@@ -57,15 +59,15 @@ async def test_update_device_registry_info_picks_camera(hass):
 
     with (
         patch(
-            "custom_components.meraki_ha.core.data_processor.dr.async_get",
+            "custom_components.meraki_ha.core.coordinator_helpers.update_processor.dr.async_get",
             return_value=mock_dr,
         ),
         patch(
-            "custom_components.meraki_ha.core.data_processor.er.async_get",
+            "custom_components.meraki_ha.core.coordinator_helpers.update_processor.er.async_get",
             return_value=mock_er,
         ),
         patch(
-            "custom_components.meraki_ha.core.data_processor.er.async_entries_for_device",
+            "custom_components.meraki_ha.core.coordinator_helpers.update_processor.er.async_entries_for_device",
             return_value=mock_entries,
         ),
     ):


### PR DESCRIPTION
This PR fixes a regression where wireless SSIDs were not being processed after recent refactoring of `DataFetchManager`.
    
    Changes:
    - Added `_process_network_strategies` to `DataFetchManager` to invoke `process_network_data` on strategies.
    - Updated `WirelessFetchStrategy` to use a new helper `update_processed_wireless_data` in `core/parsers/wireless.py`, reducing complexity.
    - Fixed multiple broken unit tests related to recent refactors.
    - Added new test `tests/core/test_wireless_ssids.py` to verify SSID fetching.

---
*PR created automatically by Jules for task [12442391379753283800](https://jules.google.com/task/12442391379753283800) started by @brewmarsh*