### PR TITLE
Fix TypeScript build errors for Meraki HA panel

### DIFF
--- a/custom_components/meraki_ha/www/src/types/ha-frontend.d.ts
+++ b/custom_components/meraki_ha/www/src/types/ha-frontend.d.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'ha-card': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { header?: string }, HTMLElement>;
+      'ha-icon': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { icon?: string; slot?: string }, HTMLElement>;
+      'ha-settings-row': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { narrow?: boolean; slot?: string }, HTMLElement>;
+      'ha-switch': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { checked?: boolean; disabled?: boolean }, HTMLElement>;
+      'ha-circular-progress': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { active?: boolean; alt?: string }, HTMLElement>;
+      'ha-tabs': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { selected?: string; "attr-for-selected"?: string; scrollable?: boolean }, HTMLElement>;
+      'paper-tab': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & { name?: string }, HTMLElement>;
+    }
+  }
+}
+export {};

--- a/custom_components/meraki_ha/www/src/types/websocket.ts
+++ b/custom_components/meraki_ha/www/src/types/websocket.ts
@@ -1,0 +1,25 @@
+/**
+ * WebSocket Command Enum
+ */
+export enum WsCommand {
+  GET_CONFIG = 'meraki_ha/get_config',
+  SUBSCRIBE_MERAKI_DATA = 'meraki_ha/subscribe_meraki_data',
+  GET_CAMERA_STREAM_URL = 'meraki_ha/get_camera_stream_url',
+  GET_CAMERA_SNAPSHOT = 'meraki_ha/get_camera_snapshot',
+  GET_VERSION = 'meraki_ha/get_version',
+  GET_NETWORK_EVENTS = 'meraki_ha/get_network_events',
+  UPDATE_OPTIONS = 'meraki_ha/update_options',
+  UPDATE_ENABLED_NETWORKS = 'meraki_ha/update_enabled_networks',
+  TIMED_ACCESS_GET_KEYS = 'meraki_ha/timed_access/get_keys',
+  TIMED_ACCESS_GET_POLICIES = 'meraki_ha/timed_access/get_policies',
+  TIMED_ACCESS_CREATE = 'meraki_ha/timed_access/create',
+  TIMED_ACCESS_DELETE = 'meraki_ha/timed_access/delete',
+}
+
+/**
+ * WebSocket Message Payload Interface
+ */
+export interface WsMessagePayload {
+  type: WsCommand | string;
+  [key: string]: any;
+}

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -139,6 +139,13 @@
 | :----------------------------------------------------- | :------- |
 | The Integration uses Voluptuous for schema validation. | Included |
 
+**Frontend Development
+
+| Requirement                                                                                                                                  | Status   |
+| :------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| Home Assistant Web Components must be explicitly registered in the global JSX namespace (e.g., `src/types/ha-frontend.d.ts`) for TypeScript. | Included |
+| WebSocket commands used by the frontend must be centralized in a type-safe enum (e.g., `src/types/websocket.ts`).                            | Included |
+
 ## Key Learnings from Debugging
 
 | Requirement                                                                                | Status             |


### PR DESCRIPTION
This submission resolves TypeScript compilation errors (TS2339 and TS2307) that were blocking the production build of the Meraki HA panel. 

Key changes:
1. **Global JSX Registration**: Added `src/types/ha-frontend.d.ts` to explicitly define `ha-card`, `ha-icon`, `ha-switch`, and other Home Assistant web components. This ensures the TypeScript compiler recognizes them as valid intrinsic elements and supports standard React attributes like `ref` and `key`.
2. **WebSocket Type Centralization**: Created `src/types/websocket.ts` defining the `WsCommand` enum and `WsMessagePayload` interface. This resolves module resolution errors in `src/utils/api.ts` and provides a single source of truth for frontend-to-backend communication.
3. **Requirement Documentation**: Updated `docs/REQUIREMENTS.md` to reflect these new frontend standards, ensuring long-term maintainability and preventing build regressions.
4. **Build Verification**: Confirmed that `npm run build` (via `tsc` and `vite`) now completes successfully without errors.

Fixes #2119

---
*PR created automatically by Jules for task [15371421190788521635](https://jules.google.com/task/15371421190788521635) started by @brewmarsh*