### PR TITLE
Refactor camera enablement to background task

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -118,18 +118,49 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
             self.coordinator.config_entry.options.get(CONF_ENABLE_CAMERA_ENTITIES, True)
             and not self.device_data.rtsp_url
         ):
-            try:
+            # Move the blocking API call to a background task to prevent Setup timeout
+            self.coordinator.config_entry.async_create_background_task(
+                self.hass,
+                self._async_enable_rtsp(),
+                f"meraki_ha_enable_rtsp_{self._device_serial}",
+            )
+
+    async def _async_enable_rtsp(self) -> None:
+        """Enable RTSP stream in the background."""
+        try:
+            _LOGGER.debug(
+                "RTSP stream is missing, enabling for camera %s in background",
+                self._device_serial,
+            )
+            # 1. Enable RTSP
+            await self._camera_service.async_set_rtsp_stream_enabled(
+                self._device_serial, True
+            )
+
+            # 2. Fetch the URL immediately
+            url = await self._camera_service.get_video_stream_url(self._device_serial)
+            if url:
                 _LOGGER.debug(
-                    "RTSP stream is missing, enabling for camera %s",
+                    "Successfully enabled and retrieved RTSP URL for %s: %s",
+                    self._device_serial,
+                    url,
+                )
+                # Update the device data model directly so the UI can use it
+                self.device_data.rtsp_url = url
+                self.async_write_ha_state()
+            else:
+                _LOGGER.debug(
+                    "RTSP enabled for %s, but URL not yet available. "
+                    "It will be picked up on the next coordinator refresh.",
                     self._device_serial,
                 )
-                await self._camera_service.async_set_rtsp_stream_enabled(
-                    self._device_serial, True
-                )
-            except Exception as e:
-                _LOGGER.warning(
-                    "Could not enable RTSP stream for %s: %s", self._device_serial, e
-                )
+
+        except Exception as e:
+            _LOGGER.warning(
+                "Could not enable RTSP stream for %s in background: %s",
+                self._device_serial,
+                e,
+            )
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -173,8 +173,15 @@ class DataFetchManager:
 
     def _get_device_capabilities(self, model: str | None) -> list[str]:
         """Return hardcoded capabilities based on device model."""
+        from ..const import DEVICE_CAPABILITIES
+
         if not model:
             return list(DEFAULT_CAPS)
+
+        # Iterate and match prefix (e.g. MV12W match MV12)
+        for prefix, caps in DEVICE_CAPABILITIES.items():
+            if model.startswith(prefix):
+                return list(caps)
 
         return list(DEFAULT_CAPS)
 

--- a/tests/camera/test_camera_auto_stream.py
+++ b/tests/camera/test_camera_auto_stream.py
@@ -18,6 +18,8 @@ def mock_camera(
 ) -> MerakiRTSPStreamCamera:
     """Create a mock MerakiRTSPStreamCamera entity."""
     mock_coordinator.get_device.return_value = MOCK_CAMERA_DEVICE
+    # Ensure the coordinator uses the same config entry as the fixture
+    mock_coordinator.config_entry = mock_config_entry
     return MerakiRTSPStreamCamera(
         coordinator=mock_coordinator,
         device=MOCK_CAMERA_DEVICE,
@@ -54,7 +56,22 @@ async def test_camera_auto_enables_stream(
         mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: True}
 
         # Act
-        await mock_camera.async_added_to_hass()
+        # In HA 2024.12+, async_create_background_task is the preferred way.
+        # We mock it to just run the task so we can wait for it.
+        # Using MagicMock for the task to prevent 'coroutine was never awaited'
+        mock_task = MagicMock()
+        with patch.object(
+                mock_config_entry, "async_create_background_task", return_value=mock_task
+        ) as mock_create_task:
+            await mock_camera.async_added_to_hass()
+
+        # Manually await the coroutine that was passed to async_create_background_task
+        # It's the second argument (index 1) in the call
+        coro = mock_create_task.call_args[0][1]
+        await coro
+
+        # Wait for background tasks
+        await hass.async_block_till_done()
 
         # Assert
         mock_camera_service.async_set_rtsp_stream_enabled.assert_awaited_once_with(
@@ -109,7 +126,12 @@ async def test_camera_does_not_auto_enable_if_option_disabled(
         mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: False}
 
         # Act
-        await mock_camera.async_added_to_hass()
+        # Even if we don't expect a task, we should mock it to be safe
+        with patch.object(
+                mock_config_entry, "async_create_background_task"
+        ) as mock_create_task:
+            await mock_camera.async_added_to_hass()
 
         # Assert
         mock_camera_service.async_set_rtsp_stream_enabled.assert_not_called()
+        mock_create_task.assert_not_called()

--- a/tests/test_camera_optimization.py
+++ b/tests/test_camera_optimization.py
@@ -102,11 +102,25 @@ async def test_dfm_batch_analytics_modulo():
     # Poll 1
     dfm.camera_strategy.increment_poll_count()
 
-    # We test via _collect_device_tasks
+    # We test via collect_device_tasks
+    from custom_components.meraki_ha.core.coordinator_helpers.strategy_executor import (
+        collect_device_tasks,
+    )
+
     tasks = {}
-    dfm._collect_device_tasks({"devices": devices}, tasks)
+    data = {"devices": devices}
+    strategies = {
+        "appliance": dfm.appliance_strategy,
+        "wireless": dfm.wireless_strategy,
+        "switch": dfm.switch_strategy,
+        "camera": dfm.camera_strategy,
+        "sensor": dfm.sensor_strategy,
+    }
+
+    collect_device_tasks(data, tasks, strategies, dfm._get_device_capabilities)
 
     # Analytics should be present in poll 1 (1 % 5 == 1? No (1-1)%5 == 0)
+    # Note: strategy.build_device_tasks checks for 'camera_analytics' in capabilities
     assert f"camera_analytics_{devices[0].serial}" in tasks
 
     # Cleanup Poll 1 tasks
@@ -117,7 +131,7 @@ async def test_dfm_batch_analytics_modulo():
     # Poll 2
     dfm.camera_strategy.increment_poll_count()
     tasks = {}
-    dfm._collect_device_tasks({"devices": devices}, tasks)
+    collect_device_tasks(data, tasks, strategies, dfm._get_device_capabilities)
 
     # Analytics should NOT be present in poll 2
     assert f"camera_analytics_{devices[0].serial}" not in tasks


### PR DESCRIPTION
Refactored the camera RTSP stream enablement logic in `meraki_ha` to run as a background task during entity setup. This prevents the MainThread from being blocked by synchronous API calls, resolving warnings about setup taking over 10 seconds. The implementation uses `config_entry.async_create_background_task` and ensures the UI is updated immediately once the stream URL is available. Additionally, improved device capability matching in `DataFetchManager` and updated relevant test suites to accommodate the async changes.

Fixes #2237

---
*PR created automatically by Jules for task [9760072585087744747](https://jules.google.com/task/9760072585087744747) started by @brewmarsh*