### PR TITLE
Fix ApplianceTrafficHelper import error

### DIFF
--- a/custom_components/meraki_ha/core/fetch_strategies/appliance.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance.py
@@ -5,16 +5,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from meraki.exceptions import APIError
-
-from ...core.errors import (
-    MerakiInformationalError,
-    MerakiTrafficAnalysisError,
-    MerakiVlanError,
-    MerakiVlansDisabledError,
-)
-from ...core.models import MerakiAppliancePort
 from ...core.models.device import MerakiDevice
+from .appliance_device import ApplianceDeviceHelper
+from .appliance_traffic import ApplianceTrafficHelper
+from .appliance_uplinks import ApplianceUplinkHelper
 from .base import BaseFetchStrategy
 
 if TYPE_CHECKING:

--- a/custom_components/meraki_ha/core/fetch_strategies/appliance_device.py
+++ b/custom_components/meraki_ha/core/fetch_strategies/appliance_device.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from meraki.exceptions import APIError
 
-from ...core.models.device import MerakiAppliancePort
+from ...core.models import MerakiAppliancePort
 
 if TYPE_CHECKING:
     from ...core.api.client import MerakiAPIClient


### PR DESCRIPTION
Added missing imports for ApplianceTrafficHelper, ApplianceUplinkHelper, and ApplianceDeviceHelper in core/fetch_strategies/appliance.py. Also cleaned up unused imports and fixed a related import issue in appliance_device.py to resolve static analysis errors.

Fixes #2174

---
*PR created automatically by Jules for task [16724619591234718283](https://jules.google.com/task/16724619591234718283) started by @brewmarsh*