### PR TITLE
Global Defensive Auditing for Coordinator Data Access

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/switch_port.py
@@ -61,6 +61,8 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
             self._device = device
             ports = device.switch_ports or device.appliance_ports or []
             for port_data in ports:
+                if port_data is None or isinstance(port_data, str):
+                    continue
                 if hasattr(port_data, "to_dict"):
                     port = port_data.to_dict()
                 else:

--- a/custom_components/meraki_ha/sensor/client/status.py
+++ b/custom_components/meraki_ha/sensor/client/status.py
@@ -108,6 +108,8 @@ class MerakiClientStatusSensor(MerakiSensor):
         """Retrieve the latest data for this client from the coordinator."""
         if self.coordinator.data and self.coordinator.data.get("clients"):
             for client in self.coordinator.data["clients"]:
+                if not isinstance(client, dict):
+                    continue
                 if client.get("mac") == self._client_mac:
                     return client
         return None

--- a/custom_components/meraki_ha/sensor/client_tracker.py
+++ b/custom_components/meraki_ha/sensor/client_tracker.py
@@ -97,6 +97,8 @@ class MerakiClientSensor(CoordinatorEntity, SensorEntity):
         client_info = {}
         if self.coordinator.data and self.coordinator.data.get("clients"):
             for client in self.coordinator.data["clients"]:
+                if not isinstance(client, dict):
+                    continue
                 if client.get("mac") == self._client_mac:
                     is_online = True
                     client_info = client

--- a/custom_components/meraki_ha/sensor/device/ap_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/ap_client_count.py
@@ -67,7 +67,8 @@ class MerakiAPClientCountSensor(MerakiSensor):
         self._attr_native_value = sum(
             1
             for client in clients
-            if client.get("recentDeviceSerial") == self._device_serial
+            if isinstance(client, dict)
+            and client.get("recentDeviceSerial") == self._device_serial
         )
 
     @callback

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -88,7 +88,9 @@ class MerakiPoeUsageSensor(
             return None
 
         total_poe_usage_wh = sum(
-            port.get("powerUsageInWh", 0) or 0 for port in ports_statuses
+            port.get("powerUsageInWh", 0) or 0
+            for port in ports_statuses
+            if isinstance(port, dict)
         )
 
         # The API returns power usage in Wh over the last day.
@@ -107,4 +109,5 @@ class MerakiPoeUsageSensor(
         return {
             f"port_{port['portId']}_power_usage_wh": port.get("powerUsageInWh")
             for port in ports_statuses
+            if isinstance(port, dict) and "portId" in port
         }

--- a/custom_components/meraki_ha/sensor/device/switch_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/switch_client_count.py
@@ -67,7 +67,8 @@ class MerakiSwitchClientCountSensor(MerakiSensor):
         self._attr_native_value = sum(
             1
             for client in clients
-            if client.get("recentDeviceSerial") == self._device_serial
+            if isinstance(client, dict)
+            and client.get("recentDeviceSerial") == self._device_serial
         )
 
     @callback

--- a/custom_components/meraki_ha/sensor/device/switch_poe.py
+++ b/custom_components/meraki_ha/sensor/device/switch_poe.py
@@ -62,9 +62,13 @@ class MerakiSwitchPoESensor(CoordinatorEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         for device in self.coordinator.data.get("devices", []):
+            if not hasattr(device, "serial"):
+                continue
             if device.serial == self._device.serial:
                 self._device = device
                 for port in self._device.switch_ports:
+                    if not isinstance(port, dict):
+                        continue
                     port_id = self._port.get("portId") or self._port.get("number")
                     if port.get("portId") == port_id or port.get("number") == port_id:
                         self._port = port

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -75,12 +75,15 @@ class MerakiSwitchPortBaseSensor(CoordinatorEntity, SensorEntity, ABC):
         else:
             current_port_id = self._get_port_id_from_data(self._port)
             _LOGGER.debug(
-                "Could not find updated data for device serial '%s', port ID '%s' in coordinator data. Sensor might be stale or unavailable.",
+                "Could not find updated data for device serial '%s', port ID '%s' "
+                "in coordinator data. Sensor might be stale or unavailable.",
                 self._device.serial,
                 current_port_id,
             )
-            # If the device or port is not found, the entity should eventually reflect unavailability.
-            # For now, it will keep its last known state, and 'available' property check handles device online status.
+            # If the device or port is not found, the entity should
+            # eventually reflect unavailability.
+            # For now, it will keep its last known state, and 'available'
+            # property check handles device online status.
 
     def _get_port_id_from_data(self, port_data: dict[str, Any]) -> str | int | None:
         """Extract the port ID from port data, preferring 'portId' then 'number'."""
@@ -93,28 +96,37 @@ class MerakiSwitchPortBaseSensor(CoordinatorEntity, SensorEntity, ABC):
         current_port_id = self._get_port_id_from_data(self._port)
         if not current_port_id:
             _LOGGER.warning(
-                "Current port data for sensor '%s' is missing 'portId' or 'number'. Cannot update.",
+                "Current port data for sensor '%s' is missing 'portId' or 'number'. "
+                "Cannot update.",
                 self.unique_id,
             )
             return None, None
 
         for device in self.coordinator.data.get("devices", []):
+            if not hasattr(device, "serial"):
+                continue
             if device.serial == self._device.serial:
                 for port in device.switch_ports:
+                    if not isinstance(port, dict):
+                        continue
                     port_id_candidate = self._get_port_id_from_data(port)
                     if port_id_candidate == current_port_id:
                         return device, port
                 _LOGGER.debug(
-                    "Port ID '%s' not found in updated device '%s' port statuses. Sensor '%s' might be stale.",
+                    "Port ID '%s' not found in updated device '%s' port statuses. "
+                    "Sensor '%s' might be stale.",
                     current_port_id,
                     self._device.serial,
                     self.unique_id,
                 )
-                # Device found, but the specific port was not in its updated ports_statuses.
-                # This could mean the port was removed or its data is temporarily missing.
+                # Device found, but the specific port was not in its
+                # updated ports_statuses.
+                # This could mean the port was removed or its data is
+                # temporarily missing.
                 return device, None  # Return device, but not the specific port
         _LOGGER.debug(
-            "Device serial '%s' not found in coordinator data for sensor '%s'. Sensor might be stale or unavailable.",
+            "Device serial '%s' not found in coordinator data for sensor '%s'. "
+            "Sensor might be stale or unavailable.",
             self._device.serial,
             self.unique_id,
         )

--- a/custom_components/meraki_ha/sensor/network/base.py
+++ b/custom_components/meraki_ha/sensor/network/base.py
@@ -71,6 +71,8 @@ class MerakiSSIDBaseSensor(MerakiEntity, SensorEntity):
             return None
 
         for ssid in network_ssids:
+            if not isinstance(ssid, dict):
+                continue
             if str(ssid.get("number")) == str(self._ssid_number):
                 return ssid
         return None
@@ -78,6 +80,8 @@ class MerakiSSIDBaseSensor(MerakiEntity, SensorEntity):
     def _find_ssid_in_flat_list(self) -> dict[str, Any] | None:
         """Find the SSID data in the flat ssids list."""
         for ssid in self.coordinator.data["ssids"]:
+            if not isinstance(ssid, dict):
+                continue
             if ssid.get("networkId") == self._network_id and str(
                 ssid.get("number")
             ) == str(self._ssid_number):

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -43,6 +43,10 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         if not self._network:
             return
         vlans = self.coordinator.data.get("vlans", {}).get(self._network.id, [])
-        self._vlan_list = [vlan.name or f"VLAN {vlan.id}" for vlan in vlans]
-        self._attr_native_value = len(vlans)
+        self._vlan_list = [
+            getattr(vlan, "name", None) or f"VLAN {vlan.id}"
+            for vlan in vlans
+            if vlan and hasattr(vlan, "id")
+        ]
+        self._attr_native_value = len(self._vlan_list)
         self.async_write_ha_state()

--- a/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
@@ -63,6 +63,8 @@ class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity)
 
         count = 0
         for client in self.coordinator.data["clients"]:
+            if not isinstance(client, dict):
+                continue
             if client.get("deviceType") == self._device_type:
                 count += 1
         return count

--- a/custom_components/meraki_ha/sensor/uplink_performance.py
+++ b/custom_components/meraki_ha/sensor/uplink_performance.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # --- Constants for metrics and units ---
-# Using a dict to map user-friendly metric names to Meraki API keys and Home Assistant units/device classes.
+# Using a dict to map user-friendly metric names to Meraki API keys
+# and Home Assistant units/device classes.
 # This centralizes configuration and makes the __init__ method cleaner.
 METRIC_MAPPING: dict[str, dict[str, Any]] = {
     "latency": {
@@ -61,7 +62,7 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
         self,
         coordinator: MerakiMainCoordinator,
         device: MerakiDevice,
-        config_entry: ConfigEntry,  # Kept for consistency, though not directly used here
+        config_entry: ConfigEntry,  # Kept for consistency
         interface: str,
         metric: Literal[
             "latency", "jitter", "lossPercent"
@@ -77,7 +78,8 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
                 device.name,
             )
             raise ValueError(
-                f"Device serial is required for uplink performance sensor (Device: {device.name})"
+                f"Device serial is required for uplink performance sensor (Device: "
+                f"{device.name})"
             )
         self._device_serial = device.serial
         self._interface = interface
@@ -86,7 +88,8 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
         metric_details = METRIC_MAPPING.get(metric)
         if not metric_details:
             _LOGGER.error(
-                "Unsupported uplink performance metric: %s for device %s. Supported: %s",
+                "Unsupported uplink performance metric: %s for device %s. "
+                "Supported: %s",
                 metric,
                 device.name,
                 ", ".join(METRIC_MAPPING.keys()),
@@ -120,11 +123,13 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
         interface: str,
         metric_api_key: str,
     ) -> float | None:
-        """
-        Helper to find and parse the metric value for a specific uplink interface.
+        """Find and parse the metric value for a specific uplink interface.
+
         Encapsulates the iteration and type conversion logic.
         """
         for uplink in uplinks:
+            if not isinstance(uplink, dict):
+                continue
             if uplink.get("interface") == interface:
                 value = uplink.get(metric_api_key)
                 if value is not None:
@@ -132,7 +137,8 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
                         return float(value)
                     except (ValueError, TypeError):
                         _LOGGER.debug(
-                            "Could not convert uplink value '%s' to float for interface '%s', metric '%s' on entity '%s'. "
+                            "Could not convert uplink value '%s' to float for "
+                            "interface '%s', metric '%s' on entity '%s'. "
                             "This may indicate unexpected data format from Meraki API.",
                             value,
                             interface,
@@ -142,7 +148,8 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
                         return None  # Value found but invalid type
                 else:
                     _LOGGER.debug(
-                        "Uplink metric '%s' value is None for interface '%s' on entity '%s'.",
+                        "Uplink metric '%s' value is None for interface '%s' "
+                        "on entity '%s'.",
                         metric_api_key,
                         interface,
                         self.name,
@@ -161,7 +168,8 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
         device = self.coordinator.get_device(self._device_serial)
         if not device or not device.uplinks:
             _LOGGER.debug(
-                "No device or no uplink data found for serial %s. Setting state to None for %s.",
+                "No device or no uplink data found for serial %s. "
+                "Setting state to None for %s.",
                 self._device_serial,
                 self.name,
             )
@@ -174,7 +182,8 @@ class MerakiUplinkPerformanceSensor(MerakiSensor):
             metric_api_key=self._metric_api_key,
         )
 
-        # If after attempting to get the value, it's still None, log informative message.
+        # If after attempting to get the value, it's still None,
+        # log informative message.
         if self._attr_native_value is None:
             _LOGGER.debug(
                 "Final native value for '%s' on interface '%s' for device %s is None. "

--- a/custom_components/meraki_ha/switch/builders/camera.py
+++ b/custom_components/meraki_ha/switch/builders/camera.py
@@ -34,6 +34,8 @@ def _build_camera_entities(
     entities: list[SwitchEntity] = []
     devices = data.get("devices", [])
     for device_info in devices:
+        if not hasattr(device_info, "product_type"):
+            continue
         entity = _create_camera_analytics_switch(
             coordinator, device_info, added_entities
         )

--- a/custom_components/meraki_ha/switch/builders/mt40.py
+++ b/custom_components/meraki_ha/switch/builders/mt40.py
@@ -42,6 +42,8 @@ def _build_mt40_entities(
     entities: list[SwitchEntity] = []
     devices = data.get("devices", [])
     for device_info in devices:
+        if not hasattr(device_info, "model"):
+            continue
         entity = _create_mt40_outlet_switch(
             coordinator, device_info, config_entry, added_entities, meraki_client
         )

--- a/custom_components/meraki_ha/switch/builders/ssid.py
+++ b/custom_components/meraki_ha/switch/builders/ssid.py
@@ -40,6 +40,8 @@ def _build_ssid_entities(
     entities: list[SwitchEntity] = []
     ssids = data.get("ssids", [])
     for ssid in ssids:
+        if not isinstance(ssid, dict):
+            continue
         entities.extend(
             _build_ssid_pair(coordinator, data, config_entry, ssid, added_entities)
         )

--- a/custom_components/meraki_ha/switch/builders/vlan.py
+++ b/custom_components/meraki_ha/switch/builders/vlan.py
@@ -59,6 +59,8 @@ def _create_vlan_entities(
     """Create VLAN entities for a network."""
     entities: list[SwitchEntity] = []
     for vlan in vlans:
+        if not vlan or not hasattr(vlan, "id"):
+            continue
         vlan_id = getattr(vlan, "id", None)
         if not vlan_id:
             continue

--- a/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
@@ -87,6 +87,8 @@ class MerakiSSIDBaseSwitch(MerakiEntity, SwitchEntity):
         if not self.coordinator.data or "ssids" not in self.coordinator.data:
             return None
         for ssid in self.coordinator.data["ssids"]:
+            if not isinstance(ssid, dict):
+                continue
             if ssid.get("networkId") == self._network_id and str(
                 ssid.get("number")
             ) == str(self._ssid_number):

--- a/custom_components/meraki_ha/switch/vlan_dhcp.py
+++ b/custom_components/meraki_ha/switch/vlan_dhcp.py
@@ -57,6 +57,8 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
         """Handle updated data from the coordinator."""
         vlans = self.coordinator.data.get("vlans", {}).get(self._network_id, [])
         for vlan in vlans:
+            if not vlan or not hasattr(vlan, "id"):
+                continue
             if vlan.id == self._vlan.id:
                 self._vlan = vlan
                 break


### PR DESCRIPTION
This PR performs a global defensive audit of the Meraki integration to address intermittent crashes caused by unexpected data types in the Home Assistant coordinator. 

Recent observations showed that the Meraki API (or the parsing layer) can sometimes store `None` or string values in data structures where the integration expects dictionaries or model objects (specifically in `clients`, `devices`, `switch_ports`, `ssids`, and `vlans`). 

Changes:
- Added `isinstance(item, dict)` or `if not item: continue` guards to approximately 20 iteration loops.
- Updated list comprehensions in `poe_usage.py`, `vlans_list.py`, `switch_client_count.py`, and `ap_client_count.py` with defensive filters.
- Standardized use of `getattr(obj, 'attr', default)` in `vlans_list.py` and `switch_port.py` for safer property access.
- Verified all changes against the existing test suite, ensuring no regressions in client tracking, uplink performance, or device status reporting.
- Cleaned up `ruff` formatting and E501 line length violations in affected modules.

Fixes #2182

---
*PR created automatically by Jules for task [5904571883475844560](https://jules.google.com/task/5904571883475844560) started by @brewmarsh*