### PR TITLE
Establish WebSocket API Contract

### DIFF
--- a/custom_components/meraki_ha/api/websocket.py
+++ b/custom_components/meraki_ha/api/websocket.py
@@ -10,7 +10,22 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import async_get_integration
 
-from ..const import DOMAIN, DATA_CLIENT
+from ..const import (
+    DOMAIN,
+    DATA_CLIENT,
+    WS_CMD_GET_CONFIG,
+    WS_CMD_SUBSCRIBE_MERAKI_DATA,
+    WS_CMD_GET_CAMERA_STREAM_URL,
+    WS_CMD_GET_CAMERA_SNAPSHOT,
+    WS_CMD_GET_VERSION,
+    WS_CMD_GET_NETWORK_EVENTS,
+    WS_CMD_UPDATE_OPTIONS,
+    WS_CMD_UPDATE_ENABLED_NETWORKS,
+    WS_CMD_TIMED_ACCESS_GET_KEYS,
+    WS_CMD_TIMED_ACCESS_GET_POLICIES,
+    WS_CMD_TIMED_ACCESS_CREATE,
+    WS_CMD_TIMED_ACCESS_DELETE,
+)
 from ..helpers.serialization import to_serializable
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,11 +42,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to get Meraki config
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/get_config",
+        WS_CMD_GET_CONFIG,
         ws_get_config,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/get_config",
+                vol.Required("type"): WS_CMD_GET_CONFIG,
                 vol.Required("config_entry_id"): str,
             },
             extra=vol.ALLOW_EXTRA,
@@ -40,11 +55,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to subscribe to Meraki data
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/subscribe_meraki_data",
+        WS_CMD_SUBSCRIBE_MERAKI_DATA,
         ws_subscribe_meraki_data,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/subscribe_meraki_data",
+                vol.Required("type"): WS_CMD_SUBSCRIBE_MERAKI_DATA,
                 vol.Required("config_entry_id"): str,
             },
             extra=vol.ALLOW_EXTRA,
@@ -53,11 +68,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to get camera stream URL
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/get_camera_stream_url",
+        WS_CMD_GET_CAMERA_STREAM_URL,
         ws_get_camera_stream_url,
         vol.Schema(
             {
-                vol.Required("type"): vol.All(str, "meraki_ha/get_camera_stream_url"),
+                vol.Required("type"): vol.All(str, WS_CMD_GET_CAMERA_STREAM_URL),
                 vol.Required("config_entry_id"): str,
                 vol.Required("serial"): str,
             },
@@ -67,11 +82,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to get camera snapshot
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/get_camera_snapshot",
+        WS_CMD_GET_CAMERA_SNAPSHOT,
         ws_get_camera_snapshot,
         vol.Schema(
             {
-                vol.Required("type"): vol.All(str, "meraki_ha/get_camera_snapshot"),
+                vol.Required("type"): vol.All(str, WS_CMD_GET_CAMERA_SNAPSHOT),
                 vol.Required("config_entry_id"): str,
                 vol.Required("serial"): str,
             },
@@ -81,11 +96,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to get version
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/get_version",
+        WS_CMD_GET_VERSION,
         ws_get_version,
         vol.Schema(
             {
-                vol.Required("type"): vol.All(str, "meraki_ha/get_version"),
+                vol.Required("type"): vol.All(str, WS_CMD_GET_VERSION),
             },
             extra=vol.ALLOW_EXTRA,
         ),
@@ -93,11 +108,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to fetch network events
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/get_network_events",
+        WS_CMD_GET_NETWORK_EVENTS,
         ws_get_network_events,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/get_network_events",
+                vol.Required("type"): WS_CMD_GET_NETWORK_EVENTS,
                 vol.Required("config_entry_id"): str,
                 vol.Required("network_id"): str,
                 vol.Optional("per_page"): int,
@@ -109,11 +124,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to update options
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/update_options",
+        WS_CMD_UPDATE_OPTIONS,
         ws_update_options,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/update_options",
+                vol.Required("type"): WS_CMD_UPDATE_OPTIONS,
                 vol.Required("config_entry_id"): str,
                 vol.Required("options"): dict,
             },
@@ -123,11 +138,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to update enabled networks
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/update_enabled_networks",
+        WS_CMD_UPDATE_ENABLED_NETWORKS,
         ws_update_enabled_networks,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/update_enabled_networks",
+                vol.Required("type"): WS_CMD_UPDATE_ENABLED_NETWORKS,
                 vol.Required("config_entry_id"): str,
                 vol.Required("enabled_networks"): [str],
             },
@@ -137,11 +152,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to get timed access keys
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/timed_access/get_keys",
+        WS_CMD_TIMED_ACCESS_GET_KEYS,
         ws_timed_access_get_keys,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/timed_access/get_keys",
+                vol.Required("type"): WS_CMD_TIMED_ACCESS_GET_KEYS,
                 vol.Required("config_entry_id"): str,
                 vol.Optional("network_id"): str,
             },
@@ -151,11 +166,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to get group policies
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/timed_access/get_policies",
+        WS_CMD_TIMED_ACCESS_GET_POLICIES,
         ws_timed_access_get_policies,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/timed_access/get_policies",
+                vol.Required("type"): WS_CMD_TIMED_ACCESS_GET_POLICIES,
                 vol.Required("config_entry_id"): str,
                 vol.Required("network_id"): str,
             },
@@ -165,11 +180,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to create a timed access key
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/timed_access/create",
+        WS_CMD_TIMED_ACCESS_CREATE,
         ws_timed_access_create,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/timed_access/create",
+                vol.Required("type"): WS_CMD_TIMED_ACCESS_CREATE,
                 vol.Required("config_entry_id"): str,
                 vol.Required("network_id"): str,
                 vol.Required("ssid_number"): str,
@@ -184,11 +199,11 @@ def async_setup_websocket_api(hass: HomeAssistant) -> None:
     # Register the command to delete a timed access key
     websocket_api.async_register_command(
         hass,
-        "meraki_ha/timed_access/delete",
+        WS_CMD_TIMED_ACCESS_DELETE,
         ws_timed_access_delete,
         vol.Schema(
             {
-                vol.Required("type"): "meraki_ha/timed_access/delete",
+                vol.Required("type"): WS_CMD_TIMED_ACCESS_DELETE,
                 vol.Required("config_entry_id"): str,
                 vol.Required("identity_psk_id"): str,
                 vol.Required("network_id"): str,

--- a/custom_components/meraki_ha/const.py
+++ b/custom_components/meraki_ha/const.py
@@ -13,3 +13,17 @@ WEBHOOK_ID_FORMAT: Final = "meraki_ha_webhook_{entry_id}"
 DATA_CLIENT: Final = "meraki_client"
 
 EVENT_MERAKI_WEBHOOK_ALERT: Final = "meraki_ha_webhook_alert"
+
+# WebSocket Commands
+WS_CMD_GET_CONFIG: Final = "meraki_ha/get_config"
+WS_CMD_SUBSCRIBE_MERAKI_DATA: Final = "meraki_ha/subscribe_meraki_data"
+WS_CMD_GET_CAMERA_STREAM_URL: Final = "meraki_ha/get_camera_stream_url"
+WS_CMD_GET_CAMERA_SNAPSHOT: Final = "meraki_ha/get_camera_snapshot"
+WS_CMD_GET_VERSION: Final = "meraki_ha/get_version"
+WS_CMD_GET_NETWORK_EVENTS: Final = "meraki_ha/get_network_events"
+WS_CMD_UPDATE_OPTIONS: Final = "meraki_ha/update_options"
+WS_CMD_UPDATE_ENABLED_NETWORKS: Final = "meraki_ha/update_enabled_networks"
+WS_CMD_TIMED_ACCESS_GET_KEYS: Final = "meraki_ha/timed_access/get_keys"
+WS_CMD_TIMED_ACCESS_GET_POLICIES: Final = "meraki_ha/timed_access/get_policies"
+WS_CMD_TIMED_ACCESS_CREATE: Final = "meraki_ha/timed_access/create"
+WS_CMD_TIMED_ACCESS_DELETE: Final = "meraki_ha/timed_access/delete"

--- a/custom_components/meraki_ha/www/index.html
+++ b/custom_components/meraki_ha/www/index.html
@@ -19,7 +19,7 @@
         document.documentElement.classList.remove('dark');
       }
     </script>
-    <script type="module" crossorigin src="/src/main.tsx"></script>
+    <script type="module" crossorigin src="/meraki-panel.js"></script>
   </head>
   <body class="bg-light-background dark:bg-dark-background">
     <meraki-panel></meraki-panel>

--- a/custom_components/meraki_ha/www/src/App.tsx
+++ b/custom_components/meraki_ha/www/src/App.tsx
@@ -5,6 +5,7 @@ import DeviceView from './components/DeviceView';
 import Settings from './components/Settings';
 import TimedAccess from './components/TimedAccess';
 import { safeCallWS } from './utils/api';
+import { WsCommand } from './types/websocket';
 
 // Define the types for our data
 interface MerakiData {
@@ -163,7 +164,7 @@ const App: React.FC<AppProps> = ({ hass, panel, config_entry_id }) => {
     try {
       setLoading(true);
       const result = await safeCallWS<MerakiData>(hass, {
-        type: 'meraki_ha/get_config',
+        type: WsCommand.GET_CONFIG,
         config_entry_id: configEntryId,
       });
       setData(result);
@@ -197,8 +198,8 @@ const App: React.FC<AppProps> = ({ hass, panel, config_entry_id }) => {
       .map((network: any) => network.id);
 
     try {
-      await hass.callWS({
-        type: 'meraki_ha/update_enabled_networks',
+      await safeCallWS(hass, {
+        type: WsCommand.UPDATE_ENABLED_NETWORKS,
         config_entry_id: configEntryId,
         enabled_networks: enabledNetworkIds,
       });

--- a/custom_components/meraki_ha/www/src/components/EventLog.tsx
+++ b/custom_components/meraki_ha/www/src/components/EventLog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { safeCallWS } from '../utils/api';
+import { WsCommand } from '../types/websocket';
 
 // Define the types for our data
 interface MerakiEvent {
@@ -67,7 +68,7 @@ const EventLog: React.FC<EventLogProps> = ({
         }
 
         const resultData = await safeCallWS<EventLogResponse>(hass, {
-          type: 'meraki_ha/get_network_events',
+          type: WsCommand.GET_NETWORK_EVENTS,
           config_entry_id: configEntryId,
           network_id: networkId,
           per_page: 10,

--- a/custom_components/meraki_ha/www/src/components/Settings.tsx
+++ b/custom_components/meraki_ha/www/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { safeCallWS } from '../utils/api';
+import { WsCommand } from '../types/websocket';
 
 interface SettingsProps {
   hass: any; // Add hass to props
@@ -30,7 +31,7 @@ const Settings: React.FC<SettingsProps> = ({
       // Use the hass prop directly
       if (hass) {
         await safeCallWS(hass, {
-          type: 'meraki_ha/update_options',
+          type: WsCommand.UPDATE_OPTIONS,
           config_entry_id: configEntryId,
           options: localOptions,
         });

--- a/custom_components/meraki_ha/www/src/components/TimedAccess.tsx
+++ b/custom_components/meraki_ha/www/src/components/TimedAccess.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import QRCode from 'react-qr-code';
 import { safeCallWS } from '../utils/api';
+import { WsCommand } from '../types/websocket';
 
 interface TimedAccessKey {
   identity_psk_id: string;
@@ -60,7 +61,7 @@ const TimedAccess: React.FC<TimedAccessProps> = ({
     setLoading(true);
     try {
       const result = await safeCallWS<TimedAccessKey[]>(hass, {
-        type: 'meraki_ha/timed_access/get_keys',
+        type: WsCommand.TIMED_ACCESS_GET_KEYS,
         config_entry_id: configEntryId,
       });
       setKeys(result);
@@ -74,7 +75,7 @@ const TimedAccess: React.FC<TimedAccessProps> = ({
   const fetchPolicies = async (networkId: string) => {
     try {
       const result = await safeCallWS<GroupPolicy[]>(hass, {
-        type: 'meraki_ha/timed_access/get_policies',
+        type: WsCommand.TIMED_ACCESS_GET_POLICIES,
         config_entry_id: configEntryId,
         network_id: networkId,
       });
@@ -90,7 +91,7 @@ const TimedAccess: React.FC<TimedAccessProps> = ({
     setCreating(true);
     try {
       await safeCallWS(hass, {
-        type: 'meraki_ha/timed_access/create',
+        type: WsCommand.TIMED_ACCESS_CREATE,
         config_entry_id: configEntryId,
         network_id: selectedNetwork,
         ssid_number: selectedSsid,
@@ -114,7 +115,7 @@ const TimedAccess: React.FC<TimedAccessProps> = ({
     if (!confirm('Are you sure you want to revoke this key?')) return;
     try {
       await safeCallWS(hass, {
-        type: 'meraki_ha/timed_access/delete',
+        type: WsCommand.TIMED_ACCESS_DELETE,
         config_entry_id: configEntryId,
         identity_psk_id: key.identity_psk_id,
         network_id: key.network_id,

--- a/custom_components/meraki_ha/www/src/meraki-panel.ts
+++ b/custom_components/meraki_ha/www/src/meraki-panel.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { safeCallWS } from './utils/api';
+import { WsCommand } from './types/websocket';
 
 interface HassObject {
   connection: {
@@ -95,7 +96,7 @@ export class MerakiPanel extends LitElement {
       }
 
       const data = await safeCallWS<MerakiData>(this.hass, {
-        type: 'meraki_ha/get_config',
+        type: WsCommand.GET_CONFIG,
         config_entry_id: this.entryId,
       });
       this._data = data;
@@ -121,8 +122,8 @@ export class MerakiPanel extends LitElement {
     this._data = { ...this._data, enabled_networks };
 
     try {
-      await this.hass.connection.sendMessagePromise({
-        type: 'meraki_ha/update_enabled_networks',
+      await safeCallWS(this.hass, {
+        type: WsCommand.UPDATE_ENABLED_NETWORKS,
         config_entry_id: this.entryId,
         enabled_networks,
       });

--- a/custom_components/meraki_ha/www/src/utils/api.ts
+++ b/custom_components/meraki_ha/www/src/utils/api.ts
@@ -1,8 +1,10 @@
+import { WsMessagePayload } from '../types/websocket';
+
 /**
  * Utility for making safe WebSocket calls to Home Assistant.
  */
 
-export const safeCallWS = async <T = any>(hass: any, message: any): Promise<T> => {
+export const safeCallWS = async <T = any>(hass: any, message: WsMessagePayload): Promise<T> => {
   if (!hass) {
     throw new Error('Home Assistant object is not available.');
   }


### PR DESCRIPTION
This change implements a strict API contract between the React frontend and Python backend for WebSocket communication. It replaces hardcoded magic strings with centralized constants (`WS_CMD_*` in `const.py`) and a TypeScript enum (`WsCommand` in `websocket.ts`). This ensures that both sides are in sync and prevents `unknown_command` errors when new commands are added or renamed.

Key changes:
1.  **Backend Refactor**: Centralized 12 WebSocket command strings in `custom_components/meraki_ha/const.py` and updated `custom_components/meraki_ha/api/websocket.py` to use them for registration and validation.
2.  **Frontend Refactor**: Created a new type definition file `src/types/websocket.ts` and updated the `safeCallWS` utility to strictly type the `message` parameter.
3.  **Component Updates**: Updated `App.tsx`, `EventLog.tsx`, `Settings.tsx`, `TimedAccess.tsx`, and `meraki-panel.ts` to use the new contract.
4.  **Verification**: Verified with `pytest` for the backend and `npm run build` for the frontend.

Fixes #2087

---
*PR created automatically by Jules for task [6726716197440010760](https://jules.google.com/task/6726716197440010760) started by @brewmarsh*