### PR TITLE
Fix WebSocket JSON serialization of Exception objects

### DIFF
--- a/custom_components/meraki_ha/helpers/serialization.py
+++ b/custom_components/meraki_ha/helpers/serialization.py
@@ -1,15 +1,30 @@
+"""Serialization helpers for Meraki HA."""
+
+from __future__ import annotations
+
 import dataclasses
 from typing import Any
 
 
 def to_serializable(obj: Any) -> Any:
-    """Recursively convert dataclasses to dictionaries for serialization."""
+    """Recursively convert objects to JSON-serializable formats."""
     if hasattr(obj, "to_dict"):
-        return obj.to_dict()
+        return to_serializable(obj.to_dict())
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-        return dataclasses.asdict(obj)
+        # We don't use asdict directly because we want to recurse with our own logic
+        # for nested objects that might not be dataclasses (like Exceptions)
+        return {
+            field.name: to_serializable(getattr(obj, field.name))
+            for field in dataclasses.fields(obj)
+        }
     if isinstance(obj, list):
         return [to_serializable(item) for item in obj]
     if isinstance(obj, dict):
-        return {key: to_serializable(value) for key, value in obj.items()}
+        return {str(key): to_serializable(value) for key, value in obj.items()}
+    if isinstance(obj, Exception):
+        return {
+            "error": True,
+            "type": obj.__class__.__name__,
+            "message": str(obj),
+        }
     return obj

--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -12,10 +12,8 @@ from custom_components.meraki_ha.core.errors import (
 from custom_components.meraki_ha.core.fetch_strategies.appliance import (
     ApplianceFetchStrategy,
 )
-from custom_components.meraki_ha.core.models.device import (
-    MerakiAppliancePort,
-    MerakiDevice,
-)
+from custom_components.meraki_ha.core.models.appliance import MerakiAppliancePort
+from custom_components.meraki_ha.core.models.device import MerakiDevice
 
 
 @pytest.fixture

--- a/tests/switch/test_meraki_appliance_port_switch.py
+++ b/tests/switch/test_meraki_appliance_port_switch.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.core import HomeAssistant
 
-from custom_components.meraki_ha.core.models.device import MerakiAppliancePort
+from custom_components.meraki_ha.core.models.appliance import MerakiAppliancePort
 from custom_components.meraki_ha.switch.switch_port import MerakiAppliancePortSwitch
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,121 @@
+"""Test serialization helpers."""
+
+import dataclasses
+from typing import Any
+
+from custom_components.meraki_ha.helpers.serialization import to_serializable
+
+
+@dataclasses.dataclass
+class MockData:
+    """Mock dataclass for testing."""
+
+    name: str
+    value: int
+
+
+@dataclasses.dataclass
+class NestedMock:
+    """Nested mock dataclass."""
+
+    data: MockData
+    err: Exception
+
+
+class MockWithToDict:
+    """Mock class with to_dict method."""
+
+    def __init__(self, value: Any) -> None:
+        """Initialize."""
+        self.value = value
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict."""
+        return {"value": self.value}
+
+
+def test_to_serializable_basic():
+    """Test to_serializable with basic types."""
+    assert to_serializable(1) == 1
+    assert to_serializable("test") == "test"
+    assert to_serializable([1, 2]) == [1, 2]
+    assert to_serializable({"key": "value"}) == {"key": "value"}
+
+
+def test_to_serializable_dataclass():
+    """Test to_serializable with dataclass."""
+    data = MockData(name="test", value=123)
+    assert to_serializable(data) == {"name": "test", "value": 123}
+
+
+def test_to_serializable_to_dict():
+    """Test to_serializable with to_dict method."""
+    obj = MockWithToDict(value=1)
+    assert to_serializable(obj) == {"value": 1}
+
+
+def test_to_serializable_exception():
+    """Test to_serializable with exception."""
+    err = ValueError("Invalid value")
+    result = to_serializable(err)
+    assert result == {
+        "error": True,
+        "type": "ValueError",
+        "message": "Invalid value",
+    }
+
+
+def test_to_serializable_recursive():
+    """Test to_serializable recursively."""
+    err = ValueError("boom")
+    data = {
+        "list": [MockData(name="sub", value=1), err],
+        "dict": {"nested_err": err},
+    }
+    result = to_serializable(data)
+    expected_err = {
+        "error": True,
+        "type": "ValueError",
+        "message": "boom",
+    }
+    assert result == {
+        "list": [{"name": "sub", "value": 1}, expected_err],
+        "dict": {"nested_err": expected_err},
+    }
+
+
+def test_to_serializable_nested_dataclass_exception():
+    """Test to_serializable with exception nested in dataclass."""
+    err = ValueError("nested boom")
+    data = MockData(name="sub", value=1)
+    nested = NestedMock(data=data, err=err)
+    result = to_serializable(nested)
+    assert result == {
+        "data": {"name": "sub", "value": 1},
+        "err": {
+            "error": True,
+            "type": "ValueError",
+            "message": "nested boom",
+        },
+    }
+
+
+def test_to_serializable_nested_to_dict_exception():
+    """Test to_serializable with exception nested in to_dict result."""
+    err = ValueError("to_dict boom")
+    obj = MockWithToDict(value=err)
+    result = to_serializable(obj)
+    assert result == {
+        "value": {
+            "error": True,
+            "type": "ValueError",
+            "message": "to_dict boom",
+        },
+    }
+
+
+def test_to_serializable_dict_keys_stringified():
+    """Test to_serializable stringifies dict keys."""
+    data = {1: "one", 2: "two"}
+    result = to_serializable(data)
+    assert result == {"1": "one", "2": "two"}


### PR DESCRIPTION
This PR resolves a critical JSON serialization crash in the Meraki HA WebSocket API. The crash occurred when certain data fields (like `appliance_ports` or `appliance_traffic`) contained raw Python `Exception` objects (e.g., `MerakiVlansDisabledError`).

Key changes:
1.  **Robust Serialization**: The `to_serializable` helper now explicitly checks for `Exception` instances and converts them to a structured dictionary: `{"error": True, "type": "ClassName", "message": "error message"}`.
2.  **Deep Recursion**: Improved the recursion logic to ensure that even if an exception is nested deep within a dataclass or a dictionary returned by `to_dict`, it still gets sanitized.
3.  **JSON Compatibility**: Added stringification of dictionary keys to prevent issues with non-string keys in JSON.
4.  **Test Suite Stability**: Fixed two broken tests that were failing due to an incorrect import path for `MerakiAppliancePort`, ensuring the CI/CD pipeline remains green.
5.  **New Tests**: Added a suite of unit tests in `tests/test_serialization.py` covering basic types, dataclasses, nested structures, and exceptions.

Fixes #2063

---
*PR created automatically by Jules for task [5488648115308416358](https://jules.google.com/task/5488648115308416358) started by @brewmarsh*