### PR TITLE
Improve restart command and config flow response handling

### DIFF
--- a/tests/scripts/reset_integration.py
+++ b/tests/scripts/reset_integration.py
@@ -94,11 +94,22 @@ async def _send_restart_command(session: aiohttp.ClientSession) -> bool:
     """Send the restart command to Home Assistant."""
     restart_url = f"{HA_URL}/api/services/homeassistant/restart"
     logger.info("Restarting Home Assistant...")
-    async with session.post(restart_url) as resp:
-        if resp.status != 200:
+    
+    try:
+        # A timeout ensures we don't hang if the reverse proxy blackholes the connection
+        async with session.post(restart_url, timeout=15) as resp:
+            # 200 = OK, 502/504 = Server went down before responding (Normal)
+            if resp.status in (200, 502, 504):
+                logger.warning(f"Restart command sent with status: {resp.status}")
+                return True
+                
             logger.error(f"Restart command failed: {resp.status}")
             return False
-    return True
+            
+    except (aiohttp.ClientError, asyncio.TimeoutError):
+        # Connection violently dropping is the ultimate proof it is restarting
+        logger.warning("Connection dropped. Restart is in progress.")
+        return True
 
 
 async def _wait_for_restart(session: aiohttp.ClientSession) -> bool:
@@ -206,7 +217,8 @@ async def _start_config_flow(session: aiohttp.ClientSession) -> dict[str, Any] |
 
     logger.info("Initiating config flow for meraki_ha...")
     async with session.post(flow_url, json=payload) as resp:
-        if resp.status != 201:
+        # Accept both 200 (OK) and 201 (Created) as successful responses
+        if resp.status not in (200, 201):
             logger.error(f"Failed to start config flow: {resp.status}")
             logger.debug(await resp.text())
             return None


### PR DESCRIPTION
Update restart command handling to accept 200, 502, and 504 status codes. Modify config flow initiation to accept both 200 and 201 as successful responses.

## 🛠 Integration Contribution Summary

### 🎯 Versioning & Type

**PR Title Format:** `[major|minor|patch] Short Description`

- [ ] **Type:** (Bug fix / New feature / Breaking change)

### 🔗 Context

- **Linked Issue:** Fixes #
- **Milestone:** v2.3.0 (2026.1 Infrastructure Update)

### 🛠 2026.1 Compliance Checklist

- [ ] **Naming:** Implemented `has_entity_name: true` & Sentence case.
- [ ] **Translations:** Updated `strings.json` and linked `en.json`.
- [ ] **Categorization:** Moved technical metadata to `DIAGNOSTIC`.
- [ ] **Refactoring:** Followed `ROADMAP.md` instructions.

### ✍️ Documentation & Quality

- [ ] **Comments:** I have commented code in complex Meraki API logic areas.
- [ ] **Self-Review:** I have verified this code generates no new `meraki_ha` warnings.
- [ ] **Roadmap:** I have marked the task as complete in `ROADMAP.md` (if applicable).

---

**Contributor Type:**

- [x] Human Developer
- [ ] Jules AI Agent

_Please review for 2026.1 architectural alignment before merging into beta._
