### PR TITLE
chore: remove obsolete TODO comments from test_config_flow.py

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,14 +1,3 @@
-# TODO:
-# SETUP-P0-01: Test successful setup with valid API key and organization ID
-# - Mock the Meraki API client to return valid data.
-# - Trigger the config flow with the mock client.
-# - Assert that the flow completes successfully and a config entry is created.
-#
-# SETUP-P0-02: Test setup failure with invalid API key
-# - Mock the Meraki API client to raise an AuthenticationError.
-# - Trigger the config flow.
-# - Assert that the flow shows an "invalid_auth" error.
-
 """Test the Meraki HA config flow."""
 
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
The tests described in the `TODO` block at the top of `tests/test_config_flow.py` (SETUP-P0-01 and SETUP-P0-02) were already implemented in the file (`test_form` and `test_form_invalid_auth`).

This change simply removes the obsolete comments to keep the test file clean. I've also verified that the tests continue to pass.

---
*PR created automatically by Jules for task [4724252413542504634](https://jules.google.com/task/4724252413542504634) started by @brewmarsh*