### PR TITLE
Enforce [Sensor] prefix for Meraki MT devices

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
+++ b/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.typing import UNDEFINED
 from ...const import DOMAIN
 from ...coordinators import MerakiSensorCoordinator as MerakiDataCoordinator
 from ...core.models.device import MerakiDevice
-from ...core.utils.naming_utils import format_device_name
+from ...helpers.device_info_helpers import resolve_device_info
 from ...entity import MerakiBinarySensor
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,25 +37,11 @@ class MerakiMtBinarySensor(MerakiBinarySensor):
             self._attr_name = cast(str | None, self.entity_description.name)
 
     @property
-    def device_info(self) -> DeviceInfo:
+    def device_info(self) -> DeviceInfo | None:
         """Return device information."""
-        device_identifiers = set()
-        if self._device.serial:
-            device_identifiers = {(DOMAIN, str(self._device.serial))}
-
-        if self.coordinator.config_entry:
-            format_device_name(self._device, self.coordinator.config_entry.options)
-        return DeviceInfo(
-            identifiers=device_identifiers,
-            name=format_device_name(
-                self._device,
-                self.coordinator.config_entry.options
-                if self.coordinator.config_entry
-                else {},
-            ),
-            model=str(self._device.model),
-            manufacturer="Cisco Meraki",
-        )
+        if not self.coordinator.config_entry:
+            return None
+        return resolve_device_info(self._device, self.coordinator.config_entry)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -83,7 +83,6 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         Camera.__init__(self)
         self._device_serial = device.serial or ""
         self._camera_service = camera_service
-        self._config_entry = config_entry
 
         # Setting name to None with has_entity_name=True makes this the "Main" entity
         self._attr_name = None
@@ -109,14 +108,14 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return device information."""
-        return resolve_device_info(self.device_data, self._config_entry)
+        return resolve_device_info(self.device_data, self.coordinator.config_entry)
 
     async def async_added_to_hass(self) -> None:
         """Handle when entity is added to hass."""
         await super().async_added_to_hass()
 
         if (
-            self._config_entry.options.get(CONF_ENABLE_CAMERA_ENTITIES, True)
+            self.coordinator.config_entry.options.get(CONF_ENABLE_CAMERA_ENTITIES, True)
             and not self.device_data.rtsp_url
         ):
             try:

--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN, MANUFACTURER
 from ...coordinators import MerakiMainCoordinator
+from ...helpers.device_info_helpers import resolve_device_info
 from ..utils.naming_utils import standardize_device_name
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
     """
 
     coordinator: MerakiMainCoordinator
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -46,7 +48,6 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
 
         """
         super().__init__(coordinator)
-        self._config_entry = config_entry
         self._serial = serial
         self._network_id = network_id
         self._attr_has_entity_name = True
@@ -70,30 +71,13 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
         if self._network_id and not self._serial:
             network = self.coordinator.get_network(self._network_id)
             if network:
-                return DeviceInfo(
-                    identifiers={(DOMAIN, f"network_{self._network_id}")},
-                    name=standardize_device_name(network.name),
-                    manufacturer=MANUFACTURER,
-                    model="Network",
-                    sw_version="unknown",
-                )
+                return resolve_device_info(network, self.coordinator.config_entry)
 
         # Handle device-based entities
         if self._serial:
             device = self.coordinator.get_device(self._serial)
             if device:
-                model = device.model
-                return DeviceInfo(
-                    identifiers={(DOMAIN, self._serial)},
-                    name=standardize_device_name(device.name),
-                    manufacturer=MANUFACTURER,
-                    model=model,
-                    sw_version=device.firmware or "unknown",
-                    suggested_area=device.address or "",
-                    hw_version=model,
-                    configuration_url=device.url
-                    or f"https://dashboard.meraki.com/devices/{self._serial}",
-                )
+                return resolve_device_info(device, self.coordinator.config_entry)
 
         return None
 

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -57,7 +57,7 @@ class MerakiNetworkEntity(BaseMerakiEntity):
         if self._network.id is None:
             raise ValueError("Network ID cannot be None")
 
-        if info := resolve_device_info(self._network.to_dict(), self._config_entry):
+        if info := resolve_device_info(self._network.to_dict(), self.coordinator.config_entry):
             return info
 
         return DeviceInfo(

--- a/custom_components/meraki_ha/core/utils/naming_utils.py
+++ b/custom_components/meraki_ha/core/utils/naming_utils.py
@@ -13,7 +13,11 @@ def standardize_device_name(name: str | None) -> str:
     if not name:
         return "Meraki Device"
     name_str = str(name)
-    if name_str.lower().startswith("meraki"):
+    if (
+        name_str.lower().startswith("meraki")
+        or name_str.startswith("[")
+        or name_str.startswith("Site: ")
+    ):
         return name_str
     return f"Meraki {name_str}"
 
@@ -24,11 +28,19 @@ def format_device_name(device: dict[str, Any] | Any, config: Mapping[str, Any]) 
         device = dataclasses.asdict(cast(Any, device))
 
     name = device.get("name")
+    model = str(device.get("model") or "")
+    product_type = str(device.get("productType") or device.get("product_type") or "")
+
     if not name:
-        if device.get("productType") == "ssid":
+        if product_type == "ssid":
             name = f"[SSID {device.get('number')}]"
         else:
-            name = f"Meraki {device.get('model', 'Device')} {device.get('serial')}"
+            name = f"{model} {device.get('serial')}"
+
+    # Enforce [Sensor] prefix for MT devices
+    if product_type == "sensor" or model.startswith("MT"):
+        if not str(name).startswith("[Sensor]"):
+            name = f"[Sensor] {name}"
 
     return standardize_device_name(name)
 

--- a/custom_components/meraki_ha/helpers/device_info_helpers.py
+++ b/custom_components/meraki_ha/helpers/device_info_helpers.py
@@ -87,9 +87,13 @@ def _resolve_physical_device_info(data: dict[str, Any]) -> DeviceInfo | None:
 
         # Identify Camera Logic: strictly enforce [Camera] prefix for all camera models
         is_camera = product_type.lower() == "camera" or model.startswith(("MV", "CS-"))
+        # Identify Sensor Logic: strictly enforce [Sensor] prefix for all MT sensor models
+        is_sensor = product_type.lower() == "sensor" or model.startswith("MT")
 
         if is_camera:
             prefix = "Camera"
+        elif is_sensor:
+            prefix = "Sensor"
         else:
             prefix = DEVICE_TYPE_MAPPING.get(product_type, "Device")
 

--- a/custom_components/meraki_ha/sensor/device/connected_clients.py
+++ b/custom_components/meraki_ha/sensor/device/connected_clients.py
@@ -39,7 +39,6 @@ class MerakiDeviceConnectedClientsSensor(MerakiSensor):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device_serial: str | None = device_data.serial
-        self._config_entry = config_entry
         self.entity_description = SensorEntityDescription(
             key="connected_clients",
             name="Connected Clients",
@@ -47,7 +46,7 @@ class MerakiDeviceConnectedClientsSensor(MerakiSensor):
 
         self._attr_device_info = resolve_device_info(
             entity_data=asdict(device_data),
-            config_entry=self._config_entry,
+            config_entry=self.coordinator.config_entry,
         )
         self._update_state()
 

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from ...const import DOMAIN
 from ...coordinators import MerakiMainCoordinator
 from ...core.models.device import MerakiDevice
-from ...core.utils.naming_utils import format_device_name
+from ...helpers.device_info_helpers import resolve_device_info
 from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,16 +69,7 @@ class MerakiDeviceStatusSensor(MerakiSensor):
 
         # Set device info for linking to HA device registry
         # This uses the initial device_data for static info.
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._device_serial)},
-            name=format_device_name(device_data, config_entry.options),
-            model=device_data.model,
-            manufacturer="Cisco Meraki",
-            serial_number=self._device_serial,
-            sw_version=device_data.firmware,
-            suggested_area=device_data.address,
-            configuration_url=device_data.url,
-        )
+        self._attr_device_info = resolve_device_info(device_data, config_entry)
 
         # _attr_name is not explicitly set
         self.entity_description = SensorEntityDescription(

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.typing import UNDEFINED
 from ...const import DOMAIN
 from ...coordinators import MerakiSensorCoordinator
 from ...core.models.device import MerakiDevice
-from ...core.utils.naming_utils import format_device_name
+from ...helpers.device_info_helpers import resolve_device_info
 from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,16 +65,9 @@ class MerakiMtSensor(MerakiSensor, RestoreSensor):
                 # Ignore other types (e.g. datetime) that don't match our state type
 
     @property
-    def device_info(self) -> DeviceInfo:
+    def device_info(self) -> DeviceInfo | None:
         """Return device information."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device.serial))},
-            name=format_device_name(
-                self._device, self.coordinator.config_entry.options
-            ),
-            model=self._device.model,
-            manufacturer="Cisco Meraki",
-        )
+        return resolve_device_info(self._device, self.coordinator.config_entry)
 
     def _get_value_from_legacy_device_attributes(self, key: str) -> Any | None:
         """Retrieve value from older MT device attributes."""


### PR DESCRIPTION
This change refactors how Meraki devices are named in the Home Assistant device registry. Specifically, all MT devices (sensors) now have a `[Sensor] ` prefix added to their name if not already present. This is achieved by updating centralized naming utilities and the `resolve_device_info` helper. Furthermore, base entity classes have been updated to set `_attr_has_entity_name = True`, allowing Home Assistant to correctly format individual sensor names (e.g., "[Sensor] Garage Fridge Temperature") and ensuring a cleaner UI. The refactor also standardizes how entities access configuration data by using the coordinator's config entry.

Fixes #2148

---
*PR created automatically by Jules for task [11341365540815119620](https://jules.google.com/task/11341365540815119620) started by @brewmarsh*