### PR TITLE
Fix TypeScript build pipeline and custom element declarations

### DIFF
--- a/custom_components/meraki_ha/www/src/global.d.ts
+++ b/custom_components/meraki_ha/www/src/global.d.ts
@@ -2,24 +2,3 @@ declare module '*.css?inline' {
   const content: string;
   export default content;
 }
-
-declare namespace JSX {
-  interface IntrinsicElements {
-    'ha-card': React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement> & { header?: string },
-      HTMLElement
-    >;
-    'ha-icon': React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement> & { icon?: string },
-      HTMLElement
-    >;
-    'ha-switch': React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement> & {
-        checked?: boolean;
-        disabled?: boolean;
-        onchange?: (e: any) => void;
-      },
-      HTMLElement
-    >;
-  }
-}


### PR DESCRIPTION
This PR fixes the TypeScript build pipeline for the Meraki HA custom panel. It addresses `TS2307` (cannot find module `./types/websocket`) and `TS2339` (property does not exist on type `JSX.IntrinsicElements`).

Key changes:
1.  **Module Resolution**: Added `src/types/websocket.ts` defining the `WsCommand` enum and `WsMessagePayload` interface, which were previously missing but referenced in `api.ts`.
2.  **Custom Element Registration**: Added `src/types/hass-elements.d.ts` to globally register Home Assistant custom elements (`ha-card`, `ha-icon`, `ha-switch`, etc.) in the `JSX.IntrinsicElements` namespace. This ensures React/JSX correctly recognizes these elements without type errors.
3.  **Refactoring**: Moved existing inline element declarations from `global.d.ts` to the new dedicated type file to maintain a cleaner project structure.
4.  **Verification**: Confirmed that `npx tsc` now passes without errors and the production build via `./build.sh` completes successfully.

Fixes #2117

---
*PR created automatically by Jules for task [16018899274532533506](https://jules.google.com/task/16018899274532533506) started by @brewmarsh*