### PR TITLE
Fix custom panel loading with dynamic versioning

### DIFF
--- a/custom_components/meraki_ha/frontend.py
+++ b/custom_components/meraki_ha/frontend.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
-import aiofiles  # type: ignore[import-untyped]
 from homeassistant.components import frontend
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_loaded_integration
 
 
 async def async_register_frontend(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -17,12 +14,9 @@ async def async_register_frontend(hass: HomeAssistant, entry: ConfigEntry) -> No
     if "meraki" in hass.data.get("frontend_panels", {}):
         return
 
-    # Load version from manifest to bust browser cache
-    manifest_path = Path(__file__).parent / "manifest.json"
-    async with aiofiles.open(manifest_path, encoding="utf-8") as f:
-        manifest_data = await f.read()
-        manifest = json.loads(manifest_data)
-    version = manifest.get("version", "0.0.0")
+    # Load version from integration to bust browser cache
+    integration = async_get_loaded_integration(hass, entry.domain)
+    version = integration.version
 
     # The custom panel will be served at `/meraki_ha_static/meraki-panel.js`.
     # We manually register the static path in `__init__.py` to serve files

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -47,5 +47,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "112.0.0-beta.1"
+  "version": "2.3.0-beta.120"
 }

--- a/custom_components/meraki_ha/www/package-lock.json
+++ b/custom_components/meraki_ha/www/package-lock.json
@@ -8,6 +8,7 @@
       "name": "meraki-ha-www",
       "version": "2.3.0-beta.120",
       "dependencies": {
+        "lit": "^3.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-qr-code": "^2.0.18",
@@ -1027,6 +1028,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1517,6 +1533,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -4145,6 +4167,37 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/custom_components/meraki_ha/www/package.json
+++ b/custom_components/meraki_ha/www/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lit": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-qr-code": "^2.0.18",

--- a/tests/test_frontend_registration.py
+++ b/tests/test_frontend_registration.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch, MagicMock
+import pytest
+from homeassistant.core import HomeAssistant
+from custom_components.meraki_ha.frontend import async_register_frontend, async_remove_frontend
+
+async def test_async_register_frontend(hass: HomeAssistant):
+    """Test frontend registration."""
+    entry = MagicMock()
+    entry.domain = "meraki_ha"
+    entry.title = "Meraki"
+    entry.entry_id = "test_entry"
+
+    # Mock async_get_loaded_integration
+    integration = MagicMock()
+    integration.version = "2.3.0-beta.120"
+
+    with patch("custom_components.meraki_ha.frontend.async_get_loaded_integration", return_value=integration),          patch("homeassistant.components.frontend.async_register_built_in_panel") as mock_register:
+
+        await async_register_frontend(hass, entry)
+
+        mock_register.assert_called_once()
+        args, kwargs = mock_register.call_args
+        assert kwargs["frontend_url_path"] == "meraki"
+        assert "v=2.3.0-beta.120" in kwargs["config"]["_panel_custom"]["module_url"]
+
+async def test_async_remove_frontend(hass: HomeAssistant):
+    """Test frontend removal."""
+    with patch("homeassistant.components.frontend.async_remove_panel") as mock_remove:
+        await async_remove_frontend(hass)
+        mock_remove.assert_called_once_with(hass, "meraki")


### PR DESCRIPTION
This change fixes a critical bug where the custom panel failed to load due to an incorrect, hardcoded version string. The solution refactors the registration logic to use dynamic versioning from the integration manifest, ensuring consistent cache-busting. It also includes the necessary frontend source fixes and build artifacts to ensure the panel loads correctly in Home Assistant.

Fixes #2051

---
*PR created automatically by Jules for task [17968436703945918605](https://jules.google.com/task/17968436703945918605) started by @brewmarsh*