### PR TITLE
Automate Manifest Version Sync

### DIFF
--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -39,7 +39,7 @@
   "requirements": [
     "aiodns>=4.0.0",
     "aiofiles>=24.1.0",
-    "aiohttp>=3.8.1",
+    "aiohttp>=3.11.11",
     "diskcache==5.6.3",
     "meraki==1.54.0",
     "orjson>=3.9.0",
@@ -47,5 +47,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "112.0.0-beta.1"
+  "version": "2.3.0-beta.120"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
-    "set-version": "node get-version.js && npm version $(node get-version.js) --no-git-tag-version"
+    "set-version": "node get-version.js && npm version $(node get-version.js) --no-git-tag-version",
+    "postversion": "node scripts/sync-version.js"
   },
   "devDependencies": {
     "conventional-changelog-cli": "^4.1.0"

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const manifestJsonPath = path.join(__dirname, '..', 'custom_components', 'meraki_ha', 'manifest.json');
+
+try {
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const manifestJson = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf8'));
+
+  if (manifestJson.version !== packageJson.version) {
+    console.log(`Updating manifest.json version from ${manifestJson.version} to ${packageJson.version}`);
+    manifestJson.version = packageJson.version;
+    fs.writeFileSync(manifestJsonPath, JSON.stringify(manifestJson, null, 2) + '\n');
+    console.log('Successfully updated manifest.json version.');
+  } else {
+    console.log('Version in manifest.json is already up to date.');
+  }
+} catch (error) {
+  console.error('Error syncing version:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
This PR introduces an automated version synchronization mechanism to ensure that the Home Assistant integration's `manifest.json` always matches the project's root `package.json` version. A new Node.js script (`scripts/sync-version.js`) is used to perform the update, and it is hooked into the `npm version` lifecycle via the `postversion` script. Additionally, the `aiohttp` requirement in `manifest.json` has been updated to `>=3.11.11` to align with the development environment and Home Assistant Core standards.

Fixes #2069

---
*PR created automatically by Jules for task [69310331273898833](https://jules.google.com/task/69310331273898833) started by @brewmarsh*