### PR TITLE
Fix aggressive version reversion in release workflow

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = "112.0.0-beta.1"
+current_version = "2.3.0-beta.120"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -47,5 +47,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "112.0.0-beta.1"
+  "version": "2.3.0-beta.120"
 }

--- a/custom_components/meraki_ha/www/package.json
+++ b/custom_components/meraki_ha/www/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-www",
   "private": true,
-  "version": "112.0.0-beta.1",
+  "version": "2.3.0-beta.120",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "112.0.0-beta.1",
+  "version": "2.3.0-beta.120",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,11 +29,16 @@ if [[ $# -ne 1 ]]; then
 fi
 PART="${1}"
 
-# 2. Fetch and sanitize the latest git tag
-echo "Fetching latest git tag..."
-LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null) || error_exit "Failed to get latest git tag. Make sure you have at least one tag."
-VERSION="${LATEST_TAG#v}"
-echo "Found latest tag: ${LATEST_TAG} (version: ${VERSION})"
+# 2. Get the current version from .bumpversion.toml as the source of truth.
+# This allows manual version jumps to be respected by the release process.
+echo "Reading current version from ${BUMP_CONFIG_FILE}..."
+VERSION=$(grep "^current_version =" "${BUMP_CONFIG_FILE}" | sed -E 's/current_version = "(.*)"/\1/')
+if [[ -z "${VERSION}" ]]; then
+  echo "Warning: Could not read version from ${BUMP_CONFIG_FILE}. Falling back to git tags."
+  LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null) || error_exit "Failed to get latest git tag and no version found in config."
+  VERSION="${LATEST_TAG#v}"
+fi
+echo "Current version identified as: ${VERSION}"
 
 # Normalize bare version numbers (e.g., 112 -> 112.0.0)
 if [[ "$VERSION" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
Investigated and fixed a rogue GitHub Actions behavior where the repository version was being aggressively reverted to 112.0.0-beta.1.

The root cause was identified in `scripts/release.sh`, which used `git describe` to determine the current version, thereby overwriting any manual updates in configuration files with the latest git tag.

Changes:
- Refactored `scripts/release.sh` to use `.bumpversion.toml` as the primary source of truth for the current version, with a fallback to git tags.
- Updated `.bumpversion.toml`, `package.json`, `custom_components/meraki_ha/manifest.json`, and `custom_components/meraki_ha/www/package.json` to the target version `2.3.0-beta.120`.
- Verified the fix by reviewing the script logic and ensuring consistent versioning across files.
- Ran existing tests to ensure no regressions were introduced.

Fixes #2108

---
*PR created automatically by Jules for task [5497904238293994852](https://jules.google.com/task/5497904238293994852) started by @brewmarsh*