### PR TITLE
Fix sensor state classes for energy sensors

### DIFF
--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -212,7 +212,7 @@ class MerakiSwitchPortEnergySensor(MerakiSwitchPortBaseSensor):
 
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_translation_key = "energy"
 
     def __init__(

--- a/tests/sensor/device/test_meraki_switch_port_sensor.py
+++ b/tests/sensor/device/test_meraki_switch_port_sensor.py
@@ -65,7 +65,7 @@ def test_switch_port_energy_sensor(mock_coordinator_and_device):
     assert sensor.translation_key == "energy"
     assert sensor.device_class == SensorDeviceClass.ENERGY
     assert sensor.native_unit_of_measurement == UnitOfEnergy.WATT_HOUR
-    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    assert sensor.state_class == SensorStateClass.TOTAL_INCREASING
 
     assert sensor.native_value == 240
 


### PR DESCRIPTION
Fixed a strict entity validation error where `MerakiSwitchPortEnergySensor` was using `SensorStateClass.MEASUREMENT` with `SensorDeviceClass.ENERGY`. According to Home Assistant standards, energy sensors must use `TOTAL` or `TOTAL_INCREASING`.

Changes:
- Modified `custom_components/meraki_ha/sensor/device/switch_port.py` to update `_attr_state_class`.
- Updated `tests/sensor/device/test_meraki_switch_port_sensor.py` to reflect the change in the state class.
- Verified that no other sensors in the integration use `SensorDeviceClass.ENERGY` with an incorrect `state_class`.
- Removed accidental environment artifacts from the repository.

Fixes #2047

---
*PR created automatically by Jules for task [256398362906725260](https://jules.google.com/task/256398362906725260) started by @brewmarsh*