### PR TITLE
Refactor CI log extraction to use direct filesystem access

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -104,18 +104,12 @@ jobs:
       - name: Audit logs for errors
         id: audit_logs
         shell: bash
-        env:
-          HA_URL: ${{ secrets.HA_STAGING_URL }}
-          HA_TOKEN: ${{ secrets.HA_STAGING_TOKEN }}
         run: |
           echo "Initiating 90s discovery wait cycle..."
           sleep 90
 
-          echo "Fetching logs from Home Assistant API..."
-          # Use curl with --retry 3 as requested
-          curl --retry 3 -s -f -H "Authorization: Bearer $HA_TOKEN" \
-               -H "Content-Type: application/json" \
-               "$HA_URL/api/error_log" > full_ha_log.txt || { echo "Failed to fetch logs"; exit 1; }
+          echo "Extracting logs from local Home Assistant config directory..."
+          cat "$HA_CONFIG_DIR/home-assistant.log" > full_ha_log.txt || { echo "Failed to read local log file"; exit 1; }
 
           # Multi-Stage Audit
           # Stage 1: Search for string literal Traceback (most recent call last):


### PR DESCRIPTION
The CI pipeline's log extraction step was failing due to silent errors in the `curl` command and fragility in the network-based retrieval of Home Assistant logs. This PR refactors the 'Audit logs for errors' step in `.github/workflows/deploy-staging.yaml` to read the log file directly from the filesystem, which is a more reliable approach in this environment.

Key changes:
- Replaced `curl --retry 3 ...` with `cat "$HA_CONFIG_DIR/home-assistant.log" > full_ha_log.txt`.
- Updated the step's descriptive output to reflect the move to local filesystem extraction.
- Cleaned up the `env` block by removing `HA_URL` and `HA_TOKEN` secrets that are no longer needed for this step.
- Validated YAML syntax and verified the logic remains consistent with the multi-stage audit that follows.

Fixes #2194

---
*PR created automatically by Jules for task [8474937535323971145](https://jules.google.com/task/8474937535323971145) started by @brewmarsh*