### PR TITLE
Revert accidental bump of version in bumpversion and manifest

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = "112.0.0-beta.1"
+current_version = "2.3.0-beta.120"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -47,5 +47,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "112.0.0-beta.1"
+  "version": "2.3.0-beta.120"
 }


### PR DESCRIPTION
This pull request reverts the recent accidental version bump to `112.0.0-beta.1` and restores the intended version string `2.3.0-beta.120` in `.bumpversion.toml` and `custom_components/meraki_ha/manifest.json`.

---
*PR created automatically by Jules for task [9824875504017082850](https://jules.google.com/task/9824875504017082850) started by @brewmarsh*