### PR TITLE
chore: sync version to 112.0.0-beta.1 and fix broken imports

### DIFF
--- a/custom_components/meraki_ha/event/device/camera_motion.py
+++ b/custom_components/meraki_ha/event/device/camera_motion.py
@@ -12,7 +12,7 @@ from homeassistant.components.event import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from ..coordinators import MerakiCameraCoordinator
+from ...coordinators import MerakiCameraCoordinator
 from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
 

--- a/custom_components/meraki_ha/event/device/mt_button.py
+++ b/custom_components/meraki_ha/event/device/mt_button.py
@@ -12,7 +12,7 @@ from homeassistant.components.event import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from ..coordinators import MerakiMainCoordinator
+from ...coordinators import MerakiMainCoordinator
 from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
 

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinators import MerakiMainCoordinator
+from ..coordinators import MerakiMainCoordinator
 from ..core.api.client import MerakiAPIClient
 from ..helpers.device_info_helpers import resolve_device_info
 

--- a/custom_components/meraki_ha/www/package.json
+++ b/custom_components/meraki_ha/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-www",
   "private": true,
-  "version": "2.3.0-beta.120",
+  "version": "112.0.0-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.3.0-beta.120",
+  "version": "112.0.0-beta.1",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",

--- a/tests/core/api/endpoints/test_appliance.py
+++ b/tests/core/api/endpoints/test_appliance.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
+from custom_components.meraki_ha.coordinators.main import MerakiMainCoordinator as MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.core.api.client import MerakiAPIClient
 from custom_components.meraki_ha.core.api.endpoints.appliance import (
     ApplianceEndpoints,

--- a/tests/discovery/test_service.py
+++ b/tests/discovery/test_service.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.config_entries import ConfigEntry
 
-from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
+from custom_components.meraki_ha.coordinators.main import MerakiMainCoordinator as MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
 from custom_components.meraki_ha.services.camera_service import CameraService
 from custom_components.meraki_ha.services.device_control_service import (

--- a/tests/sensor/device/test_meraki_firmware_status.py
+++ b/tests/sensor/device/test_meraki_firmware_status.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
+from custom_components.meraki_ha.coordinators.main import MerakiMainCoordinator as MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.sensor.device.meraki_firmware_status import (
     MerakiFirmwareStatusSensor,
 )

--- a/tests/test_adaptive_polling.py
+++ b/tests/test_adaptive_polling.py
@@ -11,8 +11,8 @@ from custom_components.meraki_ha.const_conf import (
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
 )
-from custom_components.meraki_ha.coordinator import (
-    MerakiDataUpdateCoordinator as MerakiDataCoordinator,
+from custom_components.meraki_ha.coordinators.main import (
+    MerakiMainCoordinator as MerakiDataCoordinator,
 )
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,8 +11,8 @@ from custom_components.meraki_ha.const_conf import (
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
 )
-from custom_components.meraki_ha.coordinator import (
-    MerakiDataUpdateCoordinator as MerakiDataCoordinator,
+from custom_components.meraki_ha.coordinators.main import (
+    MerakiMainCoordinator as MerakiDataCoordinator,
 )
 from tests.const import MOCK_NETWORK
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError
 
 from custom_components.meraki_ha.const import DOMAIN, EVENT_MERAKI_WEBHOOK_ALERT
-from custom_components.meraki_ha.coordinator import MerakiDataUpdateCoordinator
+from custom_components.meraki_ha.coordinators.main import MerakiMainCoordinator as MerakiDataUpdateCoordinator
 from custom_components.meraki_ha.types import MerakiDevice
 from custom_components.meraki_ha.webhook import async_handle_webhook, get_webhook_url
 


### PR DESCRIPTION
This PR finalizes the release choreography for `112.0.0-beta.1` by synchronizing the version string across all Node.js package manifests to match the Home Assistant `manifest.json`.

In addition, it unblocks the test suite by fixing several remaining broken import paths that were causing `ModuleNotFoundError` regressions during test collection. These import errors were left over from a recent structural refactor of the `coordinators` module.

---
*PR created automatically by Jules for task [13400597668569737982](https://jules.google.com/task/13400597668569737982) started by @brewmarsh*