### PR TITLE
Centralize Meraki Coordinators to Resolve Thundering Herd Bug

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .api.websocket import async_setup_websocket_api
 from .const import DOMAIN, WEBHOOK_ID_FORMAT
-from .const_conf import CONF_MERAKI_ORG_ID
+from .const_conf import CONF_MERAKI_API_KEY, CONF_MERAKI_ORG_ID
 from .const_platform import PLATFORMS
 from .coordinators import (
     MerakiApplianceCoordinator,
@@ -26,6 +26,7 @@ from .coordinators import (
     MerakiSwitchCoordinator,
     MerakiWirelessCoordinator,
 )
+from .core.api.client import MerakiAPIClient
 from .core.repositories.camera_repository import CameraRepository
 from .core.repository import MerakiRepository
 from .discovery.service import DeviceDiscoveryService
@@ -107,15 +108,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_migrate_entities(hass, entry.entry_id)
     await async_cleanup_ghost_devices(hass, entry.entry_id)
 
+    # Initialize shared API client
+    api_client = MerakiAPIClient(
+        hass=hass,
+        api_key=entry.data[CONF_MERAKI_API_KEY],
+        org_id=entry.data[CONF_MERAKI_ORG_ID],
+    )
+
     # Initialize specialized coordinators
-    main_coordinator = MerakiMainCoordinator(hass, entry)
-    device_coordinator = MerakiDeviceCoordinator(hass, entry)
-    switch_coordinator = MerakiSwitchCoordinator(hass, entry)
-    camera_coordinator = MerakiCameraCoordinator(hass, entry)
-    sensor_coordinator = MerakiSensorCoordinator(hass, entry)
-    wireless_coordinator = MerakiWirelessCoordinator(hass, entry)
-    appliance_coordinator = MerakiApplianceCoordinator(hass, entry)
-    client_coordinator = MerakiClientCoordinator(hass, entry)
+    main_coordinator = MerakiMainCoordinator(hass, entry, api_client)
+    device_coordinator = MerakiDeviceCoordinator(hass, entry, api_client)
+    switch_coordinator = MerakiSwitchCoordinator(hass, entry, api_client)
+    camera_coordinator = MerakiCameraCoordinator(hass, entry, api_client)
+    sensor_coordinator = MerakiSensorCoordinator(hass, entry, api_client)
+    wireless_coordinator = MerakiWirelessCoordinator(hass, entry, api_client)
+    appliance_coordinator = MerakiApplianceCoordinator(hass, entry, api_client)
+    client_coordinator = MerakiClientCoordinator(hass, entry, api_client)
 
     # 1. Block setup until the basic device skeleton is loaded (Tier 1)
     # This is strictly required to populate the Device Registry promptly.
@@ -155,7 +163,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass, coord.async_request_refresh(), name=name
         )
 
-    api_client = main_coordinator.api
     repo = MerakiRepository(api_client)
     device_control_service = DeviceControlService(repo)
     switch_port_service = SwitchPortService(repo)

--- a/custom_components/meraki_ha/binary_sensor/network.py
+++ b/custom_components/meraki_ha/binary_sensor/network.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Meraki network status binary sensor entities."""
     coordinator: MerakiMainCoordinator = hass.data[DOMAIN][config_entry.entry_id][
-        "coordinator"
+        "main_coordinator"
     ]
 
     if coordinator.data.get("networks"):

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Meraki camera entities from a config entry."""
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator: MerakiCameraCoordinator = entry_data["coordinator"]
+    coordinator: MerakiCameraCoordinator = entry_data["camera_coordinator"]
     camera_service: CameraService = entry_data["camera_service"]
 
     devices: list[MerakiDevice] = coordinator.data.get("devices", [])

--- a/custom_components/meraki_ha/coordinators/appliance.py
+++ b/custom_components/meraki_ha/coordinators/appliance.py
@@ -13,9 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiApplianceCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for Meraki appliance data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the appliance coordinator."""
-        super().__init__(hass, entry, name="appliance")
+        super().__init__(hass, entry, api_client, name="appliance")
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval
         from datetime import timedelta

--- a/custom_components/meraki_ha/coordinators/base.py
+++ b/custom_components/meraki_ha/coordinators/base.py
@@ -39,16 +39,13 @@ class MerakiBaseCoordinator(DataUpdateCoordinator[T], Generic[T]):
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
+        api_client: ApiClient,
         name: str = DOMAIN,
     ) -> None:
         """Initialize the base coordinator."""
         self.config = get_coordinator_config(entry)
 
-        self.api = ApiClient(
-            hass=hass,
-            api_key=self.config.api_key,
-            org_id=self.config.org_id,
-        )
+        self.api = api_client
 
         self.data_fetch_manager = DataFetchManager(
             client=self.api,

--- a/custom_components/meraki_ha/coordinators/camera.py
+++ b/custom_components/meraki_ha/coordinators/camera.py
@@ -13,9 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiCameraCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for Meraki camera data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the camera coordinator."""
-        super().__init__(hass, entry, name="camera")
+        super().__init__(hass, entry, api_client, name="camera")
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval
         from datetime import timedelta

--- a/custom_components/meraki_ha/coordinators/client.py
+++ b/custom_components/meraki_ha/coordinators/client.py
@@ -13,9 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiClientCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for Meraki client data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the client coordinator."""
-        super().__init__(hass, entry, name="client")
+        super().__init__(hass, entry, api_client, name="client")
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval
         from datetime import timedelta

--- a/custom_components/meraki_ha/coordinators/device.py
+++ b/custom_components/meraki_ha/coordinators/device.py
@@ -16,9 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiDeviceCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for fast-poll Meraki device status data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the device coordinator."""
-        super().__init__(hass, entry, name="device")
+        super().__init__(hass, entry, api_client, name="device")
         self.last_successful_data: dict[str, Any] = {}
         # Fast poll interval
         self.update_interval = timedelta(seconds=60)

--- a/custom_components/meraki_ha/coordinators/main.py
+++ b/custom_components/meraki_ha/coordinators/main.py
@@ -19,9 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A centralized coordinator for main Meraki organization and network data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the main coordinator."""
-        super().__init__(hass, entry, name="main")
+        super().__init__(hass, entry, api_client, name="main")
         self.last_successful_update: datetime | None = None
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval

--- a/custom_components/meraki_ha/coordinators/sensor.py
+++ b/custom_components/meraki_ha/coordinators/sensor.py
@@ -15,9 +15,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiSensorCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for Meraki sensor data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the sensor coordinator."""
-        super().__init__(hass, entry, name="sensor")
+        super().__init__(hass, entry, api_client, name="sensor")
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval
         from datetime import timedelta

--- a/custom_components/meraki_ha/coordinators/switch.py
+++ b/custom_components/meraki_ha/coordinators/switch.py
@@ -13,9 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiSwitchCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for Meraki switch data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the switch coordinator."""
-        super().__init__(hass, entry, name="switch")
+        super().__init__(hass, entry, api_client, name="switch")
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval
         from datetime import timedelta

--- a/custom_components/meraki_ha/coordinators/wireless.py
+++ b/custom_components/meraki_ha/coordinators/wireless.py
@@ -13,9 +13,9 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiWirelessCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     """A coordinator for Meraki wireless data."""
 
-    def __init__(self, hass, entry) -> None:
+    def __init__(self, hass, entry, api_client) -> None:
         """Initialize the wireless coordinator."""
-        super().__init__(hass, entry, name="wireless")
+        super().__init__(hass, entry, api_client, name="wireless")
         self.last_successful_data: dict[str, Any] = {}
         # Slow poll interval
         from datetime import timedelta

--- a/custom_components/meraki_ha/number/__init__.py
+++ b/custom_components/meraki_ha/number/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     """Set up Meraki number entities from a config entry."""
     if config_entry.entry_id not in hass.data[DOMAIN]:
         return False
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["main_coordinator"]
 
     number_entities = async_setup_numbers(hass, config_entry, coordinator)
 

--- a/custom_components/meraki_ha/platforms/sensor/__init__.py
+++ b/custom_components/meraki_ha/platforms/sensor/__init__.py
@@ -25,9 +25,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors based on a config entry."""
-    coordinator: MerakiDeviceDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["main_coordinator"]
 
     # List to collect all entities
     entities = []

--- a/custom_components/meraki_ha/switch/__init__.py
+++ b/custom_components/meraki_ha/switch/__init__.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
         # This entry is not ready yet, we'll wait for the coordinator to be ready
         return False
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = entry_data["coordinator"]
+    coordinator = entry_data["switch_coordinator"]
     meraki_client = entry_data.get("meraki_client")
     if not meraki_client:
         _LOGGER.warning("Meraki client not available; skipping switch setup.")

--- a/custom_components/meraki_ha/text/__init__.py
+++ b/custom_components/meraki_ha/text/__init__.py
@@ -22,8 +22,8 @@ async def async_setup_entry(
     if config_entry.entry_id not in hass.data[DOMAIN]:
         return False
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator = entry_data["coordinator"]
-    meraki_client = coordinator.api
+    coordinator = entry_data["main_coordinator"]
+    meraki_client = entry_data["meraki_client"]
 
     if coordinator.data:
         text_entities = [

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -48,15 +48,11 @@ def coordinator(hass, mock_api_client, mock_data_fetch_manager):
     # Patched to reflect the new internal module structure for base components
     with (
         patch(
-            "custom_components.meraki_ha.coordinators.base.ApiClient",
-            return_value=mock_api_client,
-        ),
-        patch(
             "custom_components.meraki_ha.coordinators.base.DataFetchManager",
             return_value=mock_data_fetch_manager,
         ),
     ):
-        yield MerakiDataCoordinator(hass=hass, entry=entry)
+        yield MerakiDataCoordinator(hass=hass, entry=entry, api_client=mock_api_client)
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -126,7 +126,7 @@ async def test_ssid_device_creation_and_unification(
 
     with (
         patch(
-            "custom_components.meraki_ha.coordinators.base.ApiClient",
+            "custom_components.meraki_ha.MerakiAPIClient",
             return_value=mock_meraki_client,
         ),
         patch(
@@ -188,7 +188,7 @@ async def test_integration_reload(
 
     with (
         patch(
-            "custom_components.meraki_ha.coordinators.base.ApiClient",
+            "custom_components.meraki_ha.MerakiAPIClient",
             return_value=mock_meraki_client,
         ),
         patch(
@@ -208,4 +208,4 @@ async def test_integration_reload(
         # Check that the coordinator is still there, indicating a successful reload
         assert DOMAIN in hass.data
         assert mock_config_entry.entry_id in hass.data[DOMAIN]
-        assert "coordinator" in hass.data[DOMAIN][mock_config_entry.entry_id]
+        assert "main_coordinator" in hass.data[DOMAIN][mock_config_entry.entry_id]


### PR DESCRIPTION
The Meraki Home Assistant integration was experiencing 'Thundering Herd' issues where multiple coordinator instances were independently creating API clients and fetching data, leading to frequent 429 Too Many Requests errors.

This PR centralizes the Meraki API client and the specialized coordinators. By instantiating a single API client at the integration level and passing it to all coordinators, we ensure that all API calls are governed by a single semaphore. Furthermore, platforms now retrieve shared coordinator instances from `hass.data`, preventing redundant data fetching and improving overall integration stability and performance.

Fixes #2230

---
*PR created automatically by Jules for task [2870821185533834682](https://jules.google.com/task/2870821185533834682) started by @brewmarsh*