### PR TITLE
Refactor network parser and SSID status calculator for ACL reduction

### DIFF
--- a/custom_components/meraki_ha/core/parsers/network.py
+++ b/custom_components/meraki_ha/core/parsers/network.py
@@ -40,56 +40,18 @@ def parse_network_data(
     for network in networks:
         if not network.id:
             continue
-        network_id = str(network.id)
 
-        _parse_traffic(
-            network_id,
+        _process_single_network(
+            str(network.id),
             detail_data,
             previous_data,
             disabled_features,
             appliance_traffic,
-        )
-
-        _parse_vlans(
-            network_id,
-            detail_data,
-            previous_data,
-            disabled_features,
             vlan_by_network,
-        )
-
-        _parse_firewall_rules(
-            network_id,
-            detail_data,
-            previous_data,
             l3_firewall_rules_by_network,
-        )
-
-        _parse_traffic_shaping(
-            network_id,
-            detail_data,
-            previous_data,
             traffic_shaping_by_network,
-        )
-
-        _parse_vpn_status(
-            network_id,
-            detail_data,
-            previous_data,
             vpn_status_by_network,
-        )
-
-        _parse_rf_profiles(
-            network_id,
-            detail_data,
-            previous_data,
             rf_profiles_by_network,
-        )
-
-        _parse_content_filtering(
-            network_id,
-            detail_data,
-            previous_data,
             content_filtering_by_network,
         )
 
@@ -102,6 +64,72 @@ def parse_network_data(
         "rf_profiles": rf_profiles_by_network,
         "content_filtering": content_filtering_by_network,
     }
+
+
+def _process_single_network(
+    network_id: str,
+    detail_data: dict[str, Any],
+    previous_data: dict[str, Any],
+    disabled_features: set[str],
+    appliance_traffic: dict[str, Any],
+    vlan_by_network: dict[str, list[MerakiVlan]],
+    l3_firewall_rules_by_network: dict[str, list[MerakiFirewallRule]],
+    traffic_shaping_by_network: dict[str, MerakiTrafficShaping],
+    vpn_status_by_network: dict[str, MerakiVpn],
+    rf_profiles_by_network: dict[str, Any],
+    content_filtering_by_network: dict[str, Any],
+) -> None:
+    """Process a single network's data."""
+    _parse_traffic(
+        network_id,
+        detail_data,
+        previous_data,
+        disabled_features,
+        appliance_traffic,
+    )
+
+    _parse_vlans(
+        network_id,
+        detail_data,
+        previous_data,
+        disabled_features,
+        vlan_by_network,
+    )
+
+    _parse_firewall_rules(
+        network_id,
+        detail_data,
+        previous_data,
+        l3_firewall_rules_by_network,
+    )
+
+    _parse_traffic_shaping(
+        network_id,
+        detail_data,
+        previous_data,
+        traffic_shaping_by_network,
+    )
+
+    _parse_vpn_status(
+        network_id,
+        detail_data,
+        previous_data,
+        vpn_status_by_network,
+    )
+
+    _parse_rf_profiles(
+        network_id,
+        detail_data,
+        previous_data,
+        rf_profiles_by_network,
+    )
+
+    _parse_content_filtering(
+        network_id,
+        detail_data,
+        previous_data,
+        content_filtering_by_network,
+    )
 
 
 def _parse_traffic(

--- a/custom_components/meraki_ha/helpers/ssid_status_calculator.py
+++ b/custom_components/meraki_ha/helpers/ssid_status_calculator.py
@@ -22,8 +22,9 @@ class SsidStatusCalculator:
     of relevant Meraki wireless access points (APs).
     """
 
-    @staticmethod
+    @classmethod
     def calculate_ssid_status(
+        cls,
         ssids: list[dict[str, Any]] | None,
         # Device list; tags are expected within each device dict.
         devices: list[dict[str, Any]] | None,
@@ -64,7 +65,8 @@ class SsidStatusCalculator:
         if devices is None:
             _LOGGER.warning("Device data is None; SSID statuses cannot be determined.")
             for ssid in ssids:
-                ssid["status"] = "unknown_device_data_missing"
+                if isinstance(ssid, dict):
+                    ssid["status"] = "unknown_device_data_missing"
             return ssids
 
         updated_ssids_list: list[dict[str, Any]] = []
@@ -73,61 +75,94 @@ class SsidStatusCalculator:
                 _LOGGER.warning("Skipping non-dictionary SSID item: %s", ssid_info)
                 continue
 
-            is_enabled = ssid_info.get("enabled", False)
-            ssid_configured_tags: list[str] = ssid_info.get("tags", [])
-            network_id = ssid_info.get("networkId")
-
-            matching_devices_online_count = 0
-            matching_devices_total_count = 0
-
-            for device_info in devices:
-                if not isinstance(device_info, dict):
-                    _LOGGER.warning(
-                        "Skipping non-dictionary device item: %s", device_info
-                    )
-                    continue
-
-                device_model: str | None = device_info.get("model")
-                if device_model and device_model.upper().startswith("MR"):
-                    device_status_raw = device_info.get("status")
-                    device_status: str = "unknown"
-                    if isinstance(device_status_raw, str):
-                        device_status = device_status_raw.lower()
-                    current_device_tags: list[str] = device_info.get("tags", [])
-
-                    if SsidStatusCalculator._does_device_match_ssid_tags(
-                        ssid_configured_tags,
-                        current_device_tags,
-                    ):
-                        matching_devices_total_count += 1
-                        if device_status == "online":
-                            matching_devices_online_count += 1
-
-            ssid_info["matching_devices_online"] = matching_devices_online_count
-            ssid_info["matching_devices_total"] = matching_devices_total_count
-
-            if not is_enabled:
-                ssid_info["status"] = "disabled"
-            elif not network_id:
-                _LOGGER.warning(
-                    "SSID '%s' is missing networkId; setting status to 'unknown'.",
-                    ssid_info.get("name", "Unknown SSID"),
-                )
-                ssid_info["status"] = "unknown"
-            elif matching_devices_total_count == 0:
-                ssid_info["status"] = "no_matching_devices"
-            elif matching_devices_online_count == matching_devices_total_count:
-                ssid_info["status"] = "online"
-            elif matching_devices_online_count > 0:
-                ssid_info["status"] = "partially_online"
-            else:
-                ssid_info["status"] = "offline"
-
-            # Per-SSID status log removed
+            cls._process_single_ssid(ssid_info, devices)
             updated_ssids_list.append(ssid_info)
 
-        # Overall completion log removed
         return updated_ssids_list
+
+    @classmethod
+    def _process_single_ssid(
+        cls, ssid_info: dict[str, Any], devices: list[dict[str, Any]]
+    ) -> None:
+        """Process status calculation for a single SSID."""
+        ssid_configured_tags: list[str] = ssid_info.get("tags", [])
+
+        online_count, total_count = cls._count_matching_devices(
+            ssid_configured_tags, devices
+        )
+
+        ssid_info["matching_devices_online"] = online_count
+        ssid_info["matching_devices_total"] = total_count
+        ssid_info["status"] = cls._determine_ssid_status(
+            ssid_info, online_count, total_count
+        )
+
+    @classmethod
+    def _count_matching_devices(
+        cls, ssid_tags: list[str], devices: list[dict[str, Any]]
+    ) -> tuple[int, int]:
+        """Count total and online devices matching the SSID tags."""
+        online_count = 0
+        total_count = 0
+
+        for device_info in devices:
+            if not isinstance(device_info, dict):
+                _LOGGER.warning(
+                    "Skipping non-dictionary device item: %s", device_info
+                )
+                continue
+
+            if not cls._is_valid_ap(device_info):
+                continue
+
+            # Check if device matches SSID tags
+            device_tags: list[str] = device_info.get("tags", [])
+            if cls._does_device_match_ssid_tags(ssid_tags, device_tags):
+                total_count += 1
+                if cls._is_device_online(device_info):
+                    online_count += 1
+
+        return online_count, total_count
+
+    @staticmethod
+    def _is_valid_ap(device_info: dict[str, Any]) -> bool:
+        """Check if the device is a valid wireless access point."""
+        device_model: str | None = device_info.get("model")
+        return bool(device_model and device_model.upper().startswith("MR"))
+
+    @staticmethod
+    def _is_device_online(device_info: dict[str, Any]) -> bool:
+        """Check if the device status is online."""
+        device_status_raw = device_info.get("status")
+        if isinstance(device_status_raw, str):
+            return device_status_raw.lower() == "online"
+        return False
+
+    @staticmethod
+    def _determine_ssid_status(
+        ssid_info: dict[str, Any], online_count: int, total_count: int
+    ) -> str:
+        """Determine the final status string for the SSID."""
+        if not ssid_info.get("enabled", False):
+            return "disabled"
+
+        if not ssid_info.get("networkId"):
+            _LOGGER.warning(
+                "SSID '%s' is missing networkId; setting status to 'unknown'.",
+                ssid_info.get("name", "Unknown SSID"),
+            )
+            return "unknown"
+
+        if total_count == 0:
+            return "no_matching_devices"
+
+        if online_count == total_count:
+            return "online"
+
+        if online_count > 0:
+            return "partially_online"
+
+        return "offline"
 
     @staticmethod
     def _does_device_match_ssid_tags(


### PR DESCRIPTION
- Refactored `parse_network_data` in `custom_components/meraki_ha/core/parsers/network.py` by extracting loop body into `_process_single_network` to reduce cyclomatic complexity.
- Refactored `SsidStatusCalculator.calculate_ssid_status` in `custom_components/meraki_ha/helpers/ssid_status_calculator.py` by extracting logic into `_process_single_ssid` and `_count_matching_devices` helper methods.
- Verified type safety in `sensor/network/ssid_details.py`, `sensor/device/radio_settings.py`, `sensor/network/vlans_list.py`, and `switch/adult_content_filtering.py` using `mypy`.
- Verified changes with existing unit tests (`tests/core/parsers/test_network_parser.py` and `tests/helpers/test_ssid_status_calculator*.py`).
- Addressed ACL violations reported in `no_changes_report.md`.

---
*PR created automatically by Jules for task [5495294354442279663](https://jules.google.com/task/5495294354442279663) started by @brewmarsh*