### PR TITLE
Fix missing tree-sitter dependency in agent scorecard workflow

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install tool
-        run: pip install git+https://github.com/brewmarsh/agent-readiness-scorecard.git
+        run: pip install git+https://github.com/brewmarsh/agent-readiness-scorecard.git tree-sitter
 
       - name: Run agent scorecard (diff mode)
         continue-on-error: true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -120,6 +120,7 @@ termcolor==3.2.0
 text-unidecode==1.3
 toml==0.10.2
 tqdm
+tree-sitter
 types-aiofiles==25.1.0.20251011
 typing-inspection==0.4.2
 typing_extensions==4.15.0


### PR DESCRIPTION
I have fixed the `ModuleNotFoundError: No module named 'tree_sitter'` error that was causing the Agent Readiness scorecard workflow to crash.

Changes implemented:
1.  Modified `.github/workflows/agent-readiness.yaml` to explicitly include `tree-sitter` in the `Install tool` step.
2.  Updated `requirements_dev.txt` to include `tree-sitter`, ensuring that development dependencies are properly tracked and synchronized with the CI environment.

Verified the changes by reading the modified files and running the project's check suite.

Here is the refactored workflow file:

```yaml
name: Agent readiness scorecard

on:
  pull_request:
    branches:
      - beta
      - main
  workflow_dispatch:
  schedule:
    - cron: '0 2 * * *'

jobs:
  readiness-score:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      pull-requests: write
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Set up Python 3.11
        uses: actions/setup-python@v5
        with:
          python-version: '3.11'

      - name: Install tool
        run: pip install git+https://github.com/brewmarsh/agent-readiness-scorecard.git tree-sitter

      - name: Run agent scorecard (diff mode)
        continue-on-error: true
        run: |
          # Ensure we have the base branch reference locally
          git fetch origin ${{ github.base_ref || 'main' }}
          # Run diff against the PR target (e.g. main or beta)
          # Fallback to 'main' if not in a PR
          TARGET_BRANCH="origin/${{ github.base_ref || 'main' }}"
          echo "Running agent scorecard against $TARGET_BRANCH..."
          # Create an initial report in case the tool fails
          echo "Agent scorecard run failed or produced no output." > readiness_report.md
          agent-score score custom_components/meraki_ha --diff --diff-base $TARGET_BRANCH --report readiness_report.md

      - name: Upload readiness report
        if: always()
        uses: actions/upload-artifact@v4
        with:
          name: readiness-report
          path: readiness_report.md

      - name: Post comment to PR
        if: always() && github.event_name == 'pull_request'
        continue-on-error: true
        uses: marocchino/sticky-pull-request-comment@v2
        with:
          path: readiness_report.md
```


Fixes #2206

---
*PR created automatically by Jules for task [2603906781073227681](https://jules.google.com/task/2603906781073227681) started by @brewmarsh*