### PR TITLE
fix: resolve unawaited coroutine warnings in tests

### DIFF
--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -1,6 +1,6 @@
 """Test ApplianceFetchStrategy."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,7 +52,14 @@ def test_build_network_tasks_skips_disabled(strategy, disabled_features):
     disabled_features.add(f"vlans_{network_id}")
 
     tasks = {}
-    strategy.build_network_tasks(network_id, tasks)
+
+    # Patch async methods to avoid unawaited coroutine warnings
+    with patch.object(
+        strategy, "_async_get_appliance_ports", return_value=MagicMock()
+    ), patch.object(
+        strategy, "_get_uplink_performance", return_value=MagicMock()
+    ):
+        strategy.build_network_tasks(network_id, tasks)
 
     assert f"traffic_{network_id}" not in tasks
     assert f"vlans_{network_id}" not in tasks
@@ -63,7 +70,14 @@ def test_build_network_tasks_includes_enabled(strategy, disabled_features):
     network_id = "net1"
 
     tasks = {}
-    strategy.build_network_tasks(network_id, tasks)
+
+    # Patch async methods to avoid unawaited coroutine warnings
+    with patch.object(
+        strategy, "_async_get_appliance_ports", return_value=MagicMock()
+    ), patch.object(
+        strategy, "_get_uplink_performance", return_value=MagicMock()
+    ):
+        strategy.build_network_tasks(network_id, tasks)
 
     assert f"traffic_{network_id}" in tasks
     assert f"vlans_{network_id}" in tasks
@@ -85,7 +99,15 @@ def test_build_network_tasks_respects_feature_flags(mock_client, disabled_featur
         enable_traffic_shaping=True,
     )
     tasks = {}
-    strategy_enabled.build_network_tasks(network_id, tasks)
+
+    # Patch async methods to avoid unawaited coroutine warnings
+    with patch.object(
+        strategy_enabled, "_async_get_appliance_ports", return_value=MagicMock()
+    ), patch.object(
+        strategy_enabled, "_get_uplink_performance", return_value=MagicMock()
+    ):
+        strategy_enabled.build_network_tasks(network_id, tasks)
+
     assert f"vpn_status_{network_id}" in tasks
     assert f"l3_firewall_rules_{network_id}" in tasks
     assert f"traffic_shaping_{network_id}" in tasks
@@ -99,7 +121,15 @@ def test_build_network_tasks_respects_feature_flags(mock_client, disabled_featur
         enable_traffic_shaping=False,
     )
     tasks = {}
-    strategy_disabled.build_network_tasks(network_id, tasks)
+
+    # Patch async methods to avoid unawaited coroutine warnings
+    with patch.object(
+        strategy_disabled, "_async_get_appliance_ports", return_value=MagicMock()
+    ), patch.object(
+        strategy_disabled, "_get_uplink_performance", return_value=MagicMock()
+    ):
+        strategy_disabled.build_network_tasks(network_id, tasks)
+
     assert f"vpn_status_{network_id}" not in tasks
     assert f"l3_firewall_rules_{network_id}" not in tasks
     assert f"traffic_shaping_{network_id}" not in tasks

--- a/tests/test_camera_optimization.py
+++ b/tests/test_camera_optimization.py
@@ -1,5 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock
-
+import asyncio
 import pytest
 
 from custom_components.meraki_ha.core.coordinator_helpers.data_fetcher import (
@@ -30,6 +30,11 @@ async def test_camera_modulo_fetch():
     )
     assert f"sense_settings_{device.serial}" in tasks
 
+    # Cleanup Poll 1 tasks
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
+
     # Poll 2
     strategy.increment_poll_count()
     assert strategy.should_fetch_sense is False
@@ -53,6 +58,11 @@ async def test_camera_modulo_fetch():
         device, tasks, capabilities=["camera_stream", "camera_analytics"]
     )
     assert f"sense_settings_{device.serial}" in tasks
+
+    # Cleanup Poll 6 tasks
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
 
 
 @pytest.mark.asyncio
@@ -97,6 +107,11 @@ async def test_dfm_batch_analytics_modulo():
 
     # Analytics should be present in poll 1 (1 % 5 == 1? No (1-1)%5 == 0)
     assert f"camera_analytics_{devices[0].serial}" in tasks
+
+    # Cleanup Poll 1 tasks
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            await task
 
     # Poll 2
     dfm.camera_strategy.increment_poll_count()


### PR DESCRIPTION
This PR resolves `RuntimeWarning: coroutine '...' was never awaited` in the test suite.

Changes:
- In `tests/core/fetch_strategies/test_appliance_strategy.py`, `_async_get_appliance_ports` and `_get_uplink_performance` are now patched to return `MagicMock` objects. This is necessary because the tests are synchronous and verify task scheduling without executing the tasks, thus avoiding the creation of unawaited coroutines.
- In `tests/test_camera_optimization.py`, explicit cleanup loops were added to `test_dfm_batch_analytics_modulo` and `test_camera_modulo_fetch` (defensive) to ensure any coroutines created by `AsyncMock` are properly closed or awaited.

These fixes ensure a clean test output and prevent resource leakage warnings during CI.

---
*PR created automatically by Jules for task [4963697701019564060](https://jules.google.com/task/4963697701019564060) started by @brewmarsh*