### PR TITLE
ACL refactor for SSIDs and Device Status sensors

### DIFF
--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -7,7 +7,7 @@ of a specific Meraki device.
 """
 
 import logging
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -122,8 +122,22 @@ class MerakiDeviceStatusSensor(MerakiSensor):
             self._attr_icon = "mdi:help-rhombus"
             return
 
-        # Status is the primary value of this sensor
-        device_status: str | None = current_device_data.status
+        self._attr_native_value = self._determine_device_status(current_device_data)
+
+        # Populate attributes from the latest device data
+        self._attr_extra_state_attributes = self._get_base_device_attributes(
+            current_device_data
+        )
+
+        # If the device is an appliance, add uplink information as attributes
+        if current_device_data.product_type == "appliance":
+            self._attr_extra_state_attributes.update(
+                self._get_appliance_uplink_attributes(current_device_data)
+            )
+
+    def _determine_device_status(self, device_data: MerakiDevice) -> str:
+        """Determine the device status with fallback logic."""
+        device_status: str | None = device_data.status
 
         # Determine base status
         native_value = "unknown"
@@ -134,53 +148,50 @@ class MerakiDeviceStatusSensor(MerakiSensor):
             native_value = device_status.lower()
 
         # Fallback to composite state from uplinks if base status is missing/unknown
-        if native_value == "unknown" and current_device_data.uplinks:
-            if any(u.get("status") == "active" for u in current_device_data.uplinks):
+        if native_value == "unknown" and device_data.uplinks:
+            if any(u.get("status") == "active" for u in device_data.uplinks):
                 native_value = "online"
-            elif all(u.get("status") == "failed" for u in current_device_data.uplinks):
+            elif all(u.get("status") == "failed" for u in device_data.uplinks):
                 native_value = "offline"
 
-        self._attr_native_value = native_value
+        return native_value
 
-        # Populate attributes from the latest device data
-        self._attr_extra_state_attributes = {
-            "model": current_device_data.model,
-            "serial_number": current_device_data.serial,
-            "firmware_version": current_device_data.firmware,
-            "product_type": current_device_data.product_type,
-            "mac_address": current_device_data.mac,
-            "lan_ip": current_device_data.lan_ip,
-            "public_ip": current_device_data.public_ip,
-            "wan1_ip": current_device_data.wan1_ip,
-            "wan2_ip": current_device_data.wan2_ip,
-            "tags": current_device_data.tags,
-            "network_id": current_device_data.network_id,
+    def _get_base_device_attributes(self, device_data: MerakiDevice) -> dict[str, Any]:
+        """Collect base attributes for the device."""
+        attrs = {
+            "model": device_data.model,
+            "serial_number": device_data.serial,
+            "firmware_version": device_data.firmware,
+            "product_type": device_data.product_type,
+            "mac_address": device_data.mac,
+            "lan_ip": device_data.lan_ip,
+            "public_ip": device_data.public_ip,
+            "wan1_ip": device_data.wan1_ip,
+            "wan2_ip": device_data.wan2_ip,
+            "tags": device_data.tags,
+            "network_id": device_data.network_id,
         }
         # Filter out None values from attributes
-        self._attr_extra_state_attributes = {
-            k: v for k, v in self._attr_extra_state_attributes.items() if v is not None
-        }
+        return {k: v for k, v in attrs.items() if v is not None}
 
-        # If the device is an appliance, add uplink information as attributes
-        if current_device_data.product_type == "appliance":
-            for uplink in current_device_data.appliance_uplink_statuses:
-                interface = uplink.get("interface")
-                if interface is not None:
-                    self._attr_extra_state_attributes[f"{interface}_status"] = (
-                        uplink.get("status")
-                    )
-                    self._attr_extra_state_attributes[f"{interface}_ip"] = uplink.get(
-                        "ip"
-                    )
-                    self._attr_extra_state_attributes[f"{interface}_gateway"] = (
-                        uplink.get("gateway")
-                    )
-                    self._attr_extra_state_attributes[f"{interface}_public_ip"] = (
-                        uplink.get("publicIp")
-                    )
-                    self._attr_extra_state_attributes[f"{interface}_dns_servers"] = (
-                        uplink.get("dns")
-                    )
+    def _get_appliance_uplink_attributes(
+        self, device_data: MerakiDevice
+    ) -> dict[str, Any]:
+        """Collect appliance-specific uplink attributes."""
+        attrs: dict[str, Any] = {}
+        for uplink in device_data.appliance_uplink_statuses:
+            interface = uplink.get("interface")
+            if interface is not None:
+                attrs.update(
+                    {
+                        f"{interface}_status": uplink.get("status"),
+                        f"{interface}_ip": uplink.get("ip"),
+                        f"{interface}_gateway": uplink.get("gateway"),
+                        f"{interface}_public_ip": uplink.get("publicIp"),
+                        f"{interface}_dns_servers": uplink.get("dns"),
+                    }
+                )
+        return attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/sensor/network/base.py
+++ b/custom_components/meraki_ha/sensor/network/base.py
@@ -57,21 +57,31 @@ class MerakiSSIDBaseSensor(MerakiEntity, SensorEntity):
 
         # Look in wireless_settings (preferred) or flat ssids list
         if "wireless_settings" in self.coordinator.data:
-            network_ssids = self.coordinator.data["wireless_settings"].get(
-                self._network_id
-            )
-            if network_ssids:
-                for ssid in network_ssids:
-                    if str(ssid.get("number")) == str(self._ssid_number):
-                        return ssid
-            return None
+            return self._find_ssid_in_wireless_settings()
 
         if "ssids" in self.coordinator.data:
-            for ssid in self.coordinator.data["ssids"]:
-                if ssid.get("networkId") == self._network_id and str(
-                    ssid.get("number")
-                ) == str(self._ssid_number):
-                    return ssid
+            return self._find_ssid_in_flat_list()
+
+        return None
+
+    def _find_ssid_in_wireless_settings(self) -> dict[str, Any] | None:
+        """Find the SSID data in the wireless_settings structure."""
+        network_ssids = self.coordinator.data["wireless_settings"].get(self._network_id)
+        if not network_ssids:
+            return None
+
+        for ssid in network_ssids:
+            if str(ssid.get("number")) == str(self._ssid_number):
+                return ssid
+        return None
+
+    def _find_ssid_in_flat_list(self) -> dict[str, Any] | None:
+        """Find the SSID data in the flat ssids list."""
+        for ssid in self.coordinator.data["ssids"]:
+            if ssid.get("networkId") == self._network_id and str(
+                ssid.get("number")
+            ) == str(self._ssid_number):
+                return ssid
         return None
 
     @property

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -206,3 +206,12 @@
 \*\*Code Quality & Refactoring
 
 - [ ] **Unit and Integration Tests:** Expand test coverage significantly.
+
+## Structural Improvements & Refactoring
+
+| Improvement                                                                                                                                                                     | Status   |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- |
+| **ACL Score Reduction:** Refactored complex sensor update functions in `device_status.py` and `base.py` to bring Agent Cognitive Load (ACL) scores below 10.                    | Complete |
+| **Logic Decomposition:** Extracted nested data parsing and status determination logic into single-responsibility helper functions (e.g., `_determine_device_status`).           | Complete |
+| **Strict Type Hinting:** Applied comprehensive Python type hints to all refactored functions to improve maintainability and catch potential errors early.                       | Complete |
+| **Helper Function Size Constraints:** Ensured all new helper functions remain strictly under 50 lines of code, promoting readability and ease of testing.                       | Complete |


### PR DESCRIPTION
Refactored high-complexity sensor update functions in `custom_components/meraki_ha/sensor/device/device_status.py` and `custom_components/meraki_ha/sensor/network/base.py` to bring their Agent Cognitive Load (ACL) scores below 10.

- In `device_status.py`, `_update_sensor_data` was decomposed into `_determine_device_status`, `_get_base_device_attributes`, and `_get_appliance_uplink_attributes`.
- In `base.py`, `_get_current_ssid_data` was decomposed into `_find_ssid_in_wireless_settings` and `_find_ssid_in_flat_list`.
- Applied strict Python type hinting to all refactored logic.
- Ensured all helper functions remain under 50 lines.
- Updated `docs/REQUIREMENTS.md` to document the structural improvements.

Fixes #2091

---
*PR created automatically by Jules for task [13345774580496683955](https://jules.google.com/task/13345774580496683955) started by @brewmarsh*