### PR TITLE
Fix Vite Build and Postbuild Script Stability

### DIFF
--- a/custom_components/meraki_ha/www/package.json
+++ b/custom_components/meraki_ha/www/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "tsc && vite build",
-    "postbuild": "cp dist/meraki-panel.js . && cp -r dist/assets . 2>/dev/null || true",
+    "postbuild": "cp dist/meraki-panel.js . && cp -r dist/assets .",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },


### PR DESCRIPTION
This change ensures that the Meraki HA frontend build process is deterministic and reliable. By configuring Vite to output a static filename (`meraki-panel.js`) and removing the silent failure trap in the postbuild script, we prevent the deployment of stale or missing frontend assets. This aligns the build output with the expectations of the Home Assistant integration and ensures that any build failures are immediately visible in the CI/CD pipeline.

Fixes #2153

---
*PR created automatically by Jules for task [14891979489792684304](https://jules.google.com/task/14891979489792684304) started by @brewmarsh*