### PR TITLE
fix: resolve MyPy errors and regressions in network, sensor, and uplink modules

### DIFF
--- a/custom_components/meraki_ha/core/parsers/network.py
+++ b/custom_components/meraki_ha/core/parsers/network.py
@@ -33,52 +33,65 @@ def parse_network_data(
 
     return {
         "appliance_traffic": {
-            nid: data
+            nid: traffic_data
             for nid in network_ids
             if (
-                data := _extract_appliance_traffic(
+                traffic_data := _extract_appliance_traffic(
                     nid, detail_data, previous_data, disabled_features
                 )
             )
             is not None
         },
         "vlans": {
-            nid: data
+            nid: vlan_data
             for nid in network_ids
             if (
-                data := _extract_vlans(
+                vlan_data := _extract_vlans(
                     nid, detail_data, previous_data, disabled_features
                 )
             )
             is not None
         },
         "l3_firewall_rules": {
-            nid: data
+            nid: firewall_data
             for nid in network_ids
-            if (data := _extract_firewall_rules(nid, detail_data, previous_data))
+            if (
+                firewall_data := _extract_firewall_rules(
+                    nid, detail_data, previous_data
+                )
+            )
             is not None
         },
         "traffic_shaping": {
-            nid: data
+            nid: shaping_data
             for nid in network_ids
-            if (data := _extract_traffic_shaping(nid, detail_data, previous_data))
+            if (
+                shaping_data := _extract_traffic_shaping(
+                    nid, detail_data, previous_data
+                )
+            )
             is not None
         },
         "vpn_status": {
-            nid: data
+            nid: vpn_data
             for nid in network_ids
-            if (data := _extract_vpn_status(nid, detail_data, previous_data)) is not None
+            if (vpn_data := _extract_vpn_status(nid, detail_data, previous_data))
+            is not None
         },
         "rf_profiles": {
-            nid: data
+            nid: rf_data
             for nid in network_ids
-            if (data := _extract_rf_profiles(nid, detail_data, previous_data))
+            if (rf_data := _extract_rf_profiles(nid, detail_data, previous_data))
             is not None
         },
         "content_filtering": {
-            nid: data
+            nid: content_data
             for nid in network_ids
-            if (data := _extract_content_filtering(nid, detail_data, previous_data))
+            if (
+                content_data := _extract_content_filtering(
+                    nid, detail_data, previous_data
+                )
+            )
             is not None
         },
     }

--- a/custom_components/meraki_ha/discovery/providers/uplink.py
+++ b/custom_components/meraki_ha/discovery/providers/uplink.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -114,20 +114,23 @@ class UplinkPerformanceProvider:
                 continue
 
             # Table-Driven approach to minimize ACL and complexity
+            # attr is the metric key expected by MerakiUplinkPerformanceSensor (Literal['latency', 'jitter', 'lossPercent'])
             perf_metrics = [
-                ("latencyMs", "latency", UnitOfTime.MILLISECONDS, SensorDeviceClass.DURATION, "mdi:timer-outline"),
+                ("latency", "latency", UnitOfTime.MILLISECONDS, SensorDeviceClass.DURATION, "mdi:timer-outline"),
                 ("lossPercent", "packet_loss", PERCENTAGE, None, "mdi:packet-loss"),
                 ("jitter", "jitter", UnitOfTime.MILLISECONDS, SensorDeviceClass.DURATION, "mdi:pulse"),
             ]
 
             for attr, key_suffix, unit, dev_class, icon in perf_metrics:
+                # Cast attr to the required Literal type for MyPy compliance
+                metric_type = cast(Literal["latency", "jitter", "lossPercent"], attr)
                 entities.append(
                     MerakiUplinkPerformanceSensor(
                         coordinator,
                         device,
                         config_entry,
                         interface,
-                        attr,
+                        metric_type,
                         SensorEntityDescription(
                             key=f"{interface}_{key_suffix}",
                             name=f"{interface.capitalize()} {key_suffix.replace('_', ' ')}",

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -55,8 +55,14 @@ class MerakiMtSensor(MerakiSensor, RestoreSensor):
         """Handle entity which provides state restoration."""
         await super().async_added_to_hass()
         if (last_sensor_data := await self.async_get_last_sensor_data()) is not None:
-            if last_sensor_data.native_value is not UNDEFINED:
-                self._attr_native_value = last_sensor_data.native_value
+            value = last_sensor_data.native_value
+            if value is not UNDEFINED:
+                # Type check and conversion for MyPy compatibility
+                if isinstance(value, (str, float, bool)):
+                    self._attr_native_value = value
+                elif isinstance(value, (int, float)):  # Handle int->float conversion
+                    self._attr_native_value = float(value)
+                # Ignore other types (e.g. datetime) that don't match our state type
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
Resolved MyPy errors and functional regressions in `network.py`, `meraki_mt_base.py`, and `uplink.py` by improving variable scoping, adding strict type checks for sensor state restoration, and correcting metric keys for uplink performance sensors.

---
*PR created automatically by Jules for task [4739303533899852123](https://jules.google.com/task/4739303533899852123) started by @brewmarsh*