### PR TITLE
Implement Adaptive Back-off for Meraki API

### DIFF
--- a/custom_components/meraki_ha/coordinators/base.py
+++ b/custom_components/meraki_ha/coordinators/base.py
@@ -109,3 +109,13 @@ class MerakiBaseCoordinator(DataUpdateCoordinator[T], Generic[T]):
     def get_ssid(self, network_id: str, ssid_number: int) -> dict[str, Any] | None:
         """Get SSID data by network ID and SSID number."""
         return self.ssids_by_network_and_number.get((network_id, ssid_number))
+
+    def apply_polling_update(self, updated: bool) -> None:
+        """Update the coordinator's update interval if the manager changed it."""
+        if updated:
+            self.update_interval = self.polling_manager.update_interval
+            _LOGGER.debug(
+                "Coordinator %s update interval changed to %s",
+                self.name,
+                self.update_interval,
+            )

--- a/custom_components/meraki_ha/coordinators/device.py
+++ b/custom_components/meraki_ha/coordinators/device.py
@@ -6,6 +6,8 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
 from .base import MerakiBaseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,8 +38,20 @@ class MerakiDeviceCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
 
+            # Record success and potentially reset interval
+            updated = self.polling_manager.record_success()
+            self.apply_polling_update(updated)
+
             return data
         except Exception as err:
             _LOGGER.error("Error fetching Meraki device data: %s", err)
+
+            # Record failure and potentially back off
+            updated = self.polling_manager.record_failure(err)
+            self.apply_polling_update(updated)
+
+            if "429" in str(err):
+                raise UpdateFailed(f"Meraki API rate limit: {err}") from err
+
             data, _ = self.update_processor.process_failure(err, self.last_successful_data)
             return data

--- a/custom_components/meraki_ha/coordinators/main.py
+++ b/custom_components/meraki_ha/coordinators/main.py
@@ -6,6 +6,8 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
 from .base import MerakiBaseCoordinator
 
 if TYPE_CHECKING:
@@ -30,13 +32,24 @@ class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint, apply filters, and handle exceptions."""
         try:
-            return await self._execute_update_cycle()
+            data = await self._execute_update_cycle()
+
+            # Record success and potentially reset interval
+            updated = self.polling_manager.record_success()
+            self.apply_polling_update(updated)
+
+            return data
         except Exception as err:
-            data, interval_changed = self.update_processor.process_failure(
-                err, self.last_successful_data
-            )
-            if interval_changed:
-                self.update_interval = self.polling_manager.update_interval
+            _LOGGER.error("Error fetching Meraki main data: %s", err)
+
+            # Record failure and potentially back off
+            updated = self.polling_manager.record_failure(err)
+            self.apply_polling_update(updated)
+
+            if "429" in str(err):
+                raise UpdateFailed(f"Meraki API rate limit: {err}") from err
+
+            data, _ = self.update_processor.process_failure(err, self.last_successful_data)
             return data
 
     async def _execute_update_cycle(self) -> dict[str, Any]:

--- a/custom_components/meraki_ha/coordinators/sensor.py
+++ b/custom_components/meraki_ha/coordinators/sensor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
 from .base import MerakiBaseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,8 +39,21 @@ class MerakiSensorCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                     _,
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
+
+            # Record success and potentially reset interval
+            updated = self.polling_manager.record_success()
+            self.apply_polling_update(updated)
+
             return data
         except Exception as err:
             _LOGGER.error("Error fetching Meraki sensor data: %s", err)
+
+            # Record failure and potentially back off
+            updated = self.polling_manager.record_failure(err)
+            self.apply_polling_update(updated)
+
+            if "429" in str(err):
+                raise UpdateFailed(f"Meraki API rate limit: {err}") from err
+
             data, _ = self.update_processor.process_failure(err, self.last_successful_data)
             return data

--- a/custom_components/meraki_ha/core/coordinator_helpers/update_processor.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/update_processor.py
@@ -131,13 +131,10 @@ class UpdateProcessor:
         This method acts as an orchestrator, delegating specific tasks to
         sub-methods to maintain a low Agent Cognitive Load (ACL).
         """
-        # 1. Update polling metrics and check for recovery via PollingManager
-        interval_changed = self._handle_interval_recovery()
-
-        # 2. Process the raw data (previously in MerakiDataProcessor)
+        # Process the raw data (previously in MerakiDataProcessor)
         processed_data = await self.async_process(data, current_data)
 
-        # 3. Extract results from the processed payload
+        # Extract results from the processed payload
         devices_by_serial = processed_data["devices_by_serial"]
         networks_by_id = processed_data["networks_by_id"]
         ssids_by_network_and_number = processed_data["ssids_by_network_and_number"]
@@ -146,7 +143,7 @@ class UpdateProcessor:
             devices_by_serial,
             networks_by_id,
             ssids_by_network_and_number,
-            interval_changed,
+            False,  # interval_changed is now handled in _async_update_data
         )
 
     async def async_process(
@@ -232,7 +229,6 @@ class UpdateProcessor:
 
         Returns the data to use and whether the interval changed.
         """
-        interval_changed = self._handle_interval_failure(err)
         self._log_failure(err)
 
         if not last_successful_data:
@@ -243,7 +239,7 @@ class UpdateProcessor:
                 raise err
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
-        return last_successful_data, interval_changed
+        return last_successful_data, False  # interval_changed is now handled in _async_update_data
 
     def _handle_interval_recovery(self) -> bool:
         """Handle polling interval recovery logic and return if interval changed."""

--- a/custom_components/meraki_ha/core/managers.py
+++ b/custom_components/meraki_ha/core/managers.py
@@ -74,16 +74,20 @@ class PollingManager:
         error_str = str(error)
         if "429" in error_str:
             old_interval = self._current_interval
-            self._current_interval = max(
-                self._current_interval * 2, timedelta(seconds=60)
-            )
-            _LOGGER.warning(
-                "Meraki API rate limit detected (429). Entering cooldown state. "
-                "Update interval increased from %s to %s",
-                old_interval,
-                self._current_interval,
-            )
-            return True
+            # Double the interval, capped at 10 minutes (600 seconds)
+            new_seconds = min(old_interval.total_seconds() * 2, 600)
+            # Ensure it's at least 60 seconds if it was somehow lower
+            new_seconds = max(new_seconds, 60)
+            self._current_interval = timedelta(seconds=new_seconds)
+
+            if self._current_interval != old_interval:
+                _LOGGER.warning(
+                    "Meraki API rate limit detected (429). Entering cooldown state. "
+                    "Update interval increased from %s to %s",
+                    old_interval,
+                    self._current_interval,
+                )
+                return True
         return False
 
     def get_success_rate(self) -> float:

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -108,6 +108,7 @@
 | :----------------------------------------------------------------------------------------- | :------- |
 | The integration should handle API errors, network issues, and other exceptions gracefully. | Included |
 | Logging should be used for debugging and error reporting.                                  | Included |
+| The integration must implement an adaptive back-off algorithm when 429 errors are detected. | Included |
 
 \*\*Data Coordination
 

--- a/tests/test_adaptive_polling.py
+++ b/tests/test_adaptive_polling.py
@@ -30,11 +30,13 @@ def coordinator(hass):
     # Patched to reflect the new internal module structure
     with (
         patch("custom_components.meraki_ha.coordinators.base.ApiClient"),
-        patch("custom_components.meraki_ha.coordinators.base.DataFetchManager"),
+        patch("custom_components.meraki_ha.coordinators.base.DataFetchManager") as mock_fetch_manager_class,
     ):
+        mock_fetch_manager = mock_fetch_manager_class.return_value
+        mock_fetch_manager.get_sensor_data = AsyncMock()
+        mock_fetch_manager.get_all_data = mock_fetch_manager.get_sensor_data
+
         coord = MerakiDataCoordinator(hass=hass, entry=entry)
-        # Mock get_all_data on the instance created by the mock fetch manager
-        coord.data_fetch_manager.get_all_data = AsyncMock()
         yield coord
 
 
@@ -48,12 +50,15 @@ async def test_adaptive_polling_429(coordinator):
     coordinator.last_successful_data = {"some": "data"}  # Avoid raising UpdateFailed
 
     # Mock 429 error
-    coordinator.data_fetch_manager.get_all_data.side_effect = Exception(
+    coordinator.data_fetch_manager.get_sensor_data.side_effect = Exception(
         "meraki.exceptions.APIError: 429 Too Many Requests"
     )
 
     # Trigger update
-    await coordinator._async_update_data()
+    try:
+        await coordinator._async_update_data()
+    except Exception:
+        pass
 
     # Interval should have doubled (30 * 2 = 60)
     assert coordinator.update_interval == timedelta(seconds=60)
@@ -61,7 +66,10 @@ async def test_adaptive_polling_429(coordinator):
     assert False in coordinator.polling_manager.success_history
 
     # Another 429
-    await coordinator._async_update_data()
+    try:
+        await coordinator._async_update_data()
+    except Exception:
+        pass
     assert coordinator.update_interval == timedelta(seconds=120)
 
 
@@ -75,8 +83,8 @@ async def test_adaptive_polling_recovery(coordinator):
     coordinator.polling_manager._consecutive_successes = 0
 
     # Success 1
-    coordinator.data_fetch_manager.get_all_data.side_effect = None
-    coordinator.data_fetch_manager.get_all_data.return_value = {"success": True}
+    coordinator.data_fetch_manager.get_sensor_data.side_effect = None
+    coordinator.data_fetch_manager.get_sensor_data.return_value = {"success": True}
     await coordinator._async_update_data()
     assert coordinator.update_interval == timedelta(seconds=120)
     assert coordinator.polling_manager.consecutive_successes == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -29,7 +29,8 @@ def mock_api_client():
 def mock_data_fetch_manager():
     """Fixture for a mocked DataFetchManager."""
     manager = MagicMock()
-    manager.get_all_data = AsyncMock()
+    manager.get_sensor_data = AsyncMock()
+    manager.get_all_data = manager.get_sensor_data
     return manager
 
 


### PR DESCRIPTION
This change implements an adaptive back-off algorithm for the Meraki API coordinators to better handle rate-limiting (HTTP 429) errors.

Key changes:
1.  **PollingManager Enhancement**: The `PollingManager` now doubles the `update_interval` when a 429 error is detected, with a maximum cap of 10 minutes (600 seconds). It also tracks consecutive successes and resets the interval to the default baseline after 3 successful polls.
2.  **Coordinator Integration**: The `MerakiBaseCoordinator` now includes an `apply_polling_update` method to synchronize the coordinator's `update_interval` with the manager's state. All specific coordinators (`Main`, `Device`, `Sensor`) have been updated to catch 429 errors, trigger the back-off, and raise `UpdateFailed`.
3.  **Refactoring**: Logic for handling interval changes was moved from the `UpdateProcessor` directly into the coordinators' `_async_update_data` method for better visibility and control.
4.  **Test Updates**: Tests in `tests/test_adaptive_polling.py` and `tests/test_coordinator.py` were updated to match the new implementation and fix mocking issues where `AsyncMock` was expected.
5.  **Requirements Update**: `docs/REQUIREMENTS.md` was updated to reflect the new adaptive back-off requirement.

Fixes #2197

---
*PR created automatically by Jules for task [15419993346712860164](https://jules.google.com/task/15419993346712860164) started by @brewmarsh*