### PR TITLE
Add TypeScript type-checking to frontend pre-commit workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,12 @@ repos:
   # Local hooks
   - repo: local
     hooks:
+      - id: ts-check
+        name: TypeScript Type Check
+        entry: bash -c 'cd custom_components/meraki_ha/www && npm run typecheck'
+        language: system
+        pass_filenames: false
+        files: ^custom_components/meraki_ha/www/.*\.(ts|tsx)$
       - id: forbid-agent-artifacts
         name: Forbid agent artifacts
         entry: python tools/check_artifacts.py

--- a/custom_components/meraki_ha/www/package.json
+++ b/custom_components/meraki_ha/www/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
+    "typecheck": "tsc --noEmit",
     "build": "tsc && vite build",
     "postbuild": "cp dist/meraki-panel.js . && cp -r dist/assets .",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
Configure a pre-commit hook to enforce TypeScript type-checking for the frontend. This involves adding a `typecheck` script to the frontend's `package.json` and a corresponding local hook to the root `.pre-commit-config.yaml` file. This change prevents developers from committing code that breaks the CI due to TypeScript errors.

Fixes #2158

---
*PR created automatically by Jules for task [4656736728743400327](https://jules.google.com/task/4656736728743400327) started by @brewmarsh*