### PR TITLE
Fix duplicate entity generation in switch platform

### DIFF
--- a/custom_components/meraki_ha/switch/__init__.py
+++ b/custom_components/meraki_ha/switch/__init__.py
@@ -40,12 +40,27 @@ async def async_setup_entry(
         for entity in discovery_service.all_entities
         if isinstance(entity, SwitchEntity)
     ]
+
+    seen_ids = set()
+    unique_discovery_entities = []
     if discovery_entities:
-        async_add_entities(discovery_entities)
+        for entity in discovery_entities:
+            if entity.unique_id:
+                if entity.unique_id not in seen_ids:
+                    seen_ids.add(entity.unique_id)
+                    unique_discovery_entities.append(entity)
+            else:
+                unique_discovery_entities.append(entity)
+        async_add_entities(unique_discovery_entities)
 
     # Add other switches from setup helpers
     async_setup_switches(
-        hass, config_entry, coordinator, meraki_client, async_add_entities
+        hass,
+        config_entry,
+        coordinator,
+        meraki_client,
+        async_add_entities,
+        added_entities=seen_ids,
     )
 
     return True

--- a/custom_components/meraki_ha/switch/builders/mt40.py
+++ b/custom_components/meraki_ha/switch/builders/mt40.py
@@ -62,7 +62,7 @@ def _create_mt40_outlet_switch(
         return None
 
     serial = device_info.serial
-    unique_id = f"{serial}_{device_info.network_id}_outlet"
+    unique_id = f"meraki_device_{serial}_outlet"
     if unique_id in added_entities:
         return None
 

--- a/custom_components/meraki_ha/switch/builders/ssid.py
+++ b/custom_components/meraki_ha/switch/builders/ssid.py
@@ -63,7 +63,7 @@ def _build_ssid_pair(
 
     # Enabled Switch
     unique_id = (
-        f"network_{ssid['networkId']}_{ssid['networkId']}_ssid_"
+        f"meraki_network_{ssid['networkId']}_ssid_"
         f"{ssid_number}_enabled"
     )
     if unique_id not in added_entities:
@@ -80,7 +80,7 @@ def _build_ssid_pair(
 
     # Broadcast Switch
     unique_id = (
-        f"network_{ssid['networkId']}_{ssid['networkId']}_ssid_"
+        f"meraki_network_{ssid['networkId']}_ssid_"
         f"{ssid_number}_broadcast"
     )
     if unique_id not in added_entities:

--- a/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
@@ -101,7 +101,7 @@ class MerakiSSIDBaseSwitch(MerakiEntity, SwitchEntity):
         we ensure that the registry stays unique for different switch types.
         """
         return (
-            f"network_{self._network_id}_{self._network_id}_ssid_"
+            f"meraki_network_{self._network_id}_ssid_"
             f"{self._ssid_number}_{self._switch_type}"
         )
 

--- a/custom_components/meraki_ha/switch/mt40_power_outlet.py
+++ b/custom_components/meraki_ha/switch/mt40_power_outlet.py
@@ -28,6 +28,11 @@ class MerakiMt40PowerOutlet(
     _attr_has_entity_name = True
     coordinator: MerakiDataUpdateCoordinator
 
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return f"meraki_device_{self._device_serial}_outlet"
+
     def __init__(
         self,
         coordinator: MerakiDataUpdateCoordinator,
@@ -52,9 +57,6 @@ class MerakiMt40PowerOutlet(
         self._network_id = device_info.network_id
         self._config_entry = config_entry
         self._meraki_client = meraki_client
-        self._attr_unique_id = (
-            f"{self._device_info.serial}_{self._device_info.network_id}_outlet"
-        )
         self._attr_name = "Outlet"
         self._attr_is_on: bool | None = None
 

--- a/custom_components/meraki_ha/switch/setup_helpers.py
+++ b/custom_components/meraki_ha/switch/setup_helpers.py
@@ -28,9 +28,11 @@ def async_setup_switches(
     coordinator: MerakiDataUpdateCoordinator,
     meraki_client: "MerakiAPIClient",
     async_add_entities: AddEntitiesCallback,
+    added_entities: set[str] | None = None,
 ) -> None:
     """Set up all switch entities from the central coordinator."""
-    added_entities: set[str] = set()
+    if added_entities is None:
+        added_entities = set()
 
     if not coordinator.data:
         _LOGGER.warning("Coordinator has no data; skipping switch setup.")

--- a/tests/switch/test_mt40_power_outlet.py
+++ b/tests/switch/test_mt40_power_outlet.py
@@ -59,11 +59,8 @@ def mock_coordinator_with_mt40_data(
 def mock_meraki_client() -> MagicMock:
     """Fixture for a mocked MerakiAPIClient."""
     # Using spec for MagicMock helps ensure the mock matches the API client's interface
-<<<<<<< fix/resolve-unique-id-collisions-9042854325858757258
-=======
     # However, since sensor is an instance attribute not present in the class definition,
     # spec=MerakiAPIClient prevents access to it. We use MagicMock() without spec.
->>>>>>> beta
     client = MagicMock()
     client.sensor.create_device_sensor_command = AsyncMock()
     return client
@@ -95,7 +92,7 @@ def test_mt40_switch_state(
     """Test the initial state and update of the MT40 power outlet switch."""
     switch = mt40_power_outlet_switch
 
-    assert switch.unique_id == "mt40-1_net-123_outlet"
+    assert switch.unique_id == "meraki_device_mt40-1_outlet"
     assert switch.name == "Outlet"
     # Initial state might be None depending on initialization, but we check update
     # by simulating a coordinator update.


### PR DESCRIPTION
This change addresses a critical bug where the Meraki switch platform was generating duplicate entities with identical unique IDs. 

Key improvements:
1. **Deduplication Safeguard:** Modified `async_setup_entry` in `switch/__init__.py` to filter entities from the discovery service and pass the set of seen IDs to the `async_setup_switches` helper.
2. **Setup Helper Update:** Updated `async_setup_switches` and its builders to accept and respect an optional `added_entities` set.
3. **SSID ID Fix:** Corrected the SSID `unique_id` property and builder logic to use a clean `meraki_network_{network_id}_ssid_{ssid_number}_{type}` format, removing the previous double network ID bug.
4. **MT40 ID Fix:** Updated `MerakiMt40PowerOutlet` and its builder to use a robust `meraki_device_{serial}_outlet` format and ensured the `unique_id` property is properly overridden and consistent.
5. **Test Updates:** Synchronized `tests/switch/test_mt40_power_outlet.py` and other relevant tests with the new ID formats and cleaned up existing git conflict markers.

Fixes #2029

---
*PR created automatically by Jules for task [12741248024063466241](https://jules.google.com/task/12741248024063466241) started by @brewmarsh*