### PR TITLE
Fix Frontend Build Configuration for Standalone ES Module

### DIFF
--- a/custom_components/meraki_ha/www/package.json
+++ b/custom_components/meraki_ha/www/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "meraki-ha-www",
+  "private": true,
+  "version": "2.3.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "dependencies": {
+    "lit": "^3.3.2"
+  },
+  "devDependencies": {
+    "vite": "^5.4.21",
+    "typescript": "^5.2.2"
+  }
+}

--- a/custom_components/meraki_ha/www/src/types/ha.ts
+++ b/custom_components/meraki_ha/www/src/types/ha.ts
@@ -1,0 +1,22 @@
+export interface HomeAssistant {
+  hassUrl(path: string): string;
+  callWS<T>(msg: any): Promise<T>;
+  callService(domain: string, service: string, data: any): Promise<void>;
+  connection: any;
+  connected: boolean;
+  states: any;
+  services: any;
+  config: any;
+  themes: any;
+  selectedTheme: any;
+  panels: any;
+  user: any;
+  userid: string;
+  language: string;
+  resources: any;
+  localize: any;
+  translationMetadata: any;
+  dockedSidebar: string;
+  defaultPanel: string;
+  moreInfoEntityId: string;
+}

--- a/custom_components/meraki_ha/www/src/types/meraki.ts
+++ b/custom_components/meraki_ha/www/src/types/meraki.ts
@@ -1,0 +1,11 @@
+export interface Network {
+  id: string;
+  name: string;
+  productTypes: string[];
+}
+
+export interface SSID {
+  name: string;
+  number: number;
+  networkId: string;
+}

--- a/custom_components/meraki_ha/www/src/types/websocket.ts
+++ b/custom_components/meraki_ha/www/src/types/websocket.ts
@@ -1,0 +1,18 @@
+export enum WsCommand {
+  GET_CONFIG = 'meraki_ha/get_config',
+  SUBSCRIBE_MERAKI_DATA = 'meraki_ha/subscribe_meraki_data',
+  GET_CAMERA_STREAM_URL = 'meraki_ha/get_camera_stream_url',
+  GET_CAMERA_SNAPSHOT = 'meraki_ha/get_camera_snapshot',
+  GET_VERSION = 'meraki_ha/get_version',
+  GET_NETWORK_EVENTS = 'meraki_ha/get_network_events',
+  UPDATE_ENABLED_NETWORKS = 'meraki_ha/update_enabled_networks',
+  CREATE_GUEST_KEY = 'meraki_ha/ipsk/create',
+  GET_GUEST_KEYS = 'meraki_ha/ipsk/get',
+  REVOKE_GUEST_KEY = 'meraki_ha/ipsk/revoke',
+  TIMED_ACCESS_GET_POLICIES = 'meraki_ha/timed_access/get_policies',
+}
+
+export interface WsMessagePayload {
+  type: string;
+  [key: string]: any;
+}

--- a/custom_components/meraki_ha/www/src/utils/api.ts
+++ b/custom_components/meraki_ha/www/src/utils/api.ts
@@ -1,0 +1,30 @@
+import { WsMessagePayload } from '../types/websocket';
+
+/**
+ * Utility for making safe WebSocket calls to Home Assistant.
+ */
+
+export const safeCallWS = async <T = any>(hass: any, message: WsMessagePayload): Promise<T> => {
+  if (!hass) {
+    throw new Error('Home Assistant object is not available.');
+  }
+
+  try {
+    // Attempt to use callWS if available (standard for newer HA)
+    if (typeof hass.callWS === 'function') {
+      return await hass.callWS(message);
+    }
+
+    // Fallback to connection.sendMessagePromise (common in custom panels)
+    if (hass.connection && typeof hass.connection.sendMessagePromise === 'function') {
+      return await hass.connection.sendMessagePromise(message);
+    }
+
+    throw new Error('Home Assistant WebSocket communication methods not found.');
+  } catch (error: any) {
+    // Log the error for easier debugging
+    console.error(`Meraki HA: WebSocket error [${message.type}]:`, error);
+    // Rethrow to let the component handle it
+    throw error;
+  }
+};

--- a/custom_components/meraki_ha/www/tsconfig.json
+++ b/custom_components/meraki_ha/www/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": false
+  },
+  "include": ["src"]
+}

--- a/custom_components/meraki_ha/www/vite.config.ts
+++ b/custom_components/meraki_ha/www/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/meraki-guest-access-card.ts'),
+      name: 'MerakiCard',
+      formats: ['es'],
+      fileName: () => 'meraki-card.js',
+    },
+    outDir: '.',
+    emptyOutDir: false,
+    rollupOptions: {
+      // Bundle all dependencies to create a standalone ES module
+      external: [],
+    },
+  },
+});


### PR DESCRIPTION
The frontend build configuration was missing, and the `meraki-guest-access-card.ts` file referenced several missing local files (`types/` and `utils/`). I have restored the build infrastructure (Vite configuration, package.json, tsconfig.json) and recreated the missing source files based on their usage and git history. The new configuration ensures that all dependencies are bundled into a single ES module, which resolves the issue where the browser was trying to fetch raw `.ts` files from `node_modules`.

Fixes #2243

---
*PR created automatically by Jules for task [3660357441213158958](https://jules.google.com/task/3660357441213158958) started by @brewmarsh*