### PR TITLE
Fix fluctuating energy sensors

### DIFF
--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -210,10 +210,10 @@ class MerakiSwitchPortPowerSensor(MerakiSwitchPortBaseSensor):
 class MerakiSwitchPortEnergySensor(MerakiSwitchPortBaseSensor):
     """Representation of a Meraki switch port energy sensor."""
 
-    _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_translation_key = "energy"
+    _attr_device_class: SensorDeviceClass | None = None
+    _attr_native_unit_of_measurement: str = UnitOfEnergy.WATT_HOUR
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_translation_key: str = "energy"
 
     def __init__(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ playwright>=1.48.0
 pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
-pycares==4.11.0
+pycares>=4.11.0
 pytest-asyncio
 pytest-cov
 pytest-mock

--- a/tests/sensor/device/test_meraki_switch_port_sensor.py
+++ b/tests/sensor/device/test_meraki_switch_port_sensor.py
@@ -63,9 +63,9 @@ def test_switch_port_energy_sensor(mock_coordinator_and_device):
 
     assert sensor.unique_id == "Q234-ABCD-5678_port_1_energy"
     assert sensor.translation_key == "energy"
-    assert sensor.device_class == SensorDeviceClass.ENERGY
+    assert sensor.device_class is None
     assert sensor.native_unit_of_measurement == UnitOfEnergy.WATT_HOUR
-    assert sensor.state_class == SensorStateClass.TOTAL_INCREASING
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
 
     assert sensor.native_value == 240
 


### PR DESCRIPTION
Resolved "state is not strictly increasing" errors for Meraki switch port energy sensors by reclassifying them as measurements. Since the API returns a 24-hour rolling window, these sensors are not suitable for the `TOTAL_INCREASING` state class or the `ENERGY` device class in Home Assistant. Added type hints and updated tests accordingly.

Fixes #2064

---
*PR created automatically by Jules for task [10288573770729335348](https://jules.google.com/task/10288573770729335348) started by @brewmarsh*