### PR TITLE
Standardize device names

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/network.py
+++ b/custom_components/meraki_ha/binary_sensor/network.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from ..const import DOMAIN
 from ..coordinator import MerakiDataUpdateCoordinator
 from ..core.models.network import MerakiNetwork
+from ..core.utils.naming_utils import standardize_device_name
 from ..helpers.device_info_helpers import resolve_device_info
 
 
@@ -69,7 +70,7 @@ class MerakiNetworkStatus(BinarySensorEntity):
 
         return DeviceInfo(
             identifiers={(DOMAIN, network_id)},
-            name=self._network.name,
+            name=standardize_device_name(self._network.name),
         )
 
     @property

--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN, MANUFACTURER
 from ...coordinator import MerakiDataUpdateCoordinator
+from ..utils.naming_utils import standardize_device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
             if network:
                 return DeviceInfo(
                     identifiers={(DOMAIN, f"network_{self._network_id}")},
-                    name=network.name,
+                    name=standardize_device_name(network.name),
                     manufacturer=MANUFACTURER,
                     model="Network",
                     sw_version="unknown",
@@ -84,7 +85,7 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
                 model = device.model
                 return DeviceInfo(
                     identifiers={(DOMAIN, self._serial)},
-                    name=device.name,
+                    name=standardize_device_name(device.name),
                     manufacturer=MANUFACTURER,
                     model=model,
                     sw_version=device.firmware or "unknown",

--- a/custom_components/meraki_ha/core/entities/meraki_firewall_rule_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_firewall_rule_entity.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.models.network import MerakiFirewallRule
+from ...core.utils.naming_utils import standardize_device_name
 from . import BaseMerakiEntity
 
 
@@ -50,7 +51,7 @@ class MerakiFirewallRuleEntity(BaseMerakiEntity):
                     f"firewall_rule_{network_id}_{rule_index}",
                 ),
             },
-            name=rule.comment,
+            name=standardize_device_name(rule.comment),
             manufacturer="Cisco Meraki",
             model="L3 Firewall Rule",
             via_device=(self._config_entry.domain, f"network_{network_id}"),

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
 from ...core.models.network import MerakiNetwork
+from ...core.utils.naming_utils import standardize_device_name
 from ...helpers.device_info_helpers import resolve_device_info
 from . import BaseMerakiEntity
 
@@ -61,7 +62,7 @@ class MerakiNetworkEntity(BaseMerakiEntity):
 
         return DeviceInfo(
             identifiers={(DOMAIN, self._network.id)},
-            name=self._network.name or f"Network {self._network.id}",
-            manufacturer="Meraki",
+            name=standardize_device_name(self._network.name or f"Network {self._network.id}"),
+            manufacturer="Cisco Meraki",
             model="Meraki Network",
         )

--- a/custom_components/meraki_ha/core/utils/naming_utils.py
+++ b/custom_components/meraki_ha/core/utils/naming_utils.py
@@ -8,6 +8,16 @@ from typing import Any, cast
 _LOGGER = logging.getLogger(__name__)
 
 
+def standardize_device_name(name: str | None) -> str:
+    """Standardize device name with Meraki prefix."""
+    if not name:
+        return "Meraki Device"
+    name_str = str(name)
+    if name_str.lower().startswith("meraki"):
+        return name_str
+    return f"Meraki {name_str}"
+
+
 def format_device_name(device: dict[str, Any] | Any, config: Mapping[str, Any]) -> str:
     """Format the device name based on the user's preference."""
     if dataclasses.is_dataclass(type(device)):
@@ -19,7 +29,8 @@ def format_device_name(device: dict[str, Any] | Any, config: Mapping[str, Any]) 
             name = f"[SSID {device.get('number')}]"
         else:
             name = f"Meraki {device.get('model', 'Device')} {device.get('serial')}"
-    return name
+
+    return standardize_device_name(name)
 
 
 def format_entity_name(

--- a/custom_components/meraki_ha/helpers/device_info_helpers.py
+++ b/custom_components/meraki_ha/helpers/device_info_helpers.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from ..const import DOMAIN
 from ..core.models.device import MerakiDevice
 from ..core.models.network import MerakiNetwork
+from ..core.utils.naming_utils import standardize_device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +23,8 @@ DEVICE_TYPE_MAPPING = {
     "security": "Appliance",
     "cellularGateway": "Gateway",
 }
+
+
 
 
 def resolve_device_info(
@@ -73,7 +76,7 @@ def resolve_device_info(
     if client_mac and parent_serial:
         return DeviceInfo(
             identifiers={(DOMAIN, client_mac)},
-            name=str(entity_data.get("description") or client_mac),
+            name=standardize_device_name(str(entity_data.get("description") or client_mac)),
             manufacturer=str(entity_data.get("manufacturer") or "Unknown"),
             via_device=(DOMAIN, parent_serial),
         )
@@ -94,7 +97,7 @@ def resolve_device_info(
 
         return DeviceInfo(
             identifiers={(DOMAIN, f"network_{network_id}")},
-            name=name,
+            name=standardize_device_name(name),
             manufacturer="Cisco Meraki",
             model="Network Controller Service",
             entry_type=DeviceEntryType.SERVICE,
@@ -127,7 +130,7 @@ def resolve_device_info(
 
         return DeviceInfo(
             identifiers={(DOMAIN, device_serial)},
-            name=name,
+            name=standardize_device_name(name),
             manufacturer="Cisco Meraki",
             model=model,
             sw_version=str(entity_data.get("firmware") or ""),

--- a/custom_components/meraki_ha/sensor/client/status.py
+++ b/custom_components/meraki_ha/sensor/client/status.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.utils.naming_utils import standardize_device_name
 from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ class MerakiClientStatusSensor(MerakiSensor):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._client_mac)},
-            name=client_name,
+            name=standardize_device_name(client_name),
             manufacturer=client_data.get("manufacturer", "Cisco Meraki"),
             model="Client",
             serial_number=self._client_mac,

--- a/custom_components/meraki_ha/sensor/client_tracker.py
+++ b/custom_components/meraki_ha/sensor/client_tracker.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..const import DOMAIN
 from ..coordinator import MerakiDataUpdateCoordinator
+from ..core.utils.naming_utils import standardize_device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class ClientTrackerDeviceSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, CLIENT_TRACKER_DEVICE_ID)},
-            name="Client Tracker",
+            name=standardize_device_name("Client Tracker"),
             manufacturer="Cisco Meraki",
             model="Client Tracker",
         )

--- a/custom_components/meraki_ha/sensor/device/appliance_uplink.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_uplink.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.utils.naming_utils import standardize_device_name
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -49,7 +50,7 @@ class MerakiApplianceUplinkSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_serial)},
-            name=device_data.name,
+            name=standardize_device_name(device_data.name),
             model=device_data.model,
             manufacturer="Cisco Meraki",
         )

--- a/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.utils.naming_utils import standardize_device_name
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -47,7 +48,7 @@ class MerakiFirmwareStatusSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_serial)},
-            name=device_data.name,
+            name=standardize_device_name(device_data.name),
             model=device_data.model,
             manufacturer="Cisco Meraki",
             sw_version=device_data.firmware,

--- a/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...core.utils.naming_utils import format_device_name
+from ...core.utils.naming_utils import standardize_device_name, format_device_name
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -62,9 +62,10 @@ class MerakiWAN1ConnectivitySensor(
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_serial)},
+            # format_device_name already calls standardize_device_name
             name=format_device_name(device_data, self._config_entry.options),
             model=device_data.model,
-            manufacturer="Meraki",
+            manufacturer="Cisco Meraki",
         )
         self._update_state()
 

--- a/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
-from ...core.utils.naming_utils import format_device_name
+from ...core.utils.naming_utils import standardize_device_name, format_device_name
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -62,9 +62,10 @@ class MerakiWAN2ConnectivitySensor(
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_serial)},
+            # format_device_name already calls standardize_device_name
             name=format_device_name(device_data, self._config_entry.options),
             model=device_data.model,
-            manufacturer="Meraki",
+            manufacturer="Cisco Meraki",
         )
         self._update_state()
 

--- a/custom_components/meraki_ha/sensor/org/org_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_clients.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.utils.naming_utils import standardize_device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class MerakiOrganizationSSIDClientsSensor(
         self._attr_unique_id = f"{org_id}_clients_ssid"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, org_id)},
-            name=org_name,
+            name=standardize_device_name(org_name),
             manufacturer="Cisco Meraki",
             model="Organization",
         )
@@ -106,7 +107,7 @@ class MerakiOrganizationWirelessClientsSensor(
         self._attr_unique_id = f"{org_id}_clients_wireless"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, org_id)},
-            name=org_name,
+            name=standardize_device_name(org_name),
             manufacturer="Cisco Meraki",
             model="Organization",
         )
@@ -162,7 +163,7 @@ class MerakiOrganizationApplianceClientsSensor(
         self._attr_unique_id = f"{org_id}_clients_appliance"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, org_id)},
-            name=org_name,
+            name=standardize_device_name(org_name),
             manufacturer="Cisco Meraki",
             model="Organization",
         )

--- a/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinator import MerakiDataUpdateCoordinator
+from ...core.utils.naming_utils import standardize_device_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,8 +42,10 @@ class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity)
         """Return the device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._org_id)},
-            name=self.coordinator.data.get("organization", {}).get(
-                "name", "Meraki Organization"
+            name=standardize_device_name(
+                self.coordinator.data.get("organization", {}).get(
+                    "name", "Organization"
+                )
             ),
             manufacturer="Cisco Meraki",
         )

--- a/custom_components/meraki_ha/switch/camera_settings.py
+++ b/custom_components/meraki_ha/switch/camera_settings.py
@@ -12,6 +12,7 @@ from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
 
 from ..core.api.client import MerakiAPIClient
 from ..core.models.device import MerakiDevice
+from ..core.utils.naming_utils import standardize_device_name
 from ..entity import MerakiEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -125,7 +126,7 @@ class MerakiCameraSettingSwitchBase(
         """Return device information."""
         return DeviceInfo(
             identifiers={("meraki_ha", cast(str, self._device_data.serial))},
-            name=self._device_data.name,
+            name=standardize_device_name(self._device_data.name),
             manufacturer="Cisco Meraki",
             model=self._device_data.model,
         )

--- a/tests/test_naming_standardization.py
+++ b/tests/test_naming_standardization.py
@@ -1,0 +1,22 @@
+
+import pytest
+from custom_components.meraki_ha.core.utils.naming_utils import standardize_device_name, format_device_name
+
+def test_standardize_device_name():
+    assert standardize_device_name("Kitchen MT14") == "Meraki Kitchen MT14"
+    assert standardize_device_name("Meraki Kitchen MT14") == "Meraki Kitchen MT14"
+    assert standardize_device_name("meraki Kitchen MT14") == "meraki Kitchen MT14"
+    assert standardize_device_name("") == "Meraki Device"
+    assert standardize_device_name(None) == "Meraki Device"
+
+def test_format_device_name():
+    config = {"options": {}}
+    device = {"name": "Kitchen MT14", "model": "MT14", "serial": "Q2XX-XXXX-XXXX"}
+    # format_device_name now calls _standardize_device_name internally
+    assert format_device_name(device, config) == "Meraki Kitchen MT14"
+
+    device_no_name = {"name": None, "model": "MT14", "serial": "Q2XX-XXXX-XXXX"}
+    assert format_device_name(device_no_name, config) == "Meraki MT14 Q2XX-XXXX-XXXX"
+
+    device_meraki_name = {"name": "Meraki Kitchen", "model": "MT14", "serial": "Q2XX-XXXX-XXXX"}
+    assert format_device_name(device_meraki_name, config) == "Meraki Kitchen"


### PR DESCRIPTION
Standardized the naming convention for all devices created by the Meraki integration. Implemented a smart prefix logic that prepends "Meraki " to device names if not already present. This ensures consistent sorting and grouping in the Home Assistant UI. The changes were applied to the base entity classes, helper functions, and all entities that manually construct device information. Added unit tests to verify the naming logic.

Fixes #2074

---
*PR created automatically by Jules for task [14009043729934821074](https://jules.google.com/task/14009043729934821074) started by @brewmarsh*