### PR TITLE
Add IPSK Native Service Action

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -32,6 +32,7 @@ from .frontend import async_register_frontend, async_remove_frontend
 from .helpers.migrations import async_cleanup_ghost_devices, async_migrate_entities
 from .services.camera_service import CameraService
 from .services.device_control_service import DeviceControlService
+from .services import async_setup_services
 from .services.ipsk_manager import IPSKManager
 from .services.manager import ServicesManager
 from .services.network_control_service import NetworkControlService
@@ -67,6 +68,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ipsk_manager = IPSKManager(hass)
         await ipsk_manager.async_setup()
         hass.data[DOMAIN]["ipsk_manager"] = ipsk_manager
+
+    # Set up services
+    await async_setup_services(hass)
 
     # Register the static path for the custom panel
     if hass.http:

--- a/custom_components/meraki_ha/services.yaml
+++ b/custom_components/meraki_ha/services.yaml
@@ -1,5 +1,5 @@
-create_timed_access:
-  name: Create Timed Access Key
+create_guest_key:
+  name: Create Guest Key
   description: Generates a temporary Identity PSK for a Meraki SSID.
   fields:
     network_id:
@@ -16,7 +16,7 @@ create_timed_access:
         number:
           min: 0
           max: 14
-    duration:
+    duration_minutes:
       name: Duration
       description: Duration in minutes before the key is auto-deleted.
       required: true
@@ -27,11 +27,12 @@ create_timed_access:
     name:
       name: Name
       description: Name for the key (e.g., "Guest-iPad").
+      default: Guest Key
       selector:
         text:
     passphrase:
       name: Passphrase
-      description: If empty, auto-generate a secure 8-char alphanumeric string.
+      description: If empty, Meraki will auto-generate a secure passphrase.
       selector:
         text:
     group_policy_id:

--- a/custom_components/meraki_ha/services/__init__.py
+++ b/custom_components/meraki_ha/services/__init__.py
@@ -1,3 +1,78 @@
-"""Services for the Meraki integration."""
-
+"""Services for the Meraki HA integration."""
 from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.exceptions import HomeAssistantError
+
+from ..const import DOMAIN
+
+if TYPE_CHECKING:
+    from .ipsk_manager import IPSKManager
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_CREATE_GUEST_KEY = "create_guest_key"
+
+SERVICE_CREATE_GUEST_KEY_SCHEMA = vol.Schema(
+    {
+        vol.Required("network_id"): cv.string,
+        vol.Required("ssid_number"): vol.All(vol.Coerce(int), vol.Range(min=0, max=14)),
+        vol.Required("duration_minutes"): cv.positive_int,
+        vol.Optional("passphrase"): cv.string,
+        vol.Optional("name", default="Guest Key"): cv.string,
+        vol.Optional("group_policy_id"): cv.string,
+    }
+)
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services for the Meraki integration."""
+
+    async def _async_create_guest_key(call: ServiceCall) -> None:
+        """Create a guest IPSK."""
+        network_id = call.data["network_id"]
+        ssid_number = str(call.data["ssid_number"])  # Convert to str for manager
+        duration_minutes = call.data["duration_minutes"]
+        passphrase = call.data.get("passphrase")
+        name = call.data["name"]
+        group_policy_id = call.data.get("group_policy_id")
+
+        ipsk_manager: IPSKManager | None = hass.data[DOMAIN].get("ipsk_manager")
+        if not ipsk_manager:
+            raise HomeAssistantError("IPSK Manager not initialized")
+
+        # Find the config entry for the given network_id
+        config_entry_id = None
+        for entry_id, entry_data in hass.data[DOMAIN].items():
+            if not isinstance(entry_data, dict):
+                continue
+
+            # Check if this entry has the network_id
+            main_coordinator = entry_data.get("main_coordinator")
+            if main_coordinator and hasattr(main_coordinator, "networks_by_id") and network_id in main_coordinator.networks_by_id:
+                config_entry_id = entry_id
+                break
+
+        if not config_entry_id:
+            raise HomeAssistantError(f"Network ID {network_id} not found in any Meraki config entry")
+
+        await ipsk_manager.create_guest_key(
+            config_entry_id=config_entry_id,
+            network_id=network_id,
+            ssid_number=ssid_number,
+            duration_minutes=duration_minutes,
+            name=name,
+            passphrase=passphrase,
+            group_policy_id=group_policy_id,
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CREATE_GUEST_KEY,
+        _async_create_guest_key,
+        schema=SERVICE_CREATE_GUEST_KEY_SCHEMA,
+    )

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -196,6 +196,7 @@
   - [ ] **Guest Wi-Fi Password Control:** Create a `text` entity to manage the guest Wi-Fi password.
   - [x] **IPSK Lifecycle Management:** Implement a backend manager to track and reap temporary guest Identity PSKs (IPSKs) upon expiration, with persistent storage across reboots.
   - [x] **IPSK WebSocket API:** Implement a strict WebSocket API contract for IPSK management with camelCase payload keys and centralized command definitions.
+  - [x] **IPSK Native Service Action:** Expose IPSK creation functionality as a standard Home Assistant Service Action, allowing users to create timed guest keys without the custom frontend panel.
 - [x] **IPSK Native UX Overhaul:** Rebuilt the TimedAccess.tsx component to provide a native Home Assistant experience using `ha-textfield`, `ha-select`, `ha-button`, and `ha-alert` web components.
 - [ ] **Enhanced Home Security & Awareness (MV Cameras & MT Sensors):**
   - [ ] **Camera Motion Events:** Create `binary_sensor` entities for camera motion events.

--- a/tests/test_services_ipsk.py
+++ b/tests/test_services_ipsk.py
@@ -1,0 +1,130 @@
+"""Tests for Meraki IPSK Services."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.meraki_ha.const import DOMAIN
+from custom_components.meraki_ha.services import async_setup_services
+
+
+@pytest.fixture(autouse=True)
+def auto_domain_init(hass):
+    """Initialize DOMAIN data."""
+    hass.data[DOMAIN] = {}
+
+
+@pytest.fixture
+def mock_ipsk_manager(hass):
+    """Mock IPSK Manager."""
+    manager = MagicMock()
+    manager.create_guest_key = AsyncMock()
+    hass.data[DOMAIN]["ipsk_manager"] = manager
+    return manager
+
+
+@pytest.fixture
+def mock_coordinator(hass):
+    """Mock Main Coordinator."""
+    coordinator = MagicMock()
+    coordinator.networks_by_id = {"N_12345": MagicMock()}
+
+    hass.data[DOMAIN]["test_entry_id"] = {
+        "main_coordinator": coordinator
+    }
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_service_registration(hass):
+    """Test service registration."""
+    await async_setup_services(hass)
+    assert hass.services.has_service(DOMAIN, "create_guest_key")
+
+
+@pytest.mark.asyncio
+async def test_create_guest_key_service_success(hass, mock_ipsk_manager, mock_coordinator):
+    """Test successful creation of guest key via service."""
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "N_12345",
+        "ssid_number": 1,
+        "duration_minutes": 60,
+        "name": "Service Guest",
+        "passphrase": "secretpassword",
+    }
+
+    await hass.services.async_call(
+        DOMAIN, "create_guest_key", service_data, blocking=True
+    )
+
+    mock_ipsk_manager.create_guest_key.assert_called_once_with(
+        config_entry_id="test_entry_id",
+        network_id="N_12345",
+        ssid_number="1",  # Coerced to string in the callback for the manager
+        duration_minutes=60,
+        name="Service Guest",
+        passphrase="secretpassword",
+        group_policy_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_guest_key_service_invalid_network(hass, mock_ipsk_manager, mock_coordinator):
+    """Test guest key creation with invalid network ID."""
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "INVALID_NETWORK",
+        "ssid_number": 1,
+        "duration_minutes": 60,
+    }
+
+    with pytest.raises(HomeAssistantError, match="Network ID INVALID_NETWORK not found"):
+        await hass.services.async_call(
+            DOMAIN, "create_guest_key", service_data, blocking=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_guest_key_service_no_manager(hass, mock_coordinator):
+    """Test guest key creation when manager is missing."""
+    # Remove manager if it exists
+    if "ipsk_manager" in hass.data[DOMAIN]:
+        del hass.data[DOMAIN]["ipsk_manager"]
+
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "N_12345",
+        "ssid_number": 1,
+        "duration_minutes": 60,
+    }
+
+    with pytest.raises(HomeAssistantError, match="IPSK Manager not initialized"):
+        await hass.services.async_call(
+            DOMAIN, "create_guest_key", service_data, blocking=True
+        )
+
+@pytest.mark.asyncio
+async def test_create_guest_key_service_safe_iteration(hass, mock_ipsk_manager, mock_coordinator):
+    """Test that service call doesn't crash if hass.data[DOMAIN] contains non-dict objects."""
+    # Add a non-dict object to hass.data[DOMAIN] to trigger potential crash
+    hass.data[DOMAIN]["services_manager"] = MagicMock()
+
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "N_12345",
+        "ssid_number": 1,
+        "duration_minutes": 60,
+    }
+
+    # Should not raise AttributeError
+    await hass.services.async_call(
+        DOMAIN, "create_guest_key", service_data, blocking=True
+    )
+
+    assert mock_ipsk_manager.create_guest_key.called


### PR DESCRIPTION
Exposed the Meraki IPSK functionality as a native Home Assistant Action (Service). This involved creating a new service registration in `services/__init__.py`, updating the main `__init__.py` to call it, defining the service in `services.yaml`, and adding tests to verify the functionality and error handling.

Fixes #2201

---
*PR created automatically by Jules for task [9585163651474786122](https://jules.google.com/task/9585163651474786122) started by @brewmarsh*