### PR TITLE
Fix TypeScript Build and Backend Import Errors

### DIFF
--- a/custom_components/meraki_ha/api/websocket.py
+++ b/custom_components/meraki_ha/api/websocket.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import logging
 from typing import Any, TYPE_CHECKING
+import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.components import websocket_api
+from homeassistant.loader import async_get_integration
 
 from ..const import (
     DOMAIN,

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from ...const_api import DEFAULT_CAPS
+from ..const import DEFAULT_CAPS
 from ...core.parsers.appliance import parse_appliance_data
 from ...core.parsers.devices import parse_device_data
 from ...core.parsers.network import parse_network_data
@@ -32,12 +32,6 @@ if TYPE_CHECKING:
     from ..models.device import MerakiDevice
 
 _LOGGER = logging.getLogger(__name__)
-
-# Shared cache for organization-wide data to prevent redundant API calls
-# between multiple domain-specific coordinators.
-_ORG_DATA_CACHE: dict[str, Any] = {}
-_ORG_DATA_CACHE_EXPIRY: datetime | None = None
-CACHE_TTL = timedelta(seconds=25)
 
 # Shared cache for organization-wide data to prevent redundant API calls
 # between multiple domain-specific coordinators.


### PR DESCRIPTION
The TypeScript build for the Meraki HA custom panel was failing due to several missing files and type mismatches. I identified and recreated the missing files (NetworkCard, TimedAccess components, and core type definitions) based on their usage in the existing codebase. I also resolved several backend Python errors that were preventing the integration from loading during tests, specifically missing imports in the WebSocket API and incorrect constant imports in the data fetcher. The frontend now compiles successfully, and the integration tests can proceed further than before.

Fixes #2151

---
*PR created automatically by Jules for task [9521381804561859275](https://jules.google.com/task/9521381804561859275) started by @brewmarsh*