### PR TITLE
Fix MT40 duplicate entity and implement strict switch deduplication

### DIFF
--- a/custom_components/meraki_ha/switch/__init__.py
+++ b/custom_components/meraki_ha/switch/__init__.py
@@ -41,27 +41,37 @@ async def async_setup_entry(
         if isinstance(entity, SwitchEntity)
     ]
 
-    seen_ids = set()
-    unique_discovery_entities = []
-    if discovery_entities:
-        for entity in discovery_entities:
+    seen_ids: set[str] = set()
+    entities_to_add: list[SwitchEntity] = []
+
+    def async_add_unique_entities(new_entities: list[SwitchEntity]) -> None:
+        """Filter and add unique entities."""
+        for entity in new_entities:
             if entity.unique_id:
                 if entity.unique_id not in seen_ids:
                     seen_ids.add(entity.unique_id)
-                    unique_discovery_entities.append(entity)
+                    entities_to_add.append(entity)
+                else:
+                    _LOGGER.debug("Ignoring duplicate entity with ID %s", entity.unique_id)
             else:
-                unique_discovery_entities.append(entity)
-        async_add_entities(unique_discovery_entities)
+                entities_to_add.append(entity)
 
-    # Add other switches from setup helpers
+    # Process discovery entities
+    if discovery_entities:
+        async_add_unique_entities(discovery_entities)
+
+    # Add other switches from setup helpers using the same deduplication logic
     async_setup_switches(
         hass,
         config_entry,
         coordinator,
         meraki_client,
-        async_add_entities,
+        async_add_unique_entities,
         added_entities=seen_ids,
     )
+
+    if entities_to_add:
+        async_add_entities(entities_to_add)
 
     return True
 

--- a/custom_components/meraki_ha/switch/builders/mt40.py
+++ b/custom_components/meraki_ha/switch/builders/mt40.py
@@ -62,7 +62,8 @@ def _create_mt40_outlet_switch(
         return None
 
     serial = device_info.serial
-    unique_id = f"meraki_device_{serial}_outlet"
+    network_id = device_info.network_id
+    unique_id = f"{serial}_{network_id}_outlet"
     if unique_id in added_entities:
         return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiodhcpwatcher
 aiodiscover
-aiodns==3.6.1
+aiodns>=4.0.0
 aiofiles>=24.1.0
 aiohttp>=3.8.1
 bandit==1.7.9

--- a/tests/switch/test_mt40_power_outlet.py
+++ b/tests/switch/test_mt40_power_outlet.py
@@ -91,7 +91,7 @@ def test_mt40_switch_state(
     """Test the initial state and update of the MT40 power outlet switch."""
     switch = mt40_power_outlet_switch
 
-    assert switch.unique_id == "meraki_device_mt40-1_outlet"
+    assert switch.unique_id == "mt40-1_net-123_outlet"
     assert switch.name == "Outlet"
     # Initial state might be None depending on initialization, but we check update
     # by simulating a coordinator update.


### PR DESCRIPTION
This PR resolves a critical bug where the Meraki switch platform was generating duplicate MT40 outlet entities during setup. 

Key changes:
1. **Strict Deduplication**: Refactored `custom_components/meraki_ha/switch/__init__.py` to use a `seen_ids` set and a local entity collection list (`entities_to_add`). A nested wrapper `async_add_unique_entities` is now passed to all builders, ensuring no duplicate `unique_id` is registered with Home Assistant during the initial setup loop.
2. **MT40 Unique ID Alignment**: Updated `custom_components/meraki_ha/switch/builders/mt40.py` to use the format `{serial}_{network_id}_outlet`, matching the entity's own `unique_id` property. This ensures the deduplication check in the builder correctly identifies existing entities.
3. **Dependency Alignment**: Updated `requirements.txt` to require `aiodns>=4.0.0`, aligning with the integration's `manifest.json` and preventing potential resolution conflicts.
4. **Test Updates**: Updated the MT40 switch tests to expect the corrected `unique_id` format.

All tests passed, and the fix was verified against the reported "already exists" error pattern.

Fixes #2048

---
*PR created automatically by Jules for task [11990689012873486108](https://jules.google.com/task/11990689012873486108) started by @brewmarsh*