### PR TITLE
Harden coordinator data iterations

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/appliance_port.py
@@ -67,7 +67,13 @@ class AppliancePortBinarySensor(CoordinatorEntity, BinarySensorEntity):
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device
-            for port in device.appliance_ports:
+            appliance_ports = getattr(device, "appliance_ports", [])
+            if not isinstance(appliance_ports, list):
+                return
+
+            for port in appliance_ports:
+                if not hasattr(port, "number"):
+                    continue
                 if port.number == self._port.number:
                     self._port = port
                     self.async_write_ha_state()

--- a/custom_components/meraki_ha/binary_sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/switch_port.py
@@ -59,7 +59,9 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device
-            ports = device.switch_ports or device.appliance_ports or []
+            switch_ports = getattr(device, "switch_ports", [])
+            appliance_ports = getattr(device, "appliance_ports", [])
+            ports = (switch_ports if isinstance(switch_ports, list) else []) or (appliance_ports if isinstance(appliance_ports, list) else [])
             for port_data in ports:
                 if port_data is None or isinstance(port_data, str):
                     continue

--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -114,8 +114,14 @@ class NetworkHandler(BaseHandler):
 
         from ...sensor.client.status import MerakiClientStatusSensor
 
-        clients = self._coordinator.data.get("clients", [])
-        for client in filter(lambda c: c.get("networkId") == network.id, clients):
+        clients = self._coordinator.data.get("clients")
+        if not isinstance(clients, list):
+            return
+
+        for client in filter(
+            lambda c: isinstance(c, dict) and c.get("networkId") == network.id,
+            clients,
+        ):
             yield MerakiClientStatusSensor(
                 self._coordinator,
                 client,
@@ -170,8 +176,11 @@ class NetworkHandler(BaseHandler):
         if network.id is None:
             return
 
-        vlans = self._coordinator.data.get("vlans", {}).get(network.id, [])
-        if not vlans:
+        vlans_data = self._coordinator.data.get("vlans", {})
+        if not isinstance(vlans_data, dict):
+            return
+        vlans = vlans_data.get(network.id, [])
+        if not vlans or not isinstance(vlans, list):
             _LOGGER.debug("No VLANs found for network %s", network.id)
             return
 
@@ -181,6 +190,8 @@ class NetworkHandler(BaseHandler):
         yield VlansListSensor(self._coordinator, self._config_entry, network)
 
         for vlan in vlans:
+            if not vlan:
+                continue
             yield MerakiVLANStatusSensor(
                 self._coordinator,
                 self._config_entry,

--- a/custom_components/meraki_ha/discovery/handlers/switch.py
+++ b/custom_components/meraki_ha/discovery/handlers/switch.py
@@ -33,7 +33,14 @@ class SwitchHandler(BaseHandler):
 
         # Discover Switch Device entities
         if self._config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, True):
-            for device in self._coordinator.data.get("devices", []):
+            devices = self._coordinator.data.get("devices", [])
+            if not isinstance(devices, list):
+                return
+
+            for device in devices:
+                if not hasattr(device, "product_type"):
+                    continue
+
                 # Add Exclusion Logic
                 if device.product_type == "appliance" or (
                     device.model

--- a/custom_components/meraki_ha/discovery/handlers/wireless.py
+++ b/custom_components/meraki_ha/discovery/handlers/wireless.py
@@ -64,7 +64,13 @@ class WirelessHandler(BaseHandler):
         if not self._config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, True):
             return
 
-        for device in self._coordinator.data.get("devices", []):
+        devices = self._coordinator.data.get("devices", [])
+        if not isinstance(devices, list):
+            return
+
+        for device in devices:
+            if not hasattr(device, "product_type"):
+                continue
             if device.product_type == "wireless":
                 # Client Count per AP
                 yield MerakiAPClientCountSensor(
@@ -87,8 +93,12 @@ class WirelessHandler(BaseHandler):
         if not self._config_entry.options.get(CONF_ENABLE_SSID_SENSORS, True):
             return
 
-        for ssid in self._coordinator.data.get("ssids", []):
-            if "networkId" not in ssid or "number" not in ssid:
+        ssids = self._coordinator.data.get("ssids", [])
+        if not isinstance(ssids, list):
+            return
+
+        for ssid in ssids:
+            if not isinstance(ssid, dict) or "networkId" not in ssid or "number" not in ssid:
                 continue
 
             rf_profile = self._get_rf_profile(ssid)
@@ -134,10 +144,9 @@ class WirelessHandler(BaseHandler):
 
     def _get_rf_profile(self, ssid: dict[str, Any]) -> dict[str, Any] | None:
         """Find the RF profile for this SSID's network."""
-        if self._coordinator.data and self._coordinator.data.get("rf_profiles"):
-            network_rf_profiles = self._coordinator.data["rf_profiles"].get(
-                ssid["networkId"]
-            )
+        rf_profiles = self._coordinator.data.get("rf_profiles") if self._coordinator.data else None
+        if isinstance(rf_profiles, dict):
+            network_rf_profiles = rf_profiles.get(ssid["networkId"])
             if network_rf_profiles:
                 return next(iter(network_rf_profiles), None)
         return None

--- a/custom_components/meraki_ha/sensor/client_tracker.py
+++ b/custom_components/meraki_ha/sensor/client_tracker.py
@@ -52,8 +52,9 @@ class ClientTrackerDeviceSensor(CoordinatorEntity, SensorEntity):
 
     def _update_state(self) -> None:
         """Update the state of the sensor."""
-        if self.coordinator.data and self.coordinator.data.get("clients"):
-            self._attr_native_value = len(self.coordinator.data["clients"])
+        clients = self.coordinator.data.get("clients") if self.coordinator.data else None
+        if isinstance(clients, list):
+            self._attr_native_value = len(clients)
         else:
             self._attr_native_value = 0
 
@@ -95,8 +96,9 @@ class MerakiClientSensor(CoordinatorEntity, SensorEntity):
         """Update the state of the sensor."""
         is_online = False
         client_info = {}
-        if self.coordinator.data and self.coordinator.data.get("clients"):
-            for client in self.coordinator.data["clients"]:
+        clients = self.coordinator.data.get("clients") if self.coordinator.data else None
+        if isinstance(clients, list):
+            for client in clients:
                 if not isinstance(client, dict):
                     continue
                 if client.get("mac") == self._client_mac:

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -66,7 +66,13 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
         device = self.coordinator.get_device(self._device.serial)
         if device:
             self._device = device
-            for port in device.appliance_ports:
+            appliance_ports = getattr(device, "appliance_ports", [])
+            if not isinstance(appliance_ports, list):
+                return
+
+            for port in appliance_ports:
+                if not hasattr(port, "number"):
+                    continue
                 if port.number == self._port.number:
                     self._port = port
                     self.async_write_ha_state()

--- a/custom_components/meraki_ha/sensor/device/connected_clients.py
+++ b/custom_components/meraki_ha/sensor/device/connected_clients.py
@@ -71,14 +71,16 @@ class MerakiDeviceConnectedClientsSensor(MerakiSensor):
         if product_type in ("appliance", "cellularGateway"):
             network_id = device.network_id
             all_clients = self.coordinator.data.get("clients", [])
-            if not all_clients:
+            if not all_clients or not isinstance(all_clients, list):
                 self._attr_native_value = 0
                 return
 
             network_clients = [
                 c
                 for c in all_clients
-                if c.get("networkId") == network_id and c.get("status") == "Online"
+                if isinstance(c, dict)
+                and c.get("networkId") == network_id
+                and c.get("status") == "Online"
             ]
             self._attr_native_value = len(network_clients)
         # For other devices (switches, APs), use the direct per-device client list.

--- a/custom_components/meraki_ha/sensor/device/switch_poe.py
+++ b/custom_components/meraki_ha/sensor/device/switch_poe.py
@@ -61,12 +61,20 @@ class MerakiSwitchPoESensor(CoordinatorEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        for device in self.coordinator.data.get("devices", []):
+        devices = self.coordinator.data.get("devices", [])
+        if not isinstance(devices, list):
+            return
+
+        for device in devices:
             if not hasattr(device, "serial"):
                 continue
             if device.serial == self._device.serial:
                 self._device = device
-                for port in self._device.switch_ports:
+                switch_ports = getattr(self._device, "switch_ports", [])
+                if not isinstance(switch_ports, list):
+                    break
+
+                for port in switch_ports:
                     if not isinstance(port, dict):
                         continue
                     port_id = self._port.get("portId") or self._port.get("number")

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -102,11 +102,19 @@ class MerakiSwitchPortBaseSensor(CoordinatorEntity, SensorEntity, ABC):
             )
             return None, None
 
-        for device in self.coordinator.data.get("devices", []):
+        devices = self.coordinator.data.get("devices", [])
+        if not isinstance(devices, list):
+            return None, None
+
+        for device in devices:
             if not hasattr(device, "serial"):
                 continue
             if device.serial == self._device.serial:
-                for port in device.switch_ports:
+                switch_ports = getattr(device, "switch_ports", [])
+                if not isinstance(switch_ports, list):
+                    return device, None
+
+                for port in switch_ports:
                     if not isinstance(port, dict):
                         continue
                     port_id_candidate = self._get_port_id_from_data(port)

--- a/custom_components/meraki_ha/sensor/network/network_clients.py
+++ b/custom_components/meraki_ha/sensor/network/network_clients.py
@@ -46,6 +46,8 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return the state of the sensor."""
+        if not self._network_id:
+            return 0
         return self._network_control_service.get_network_client_count(
             str(self._network_id)
         )

--- a/custom_components/meraki_ha/sensor/network/ssid_client_count.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_client_count.py
@@ -40,6 +40,10 @@ class MerakiSSIDClientCountSensor(MerakiSSIDBaseSensor):
         elif self.coordinator.data and "clients" in self.coordinator.data:
             # Fallback to manual calculation if clientCount not in ssid_data
             all_clients = self.coordinator.data.get("clients", [])
+            if not isinstance(all_clients, list):
+                self._attr_native_value = 0
+                return
+
             ssid_name = (
                 ssid_data.get("name")
                 if ssid_data
@@ -52,7 +56,8 @@ class MerakiSSIDClientCountSensor(MerakiSSIDBaseSensor):
             self._attr_native_value = sum(
                 1
                 for client in all_clients
-                if client.get("networkId") == self._network_id
+                if isinstance(client, dict)
+                and client.get("networkId") == self._network_id
                 and client.get("ssid") == ssid_name
                 and str(client.get("status", "")).lower() == "online"
             )

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -42,7 +42,13 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         if not self._network:
             return
-        vlans = self.coordinator.data.get("vlans", {}).get(self._network.id, [])
+        vlans_data = self.coordinator.data.get("vlans", {})
+        if not isinstance(vlans_data, dict):
+            return
+        vlans = vlans_data.get(self._network.id, [])
+        if not isinstance(vlans, list):
+            return
+
         self._vlan_list = [
             getattr(vlan, "name", None) or f"VLAN {vlan.id}"
             for vlan in vlans

--- a/custom_components/meraki_ha/services/network_control_service.py
+++ b/custom_components/meraki_ha/services/network_control_service.py
@@ -31,13 +31,17 @@ class NetworkControlService:
 
     def get_network_client_count(self, network_id: str) -> int:
         """Get the number of clients on a specific network."""
-        if not self._coordinator.data or not self._coordinator.data.get("clients"):
+        if not self._coordinator.data:
+            return 0
+
+        clients = self._coordinator.data.get("clients")
+        if not isinstance(clients, list):
             return 0
 
         return len(
             [
                 client
-                for client in self._coordinator.data["clients"]
-                if client.get("networkId") == network_id
+                for client in clients
+                if isinstance(client, dict) and client.get("networkId") == network_id
             ]
         )

--- a/custom_components/meraki_ha/switch/vlan_dhcp.py
+++ b/custom_components/meraki_ha/switch/vlan_dhcp.py
@@ -55,7 +55,13 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        vlans = self.coordinator.data.get("vlans", {}).get(self._network_id, [])
+        vlans_data = self.coordinator.data.get("vlans", {})
+        if not isinstance(vlans_data, dict):
+            return
+        vlans = vlans_data.get(self._network_id, [])
+        if not isinstance(vlans, list):
+            return
+
         for vlan in vlans:
             if not vlan or not hasattr(vlan, "id"):
                 continue

--- a/custom_components/meraki_ha/webhook.py
+++ b/custom_components/meraki_ha/webhook.py
@@ -188,7 +188,13 @@ def _handle_ap_went_down_alert(data: dict, coordinator: Any) -> None:
     if not device_serial or not coordinator.data:
         return
 
-    for i, device in enumerate(coordinator.data.get("devices", [])):
+    devices = coordinator.data.get("devices", [])
+    if not isinstance(devices, list):
+        return
+
+    for i, device in enumerate(devices):
+        if not hasattr(device, "serial"):
+            continue
         if device.serial == device_serial:
             _LOGGER.info(
                 "Device %s reported as down via webhook",
@@ -206,7 +212,13 @@ def _handle_client_connectivity_changed_alert(data: dict, coordinator: Any) -> N
     if not client_mac or not coordinator.data:
         return
 
-    for i, client in enumerate(coordinator.data.get("clients", [])):
+    clients = coordinator.data.get("clients", [])
+    if not isinstance(clients, list):
+        return
+
+    for i, client in enumerate(clients):
+        if not isinstance(client, dict):
+            continue
         if client.get("mac") == client_mac:
             _LOGGER.info(
                 "Client %s connectivity changed via webhook",


### PR DESCRIPTION
This change adds defensive type guards when iterating over coordinator data (clients, devices, vlans, appliance_ports) to prevent potential crashes if the API returns unexpected data formats. It covers discovery handlers, sensors, and services, specifically addressing areas identified as high risk for "False Green" deployments.

Fixes #2189

---
*PR created automatically by Jules for task [6480575350951692227](https://jules.google.com/task/6480575350951692227) started by @brewmarsh*