### PR TITLE
Add Meraki Guest Wi-Fi Automation Blueprint

### DIFF
--- a/custom_components/meraki_ha/blueprints/automation/meraki_guest_wifi.yaml
+++ b/custom_components/meraki_ha/blueprints/automation/meraki_guest_wifi.yaml
@@ -1,0 +1,59 @@
+blueprint:
+  name: Meraki Guest Wi-Fi Creator
+  description: Automatically creates a temporary Guest Wi-Fi key (IPSK) when a trigger entity is activated.
+  domain: automation
+  input:
+    trigger_entity:
+      name: Trigger Entity
+      description: The entity that triggers the creation of the guest key (e.g., a button or a binary sensor).
+      selector:
+        entity: {}
+    network_id:
+      name: Network ID
+      description: The ID of the Meraki network where the key will be created.
+      selector:
+        text: {}
+    ssid_number:
+      name: SSID Number
+      description: The SSID index (0-14) where the key will be created.
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 14
+          mode: box
+    duration_minutes:
+      name: Duration (Minutes)
+      description: How long the guest key should remain active before being automatically deleted.
+      default: 60
+      selector:
+        number:
+          min: 1
+          unit_of_measurement: minutes
+          mode: box
+    name:
+      name: Key Name
+      description: The name for the created guest key.
+      default: "Guest Key"
+      selector:
+        text: {}
+    passphrase:
+      name: Passphrase (Optional)
+      description: A specific passphrase to use. If left blank, Meraki will generate a secure one.
+      default: ""
+      selector:
+        text: {}
+
+trigger:
+  - platform: state
+    entity_id: !input trigger_entity
+    to: "on"
+
+action:
+  - service: meraki_ha.create_guest_key
+    data:
+      network_id: !input network_id
+      ssid_number: !input ssid_number
+      duration_minutes: !input duration_minutes
+      name: !input name
+      passphrase: !input passphrase

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -199,6 +199,7 @@
   - [x] **IPSK Lifecycle Management:** Implement a backend manager to track and reap temporary guest Identity PSKs (IPSKs) upon expiration, with persistent storage across reboots.
   - [x] **IPSK WebSocket API:** Implement a strict WebSocket API contract for IPSK management with camelCase payload keys and centralized command definitions.
   - [x] **IPSK Native Service Action:** Expose IPSK creation functionality as a standard Home Assistant Service Action, allowing users to create timed guest keys without the custom frontend panel.
+  - [x] **Guest Wi-Fi Blueprint:** Provide a plug-and-play automation template for creating temporary guest keys via the `meraki_ha.create_guest_key` action.
 - [x] **IPSK Native UX Overhaul:** Rebuilt the TimedAccess.tsx component to provide a native Home Assistant experience using `ha-textfield`, `ha-select`, `ha-button`, and `ha-alert` web components.
 - [ ] **Enhanced Home Security & Awareness (MV Cameras & MT Sensors):**
   - [ ] **Camera Motion Events:** Create `binary_sensor` entities for camera motion events.


### PR DESCRIPTION
This PR introduces a new Home Assistant Blueprint for the Meraki integration, enabling users to easily automate the creation of temporary Guest Wi-Fi keys (IPSKs). 

The Blueprint leverages the `meraki_ha.create_guest_key` service action and provides a user-friendly interface for configuring:
- Trigger entity (e.g., a button or binary sensor)
- Meraki Network ID
- SSID Number (0-14)
- Duration (in minutes)
- Key Name
- Passphrase (optional, auto-generated if left blank)

This addresses the need for a plug-and-play automation template for temporary guest access, as outlined in the project requirements.

Fixes #2220

---
*PR created automatically by Jules for task [5811597174138012341](https://jules.google.com/task/5811597174138012341) started by @brewmarsh*