### PR TITLE
Migrate to async static path registration

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -7,6 +7,7 @@ import secrets
 import string
 
 from homeassistant.components.frontend import add_extra_js_url
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -91,10 +92,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     # Register static path for frontend
     if "frontend" in hass.config.components:
-        hass.http.register_static_path(
-            "/meraki_ha_static",
-            hass.config.path("custom_components/meraki_ha/www"),
-            cache_headers=False,  # Set to False during beta/smoketest for easier debugging
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    url_path="/meraki_ha_static",
+                    path=hass.config.path("custom_components/meraki_ha/www"),
+                    cache_headers=False,
+                )
+            ]
         )
 
         # Register the JavaScript module so it appears in the dashboard

--- a/tests/test_static_path.py
+++ b/tests/test_static_path.py
@@ -1,0 +1,37 @@
+"""Test static path registration."""
+from unittest.mock import patch, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from custom_components.meraki_ha.const import DOMAIN
+from homeassistant.components.http import StaticPathConfig
+
+async def test_static_path_registration(hass: HomeAssistant) -> None:
+    """Test that static path registration uses the new async method."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        entry_id="test_entry",
+    )
+    entry.add_to_hass(hass)
+
+    # Ensure frontend is in components to trigger the registration block
+    hass.config.components.add("frontend")
+
+    with patch("custom_components.meraki_ha.MerakiAPIClient"), \
+         patch("custom_components.meraki_ha.coordinators.base.DataFetchManager"), \
+         patch("custom_components.meraki_ha.async_register_webhook", return_value=None):
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Verify async_register_static_paths was called
+    hass.http.async_register_static_paths.assert_called_once()
+    args, _ = hass.http.async_register_static_paths.call_args
+    configs = args[0]
+    assert len(configs) == 1
+    config = configs[0]
+    assert isinstance(config, StaticPathConfig)
+    assert config.url_path == "/meraki_ha_static"
+    assert config.path.endswith("custom_components/meraki_ha/www")
+    assert config.cache_headers is False


### PR DESCRIPTION
This change migrates the Meraki Home Assistant integration's static path registration to the modern asynchronous API required by newer versions of Home Assistant Core.

Key changes:
1.  **Import Update**: Added `StaticPathConfig` to the imports in `custom_components/meraki_ha/__init__.py`.
2.  **API Migration**: In `async_setup_entry`, the deprecated `hass.http.register_static_path` call was replaced with an awaited call to `hass.http.async_register_static_paths`.
3.  **Parameter Encapsulation**: Parameters are now correctly passed via a list containing a `StaticPathConfig` object, ensuring compatibility with the updated Home Assistant HTTP component.
4.  **Verification**: A new test file `tests/test_static_path.py` was added to verify that the registration is called correctly during integration setup. Existing integration tests were also run to ensure no regressions.

This resolves the `AttributeError: 'HomeAssistantHTTP' object has no attribute 'register_static_path'` observed during integration startup in recent HA Core versions.

Fixes #2238

---
*PR created automatically by Jules for task [13019409836847270280](https://jules.google.com/task/13019409836847270280) started by @brewmarsh*