### PR TITLE
Restore Minimal Build Pipeline for Custom Card

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -25,7 +25,20 @@ jobs:
           clean: true
           fetch-depth: 0
 
-      # NOTE: Node.js setup and React build steps were removed to support the React Teardown
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
 
       - name: Copy files to staging (rsync)
         shell: bash

--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -2,51 +2,722 @@
  * @license
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */const I=globalThis,K=I.ShadowRoot&&(I.ShadyCSS===void 0||I.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,q=Symbol(),Y=new WeakMap;let lt=class{constructor(t,e,s){if(this._$cssResult$=!0,s!==q)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=t,this.t=e}get styleSheet(){let t=this.o;const e=this.t;if(K&&t===void 0){const s=e!==void 0&&e.length===1;s&&(t=Y.get(e)),t===void 0&&((this.o=t=new CSSStyleSheet).replaceSync(this.cssText),s&&Y.set(e,t))}return t}toString(){return this.cssText}};const ft=r=>new lt(typeof r=="string"?r:r+"",void 0,q),$t=(r,...t)=>{const e=r.length===1?r[0]:t.reduce((s,i,n)=>s+(o=>{if(o._$cssResult$===!0)return o.cssText;if(typeof o=="number")return o;throw Error("Value passed to 'css' function must be a 'css' function result: "+o+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+r[n+1],r[0]);return new lt(e,r,q)},mt=(r,t)=>{if(K)r.adoptedStyleSheets=t.map(e=>e instanceof CSSStyleSheet?e:e.styleSheet);else for(const e of t){const s=document.createElement("style"),i=I.litNonce;i!==void 0&&s.setAttribute("nonce",i),s.textContent=e.cssText,r.appendChild(s)}},Z=K?r=>r:r=>r instanceof CSSStyleSheet?(t=>{let e="";for(const s of t.cssRules)e+=s.cssText;return ft(e)})(r):r;/**
+ */
+const I = globalThis, K = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, q = Symbol(), Y = /* @__PURE__ */ new WeakMap();
+let lt = class {
+  constructor(t, e, s) {
+    if (this._$cssResult$ = !0, s !== q) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    this.cssText = t, this.t = e;
+  }
+  get styleSheet() {
+    let t = this.o;
+    const e = this.t;
+    if (K && t === void 0) {
+      const s = e !== void 0 && e.length === 1;
+      s && (t = Y.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), s && Y.set(e, t));
+    }
+    return t;
+  }
+  toString() {
+    return this.cssText;
+  }
+};
+const ft = (r) => new lt(typeof r == "string" ? r : r + "", void 0, q), $t = (r, ...t) => {
+  const e = r.length === 1 ? r[0] : t.reduce((s, i, n) => s + ((o) => {
+    if (o._$cssResult$ === !0) return o.cssText;
+    if (typeof o == "number") return o;
+    throw Error("Value passed to 'css' function must be a 'css' function result: " + o + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+  })(i) + r[n + 1], r[0]);
+  return new lt(e, r, q);
+}, mt = (r, t) => {
+  if (K) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  else for (const e of t) {
+    const s = document.createElement("style"), i = I.litNonce;
+    i !== void 0 && s.setAttribute("nonce", i), s.textContent = e.cssText, r.appendChild(s);
+  }
+}, Z = K ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
+  let e = "";
+  for (const s of t.cssRules) e += s.cssText;
+  return ft(e);
+})(r) : r;
+/**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */const{is:gt,defineProperty:yt,getOwnPropertyDescriptor:At,getOwnPropertyNames:vt,getOwnPropertySymbols:Et,getPrototypeOf:St}=Object,y=globalThis,Q=y.trustedTypes,wt=Q?Q.emptyScript:"",L=y.reactiveElementPolyfillSupport,N=(r,t)=>r,D={toAttribute(r,t){switch(t){case Boolean:r=r?wt:null;break;case Object:case Array:r=r==null?r:JSON.stringify(r)}return r},fromAttribute(r,t){let e=r;switch(t){case Boolean:e=r!==null;break;case Number:e=r===null?null:Number(r);break;case Object:case Array:try{e=JSON.parse(r)}catch{e=null}}return e}},F=(r,t)=>!gt(r,t),X={attribute:!0,type:String,converter:D,reflect:!1,useDefault:!1,hasChanged:F};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),y.litPropertyMetadata??(y.litPropertyMetadata=new WeakMap);let b=class extends HTMLElement{static addInitializer(t){this._$Ei(),(this.l??(this.l=[])).push(t)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(t,e=X){if(e.state&&(e.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(t)&&((e=Object.create(e)).wrapped=!0),this.elementProperties.set(t,e),!e.noAccessor){const s=Symbol(),i=this.getPropertyDescriptor(t,s,e);i!==void 0&&yt(this.prototype,t,i)}}static getPropertyDescriptor(t,e,s){const{get:i,set:n}=At(this.prototype,t)??{get(){return this[e]},set(o){this[e]=o}};return{get:i,set(o){const h=i==null?void 0:i.call(this);n==null||n.call(this,o),this.requestUpdate(t,h,s)},configurable:!0,enumerable:!0}}static getPropertyOptions(t){return this.elementProperties.get(t)??X}static _$Ei(){if(this.hasOwnProperty(N("elementProperties")))return;const t=St(this);t.finalize(),t.l!==void 0&&(this.l=[...t.l]),this.elementProperties=new Map(t.elementProperties)}static finalize(){if(this.hasOwnProperty(N("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(N("properties"))){const e=this.properties,s=[...vt(e),...Et(e)];for(const i of s)this.createProperty(i,e[i])}const t=this[Symbol.metadata];if(t!==null){const e=litPropertyMetadata.get(t);if(e!==void 0)for(const[s,i]of e)this.elementProperties.set(s,i)}this._$Eh=new Map;for(const[e,s]of this.elementProperties){const i=this._$Eu(e,s);i!==void 0&&this._$Eh.set(i,e)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(t){const e=[];if(Array.isArray(t)){const s=new Set(t.flat(1/0).reverse());for(const i of s)e.unshift(Z(i))}else t!==void 0&&e.push(Z(t));return e}static _$Eu(t,e){const s=e.attribute;return s===!1?void 0:typeof s=="string"?s:typeof t=="string"?t.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){var t;this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),(t=this.constructor.l)==null||t.forEach(e=>e(this))}addController(t){var e;(this._$EO??(this._$EO=new Set)).add(t),this.renderRoot!==void 0&&this.isConnected&&((e=t.hostConnected)==null||e.call(t))}removeController(t){var e;(e=this._$EO)==null||e.delete(t)}_$E_(){const t=new Map,e=this.constructor.elementProperties;for(const s of e.keys())this.hasOwnProperty(s)&&(t.set(s,this[s]),delete this[s]);t.size>0&&(this._$Ep=t)}createRenderRoot(){const t=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return mt(t,this.constructor.elementStyles),t}connectedCallback(){var t;this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),(t=this._$EO)==null||t.forEach(e=>{var s;return(s=e.hostConnected)==null?void 0:s.call(e)})}enableUpdating(t){}disconnectedCallback(){var t;(t=this._$EO)==null||t.forEach(e=>{var s;return(s=e.hostDisconnected)==null?void 0:s.call(e)})}attributeChangedCallback(t,e,s){this._$AK(t,s)}_$ET(t,e){var n;const s=this.constructor.elementProperties.get(t),i=this.constructor._$Eu(t,s);if(i!==void 0&&s.reflect===!0){const o=(((n=s.converter)==null?void 0:n.toAttribute)!==void 0?s.converter:D).toAttribute(e,s.type);this._$Em=t,o==null?this.removeAttribute(i):this.setAttribute(i,o),this._$Em=null}}_$AK(t,e){var n,o;const s=this.constructor,i=s._$Eh.get(t);if(i!==void 0&&this._$Em!==i){const h=s.getPropertyOptions(i),a=typeof h.converter=="function"?{fromAttribute:h.converter}:((n=h.converter)==null?void 0:n.fromAttribute)!==void 0?h.converter:D;this._$Em=i;const c=a.fromAttribute(e,h.type);this[i]=c??((o=this._$Ej)==null?void 0:o.get(i))??c,this._$Em=null}}requestUpdate(t,e,s,i=!1,n){var o;if(t!==void 0){const h=this.constructor;if(i===!1&&(n=this[t]),s??(s=h.getPropertyOptions(t)),!((s.hasChanged??F)(n,e)||s.useDefault&&s.reflect&&n===((o=this._$Ej)==null?void 0:o.get(t))&&!this.hasAttribute(h._$Eu(t,s))))return;this.C(t,e,s)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(t,e,{useDefault:s,reflect:i,wrapped:n},o){s&&!(this._$Ej??(this._$Ej=new Map)).has(t)&&(this._$Ej.set(t,o??e??this[t]),n!==!0||o!==void 0)||(this._$AL.has(t)||(this.hasUpdated||s||(e=void 0),this._$AL.set(t,e)),i===!0&&this._$Em!==t&&(this._$Eq??(this._$Eq=new Set)).add(t))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(e){Promise.reject(e)}const t=this.scheduleUpdate();return t!=null&&await t,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){var s;if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(const[n,o]of this._$Ep)this[n]=o;this._$Ep=void 0}const i=this.constructor.elementProperties;if(i.size>0)for(const[n,o]of i){const{wrapped:h}=o,a=this[n];h!==!0||this._$AL.has(n)||a===void 0||this.C(n,void 0,o,a)}}let t=!1;const e=this._$AL;try{t=this.shouldUpdate(e),t?(this.willUpdate(e),(s=this._$EO)==null||s.forEach(i=>{var n;return(n=i.hostUpdate)==null?void 0:n.call(i)}),this.update(e)):this._$EM()}catch(i){throw t=!1,this._$EM(),i}t&&this._$AE(e)}willUpdate(t){}_$AE(t){var e;(e=this._$EO)==null||e.forEach(s=>{var i;return(i=s.hostUpdated)==null?void 0:i.call(s)}),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(t)),this.updated(t)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(t){return!0}update(t){this._$Eq&&(this._$Eq=this._$Eq.forEach(e=>this._$ET(e,this[e]))),this._$EM()}updated(t){}firstUpdated(t){}};b.elementStyles=[],b.shadowRootOptions={mode:"open"},b[N("elementProperties")]=new Map,b[N("finalized")]=new Map,L==null||L({ReactiveElement:b}),(y.reactiveElementVersions??(y.reactiveElementVersions=[])).push("2.1.2");/**
+ */
+const { is: gt, defineProperty: yt, getOwnPropertyDescriptor: At, getOwnPropertyNames: vt, getOwnPropertySymbols: Et, getPrototypeOf: St } = Object, y = globalThis, Q = y.trustedTypes, wt = Q ? Q.emptyScript : "", L = y.reactiveElementPolyfillSupport, N = (r, t) => r, D = { toAttribute(r, t) {
+  switch (t) {
+    case Boolean:
+      r = r ? wt : null;
+      break;
+    case Object:
+    case Array:
+      r = r == null ? r : JSON.stringify(r);
+  }
+  return r;
+}, fromAttribute(r, t) {
+  let e = r;
+  switch (t) {
+    case Boolean:
+      e = r !== null;
+      break;
+    case Number:
+      e = r === null ? null : Number(r);
+      break;
+    case Object:
+    case Array:
+      try {
+        e = JSON.parse(r);
+      } catch {
+        e = null;
+      }
+  }
+  return e;
+} }, F = (r, t) => !gt(r, t), X = { attribute: !0, type: String, converter: D, reflect: !1, useDefault: !1, hasChanged: F };
+Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), y.litPropertyMetadata ?? (y.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
+let b = class extends HTMLElement {
+  static addInitializer(t) {
+    this._$Ei(), (this.l ?? (this.l = [])).push(t);
+  }
+  static get observedAttributes() {
+    return this.finalize(), this._$Eh && [...this._$Eh.keys()];
+  }
+  static createProperty(t, e = X) {
+    if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
+      const s = Symbol(), i = this.getPropertyDescriptor(t, s, e);
+      i !== void 0 && yt(this.prototype, t, i);
+    }
+  }
+  static getPropertyDescriptor(t, e, s) {
+    const { get: i, set: n } = At(this.prototype, t) ?? { get() {
+      return this[e];
+    }, set(o) {
+      this[e] = o;
+    } };
+    return { get: i, set(o) {
+      const h = i == null ? void 0 : i.call(this);
+      n == null || n.call(this, o), this.requestUpdate(t, h, s);
+    }, configurable: !0, enumerable: !0 };
+  }
+  static getPropertyOptions(t) {
+    return this.elementProperties.get(t) ?? X;
+  }
+  static _$Ei() {
+    if (this.hasOwnProperty(N("elementProperties"))) return;
+    const t = St(this);
+    t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
+  }
+  static finalize() {
+    if (this.hasOwnProperty(N("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(N("properties"))) {
+      const e = this.properties, s = [...vt(e), ...Et(e)];
+      for (const i of s) this.createProperty(i, e[i]);
+    }
+    const t = this[Symbol.metadata];
+    if (t !== null) {
+      const e = litPropertyMetadata.get(t);
+      if (e !== void 0) for (const [s, i] of e) this.elementProperties.set(s, i);
+    }
+    this._$Eh = /* @__PURE__ */ new Map();
+    for (const [e, s] of this.elementProperties) {
+      const i = this._$Eu(e, s);
+      i !== void 0 && this._$Eh.set(i, e);
+    }
+    this.elementStyles = this.finalizeStyles(this.styles);
+  }
+  static finalizeStyles(t) {
+    const e = [];
+    if (Array.isArray(t)) {
+      const s = new Set(t.flat(1 / 0).reverse());
+      for (const i of s) e.unshift(Z(i));
+    } else t !== void 0 && e.push(Z(t));
+    return e;
+  }
+  static _$Eu(t, e) {
+    const s = e.attribute;
+    return s === !1 ? void 0 : typeof s == "string" ? s : typeof t == "string" ? t.toLowerCase() : void 0;
+  }
+  constructor() {
+    super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
+  }
+  _$Ev() {
+    var t;
+    this._$ES = new Promise((e) => this.enableUpdating = e), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), (t = this.constructor.l) == null || t.forEach((e) => e(this));
+  }
+  addController(t) {
+    var e;
+    (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(t), this.renderRoot !== void 0 && this.isConnected && ((e = t.hostConnected) == null || e.call(t));
+  }
+  removeController(t) {
+    var e;
+    (e = this._$EO) == null || e.delete(t);
+  }
+  _$E_() {
+    const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
+    for (const s of e.keys()) this.hasOwnProperty(s) && (t.set(s, this[s]), delete this[s]);
+    t.size > 0 && (this._$Ep = t);
+  }
+  createRenderRoot() {
+    const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
+    return mt(t, this.constructor.elementStyles), t;
+  }
+  connectedCallback() {
+    var t;
+    this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (t = this._$EO) == null || t.forEach((e) => {
+      var s;
+      return (s = e.hostConnected) == null ? void 0 : s.call(e);
+    });
+  }
+  enableUpdating(t) {
+  }
+  disconnectedCallback() {
+    var t;
+    (t = this._$EO) == null || t.forEach((e) => {
+      var s;
+      return (s = e.hostDisconnected) == null ? void 0 : s.call(e);
+    });
+  }
+  attributeChangedCallback(t, e, s) {
+    this._$AK(t, s);
+  }
+  _$ET(t, e) {
+    var n;
+    const s = this.constructor.elementProperties.get(t), i = this.constructor._$Eu(t, s);
+    if (i !== void 0 && s.reflect === !0) {
+      const o = (((n = s.converter) == null ? void 0 : n.toAttribute) !== void 0 ? s.converter : D).toAttribute(e, s.type);
+      this._$Em = t, o == null ? this.removeAttribute(i) : this.setAttribute(i, o), this._$Em = null;
+    }
+  }
+  _$AK(t, e) {
+    var n, o;
+    const s = this.constructor, i = s._$Eh.get(t);
+    if (i !== void 0 && this._$Em !== i) {
+      const h = s.getPropertyOptions(i), a = typeof h.converter == "function" ? { fromAttribute: h.converter } : ((n = h.converter) == null ? void 0 : n.fromAttribute) !== void 0 ? h.converter : D;
+      this._$Em = i;
+      const c = a.fromAttribute(e, h.type);
+      this[i] = c ?? ((o = this._$Ej) == null ? void 0 : o.get(i)) ?? c, this._$Em = null;
+    }
+  }
+  requestUpdate(t, e, s, i = !1, n) {
+    var o;
+    if (t !== void 0) {
+      const h = this.constructor;
+      if (i === !1 && (n = this[t]), s ?? (s = h.getPropertyOptions(t)), !((s.hasChanged ?? F)(n, e) || s.useDefault && s.reflect && n === ((o = this._$Ej) == null ? void 0 : o.get(t)) && !this.hasAttribute(h._$Eu(t, s)))) return;
+      this.C(t, e, s);
+    }
+    this.isUpdatePending === !1 && (this._$ES = this._$EP());
+  }
+  C(t, e, { useDefault: s, reflect: i, wrapped: n }, o) {
+    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t) && (this._$Ej.set(t, o ?? e ?? this[t]), n !== !0 || o !== void 0) || (this._$AL.has(t) || (this.hasUpdated || s || (e = void 0), this._$AL.set(t, e)), i === !0 && this._$Em !== t && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t));
+  }
+  async _$EP() {
+    this.isUpdatePending = !0;
+    try {
+      await this._$ES;
+    } catch (e) {
+      Promise.reject(e);
+    }
+    const t = this.scheduleUpdate();
+    return t != null && await t, !this.isUpdatePending;
+  }
+  scheduleUpdate() {
+    return this.performUpdate();
+  }
+  performUpdate() {
+    var s;
+    if (!this.isUpdatePending) return;
+    if (!this.hasUpdated) {
+      if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
+        for (const [n, o] of this._$Ep) this[n] = o;
+        this._$Ep = void 0;
+      }
+      const i = this.constructor.elementProperties;
+      if (i.size > 0) for (const [n, o] of i) {
+        const { wrapped: h } = o, a = this[n];
+        h !== !0 || this._$AL.has(n) || a === void 0 || this.C(n, void 0, o, a);
+      }
+    }
+    let t = !1;
+    const e = this._$AL;
+    try {
+      t = this.shouldUpdate(e), t ? (this.willUpdate(e), (s = this._$EO) == null || s.forEach((i) => {
+        var n;
+        return (n = i.hostUpdate) == null ? void 0 : n.call(i);
+      }), this.update(e)) : this._$EM();
+    } catch (i) {
+      throw t = !1, this._$EM(), i;
+    }
+    t && this._$AE(e);
+  }
+  willUpdate(t) {
+  }
+  _$AE(t) {
+    var e;
+    (e = this._$EO) == null || e.forEach((s) => {
+      var i;
+      return (i = s.hostUpdated) == null ? void 0 : i.call(s);
+    }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
+  }
+  _$EM() {
+    this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = !1;
+  }
+  get updateComplete() {
+    return this.getUpdateComplete();
+  }
+  getUpdateComplete() {
+    return this._$ES;
+  }
+  shouldUpdate(t) {
+    return !0;
+  }
+  update(t) {
+    this._$Eq && (this._$Eq = this._$Eq.forEach((e) => this._$ET(e, this[e]))), this._$EM();
+  }
+  updated(t) {
+  }
+  firstUpdated(t) {
+  }
+};
+b.elementStyles = [], b.shadowRootOptions = { mode: "open" }, b[N("elementProperties")] = /* @__PURE__ */ new Map(), b[N("finalized")] = /* @__PURE__ */ new Map(), L == null || L({ ReactiveElement: b }), (y.reactiveElementVersions ?? (y.reactiveElementVersions = [])).push("2.1.2");
+/**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */const x=globalThis,tt=r=>r,j=x.trustedTypes,et=j?j.createPolicy("lit-html",{createHTML:r=>r}):void 0,ct="$lit$",g=`lit$${Math.random().toFixed(9).slice(2)}$`,dt="?"+g,bt=`<${dt}>`,w=document,T=()=>w.createComment(""),O=r=>r===null||typeof r!="object"&&typeof r!="function",J=Array.isArray,Pt=r=>J(r)||typeof(r==null?void 0:r[Symbol.iterator])=="function",z=`[
-\f\r]`,C=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,st=/-->/g,it=/>/g,A=RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^
-\f\r"'\`<>=]|("|')|))|$)`,"g"),rt=/'/g,nt=/"/g,ut=/^(?:script|style|textarea|title)$/i,kt=r=>(t,...e)=>({_$litType$:r,strings:t,values:e}),v=kt(1),P=Symbol.for("lit-noChange"),d=Symbol.for("lit-nothing"),ot=new WeakMap,E=w.createTreeWalker(w,129);function _t(r,t){if(!J(r)||!r.hasOwnProperty("raw"))throw Error("invalid template strings array");return et!==void 0?et.createHTML(t):t}const Ct=(r,t)=>{const e=r.length-1,s=[];let i,n=t===2?"<svg>":t===3?"<math>":"",o=C;for(let h=0;h<e;h++){const a=r[h];let c,_,l=-1,$=0;for(;$<a.length&&(o.lastIndex=$,_=o.exec(a),_!==null);)$=o.lastIndex,o===C?_[1]==="!--"?o=st:_[1]!==void 0?o=it:_[2]!==void 0?(ut.test(_[2])&&(i=RegExp("</"+_[2],"g")),o=A):_[3]!==void 0&&(o=A):o===A?_[0]===">"?(o=i??C,l=-1):_[1]===void 0?l=-2:(l=o.lastIndex-_[2].length,c=_[1],o=_[3]===void 0?A:_[3]==='"'?nt:rt):o===nt||o===rt?o=A:o===st||o===it?o=C:(o=A,i=void 0);const m=o===A&&r[h+1].startsWith("/>")?" ":"";n+=o===C?a+bt:l>=0?(s.push(c),a.slice(0,l)+ct+a.slice(l)+g+m):a+g+(l===-2?h:m)}return[_t(r,n+(r[e]||"<?>")+(t===2?"</svg>":t===3?"</math>":"")),s]};class U{constructor({strings:t,_$litType$:e},s){let i;this.parts=[];let n=0,o=0;const h=t.length-1,a=this.parts,[c,_]=Ct(t,e);if(this.el=U.createElement(c,s),E.currentNode=this.el.content,e===2||e===3){const l=this.el.content.firstChild;l.replaceWith(...l.childNodes)}for(;(i=E.nextNode())!==null&&a.length<h;){if(i.nodeType===1){if(i.hasAttributes())for(const l of i.getAttributeNames())if(l.endsWith(ct)){const $=_[o++],m=i.getAttribute(l).split(g),R=/([.?@])?(.*)/.exec($);a.push({type:1,index:n,name:R[2],strings:m,ctor:R[1]==="."?xt:R[1]==="?"?Mt:R[1]==="@"?Tt:G}),i.removeAttribute(l)}else l.startsWith(g)&&(a.push({type:6,index:n}),i.removeAttribute(l));if(ut.test(i.tagName)){const l=i.textContent.split(g),$=l.length-1;if($>0){i.textContent=j?j.emptyScript:"";for(let m=0;m<$;m++)i.append(l[m],T()),E.nextNode(),a.push({type:2,index:++n});i.append(l[$],T())}}}else if(i.nodeType===8)if(i.data===dt)a.push({type:2,index:n});else{let l=-1;for(;(l=i.data.indexOf(g,l+1))!==-1;)a.push({type:7,index:n}),l+=g.length-1}n++}}static createElement(t,e){const s=w.createElement("template");return s.innerHTML=t,s}}function k(r,t,e=r,s){var o,h;if(t===P)return t;let i=s!==void 0?(o=e._$Co)==null?void 0:o[s]:e._$Cl;const n=O(t)?void 0:t._$litDirective$;return(i==null?void 0:i.constructor)!==n&&((h=i==null?void 0:i._$AO)==null||h.call(i,!1),n===void 0?i=void 0:(i=new n(r),i._$AT(r,e,s)),s!==void 0?(e._$Co??(e._$Co=[]))[s]=i:e._$Cl=i),i!==void 0&&(t=k(r,i._$AS(r,t.values),i,s)),t}class Nt{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:s}=this._$AD,i=((t==null?void 0:t.creationScope)??w).importNode(e,!0);E.currentNode=i;let n=E.nextNode(),o=0,h=0,a=s[0];for(;a!==void 0;){if(o===a.index){let c;a.type===2?c=new H(n,n.nextSibling,this,t):a.type===1?c=new a.ctor(n,a.name,a.strings,this,t):a.type===6&&(c=new Ot(n,this,t)),this._$AV.push(c),a=s[++h]}o!==(a==null?void 0:a.index)&&(n=E.nextNode(),o++)}return E.currentNode=w,i}p(t){let e=0;for(const s of this._$AV)s!==void 0&&(s.strings!==void 0?(s._$AI(t,s,e),e+=s.strings.length-2):s._$AI(t[e])),e++}}class H{get _$AU(){var t;return((t=this._$AM)==null?void 0:t._$AU)??this._$Cv}constructor(t,e,s,i){this.type=2,this._$AH=d,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=s,this.options=i,this._$Cv=(i==null?void 0:i.isConnected)??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return e!==void 0&&(t==null?void 0:t.nodeType)===11&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=k(this,t,e),O(t)?t===d||t==null||t===""?(this._$AH!==d&&this._$AR(),this._$AH=d):t!==this._$AH&&t!==P&&this._(t):t._$litType$!==void 0?this.$(t):t.nodeType!==void 0?this.T(t):Pt(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==d&&O(this._$AH)?this._$AA.nextSibling.data=t:this.T(w.createTextNode(t)),this._$AH=t}$(t){var n;const{values:e,_$litType$:s}=t,i=typeof s=="number"?this._$AC(t):(s.el===void 0&&(s.el=U.createElement(_t(s.h,s.h[0]),this.options)),s);if(((n=this._$AH)==null?void 0:n._$AD)===i)this._$AH.p(e);else{const o=new Nt(i,this),h=o.u(this.options);o.p(e),this.T(h),this._$AH=o}}_$AC(t){let e=ot.get(t.strings);return e===void 0&&ot.set(t.strings,e=new U(t)),e}k(t){J(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let s,i=0;for(const n of t)i===e.length?e.push(s=new H(this.O(T()),this.O(T()),this,this.options)):s=e[i],s._$AI(n),i++;i<e.length&&(this._$AR(s&&s._$AB.nextSibling,i),e.length=i)}_$AR(t=this._$AA.nextSibling,e){var s;for((s=this._$AP)==null?void 0:s.call(this,!1,!0,e);t!==this._$AB;){const i=tt(t).nextSibling;tt(t).remove(),t=i}}setConnected(t){var e;this._$AM===void 0&&(this._$Cv=t,(e=this._$AP)==null||e.call(this,t))}}class G{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,s,i,n){this.type=1,this._$AH=d,this._$AN=void 0,this.element=t,this.name=e,this._$AM=i,this.options=n,s.length>2||s[0]!==""||s[1]!==""?(this._$AH=Array(s.length-1).fill(new String),this.strings=s):this._$AH=d}_$AI(t,e=this,s,i){const n=this.strings;let o=!1;if(n===void 0)t=k(this,t,e,0),o=!O(t)||t!==this._$AH&&t!==P,o&&(this._$AH=t);else{const h=t;let a,c;for(t=n[0],a=0;a<n.length-1;a++)c=k(this,h[s+a],e,a),c===P&&(c=this._$AH[a]),o||(o=!O(c)||c!==this._$AH[a]),c===d?t=d:t!==d&&(t+=(c??"")+n[a+1]),this._$AH[a]=c}o&&!i&&this.j(t)}j(t){t===d?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class xt extends G{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===d?void 0:t}}class Mt extends G{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==d)}}class Tt extends G{constructor(t,e,s,i,n){super(t,e,s,i,n),this.type=5}_$AI(t,e=this){if((t=k(this,t,e,0)??d)===P)return;const s=this._$AH,i=t===d&&s!==d||t.capture!==s.capture||t.once!==s.once||t.passive!==s.passive,n=t!==d&&(s===d||i);i&&this.element.removeEventListener(this.name,this,s),n&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){var e;typeof this._$AH=="function"?this._$AH.call(((e=this.options)==null?void 0:e.host)??this.element,t):this._$AH.handleEvent(t)}}class Ot{constructor(t,e,s){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=s}get _$AU(){return this._$AM._$AU}_$AI(t){k(this,t)}}const B=x.litHtmlPolyfillSupport;B==null||B(U,H),(x.litHtmlVersions??(x.litHtmlVersions=[])).push("3.3.2");const Ut=(r,t,e)=>{const s=(e==null?void 0:e.renderBefore)??t;let i=s._$litPart$;if(i===void 0){const n=(e==null?void 0:e.renderBefore)??null;s._$litPart$=i=new H(t.insertBefore(T(),n),n,void 0,e??{})}return i._$AI(r),i};/**
+ */
+const x = globalThis, tt = (r) => r, j = x.trustedTypes, et = j ? j.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, ct = "$lit$", g = `lit$${Math.random().toFixed(9).slice(2)}$`, dt = "?" + g, bt = `<${dt}>`, w = document, T = () => w.createComment(""), O = (r) => r === null || typeof r != "object" && typeof r != "function", J = Array.isArray, Pt = (r) => J(r) || typeof (r == null ? void 0 : r[Symbol.iterator]) == "function", z = `[
+\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, st = /-->/g, it = />/g, A = RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^
+\f\r"'\`<>=]|("|')|))|$)`, "g"), rt = /'/g, nt = /"/g, ut = /^(?:script|style|textarea|title)$/i, kt = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), v = kt(1), P = Symbol.for("lit-noChange"), d = Symbol.for("lit-nothing"), ot = /* @__PURE__ */ new WeakMap(), E = w.createTreeWalker(w, 129);
+function _t(r, t) {
+  if (!J(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return et !== void 0 ? et.createHTML(t) : t;
+}
+const Ct = (r, t) => {
+  const e = r.length - 1, s = [];
+  let i, n = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = C;
+  for (let h = 0; h < e; h++) {
+    const a = r[h];
+    let c, _, l = -1, $ = 0;
+    for (; $ < a.length && (o.lastIndex = $, _ = o.exec(a), _ !== null); ) $ = o.lastIndex, o === C ? _[1] === "!--" ? o = st : _[1] !== void 0 ? o = it : _[2] !== void 0 ? (ut.test(_[2]) && (i = RegExp("</" + _[2], "g")), o = A) : _[3] !== void 0 && (o = A) : o === A ? _[0] === ">" ? (o = i ?? C, l = -1) : _[1] === void 0 ? l = -2 : (l = o.lastIndex - _[2].length, c = _[1], o = _[3] === void 0 ? A : _[3] === '"' ? nt : rt) : o === nt || o === rt ? o = A : o === st || o === it ? o = C : (o = A, i = void 0);
+    const m = o === A && r[h + 1].startsWith("/>") ? " " : "";
+    n += o === C ? a + bt : l >= 0 ? (s.push(c), a.slice(0, l) + ct + a.slice(l) + g + m) : a + g + (l === -2 ? h : m);
+  }
+  return [_t(r, n + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), s];
+};
+class U {
+  constructor({ strings: t, _$litType$: e }, s) {
+    let i;
+    this.parts = [];
+    let n = 0, o = 0;
+    const h = t.length - 1, a = this.parts, [c, _] = Ct(t, e);
+    if (this.el = U.createElement(c, s), E.currentNode = this.el.content, e === 2 || e === 3) {
+      const l = this.el.content.firstChild;
+      l.replaceWith(...l.childNodes);
+    }
+    for (; (i = E.nextNode()) !== null && a.length < h; ) {
+      if (i.nodeType === 1) {
+        if (i.hasAttributes()) for (const l of i.getAttributeNames()) if (l.endsWith(ct)) {
+          const $ = _[o++], m = i.getAttribute(l).split(g), R = /([.?@])?(.*)/.exec($);
+          a.push({ type: 1, index: n, name: R[2], strings: m, ctor: R[1] === "." ? xt : R[1] === "?" ? Mt : R[1] === "@" ? Tt : G }), i.removeAttribute(l);
+        } else l.startsWith(g) && (a.push({ type: 6, index: n }), i.removeAttribute(l));
+        if (ut.test(i.tagName)) {
+          const l = i.textContent.split(g), $ = l.length - 1;
+          if ($ > 0) {
+            i.textContent = j ? j.emptyScript : "";
+            for (let m = 0; m < $; m++) i.append(l[m], T()), E.nextNode(), a.push({ type: 2, index: ++n });
+            i.append(l[$], T());
+          }
+        }
+      } else if (i.nodeType === 8) if (i.data === dt) a.push({ type: 2, index: n });
+      else {
+        let l = -1;
+        for (; (l = i.data.indexOf(g, l + 1)) !== -1; ) a.push({ type: 7, index: n }), l += g.length - 1;
+      }
+      n++;
+    }
+  }
+  static createElement(t, e) {
+    const s = w.createElement("template");
+    return s.innerHTML = t, s;
+  }
+}
+function k(r, t, e = r, s) {
+  var o, h;
+  if (t === P) return t;
+  let i = s !== void 0 ? (o = e._$Co) == null ? void 0 : o[s] : e._$Cl;
+  const n = O(t) ? void 0 : t._$litDirective$;
+  return (i == null ? void 0 : i.constructor) !== n && ((h = i == null ? void 0 : i._$AO) == null || h.call(i, !1), n === void 0 ? i = void 0 : (i = new n(r), i._$AT(r, e, s)), s !== void 0 ? (e._$Co ?? (e._$Co = []))[s] = i : e._$Cl = i), i !== void 0 && (t = k(r, i._$AS(r, t.values), i, s)), t;
+}
+class Nt {
+  constructor(t, e) {
+    this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
+  }
+  get parentNode() {
+    return this._$AM.parentNode;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  u(t) {
+    const { el: { content: e }, parts: s } = this._$AD, i = ((t == null ? void 0 : t.creationScope) ?? w).importNode(e, !0);
+    E.currentNode = i;
+    let n = E.nextNode(), o = 0, h = 0, a = s[0];
+    for (; a !== void 0; ) {
+      if (o === a.index) {
+        let c;
+        a.type === 2 ? c = new H(n, n.nextSibling, this, t) : a.type === 1 ? c = new a.ctor(n, a.name, a.strings, this, t) : a.type === 6 && (c = new Ot(n, this, t)), this._$AV.push(c), a = s[++h];
+      }
+      o !== (a == null ? void 0 : a.index) && (n = E.nextNode(), o++);
+    }
+    return E.currentNode = w, i;
+  }
+  p(t) {
+    let e = 0;
+    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(t, s, e), e += s.strings.length - 2) : s._$AI(t[e])), e++;
+  }
+}
+class H {
+  get _$AU() {
+    var t;
+    return ((t = this._$AM) == null ? void 0 : t._$AU) ?? this._$Cv;
+  }
+  constructor(t, e, s, i) {
+    this.type = 2, this._$AH = d, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = s, this.options = i, this._$Cv = (i == null ? void 0 : i.isConnected) ?? !0;
+  }
+  get parentNode() {
+    let t = this._$AA.parentNode;
+    const e = this._$AM;
+    return e !== void 0 && (t == null ? void 0 : t.nodeType) === 11 && (t = e.parentNode), t;
+  }
+  get startNode() {
+    return this._$AA;
+  }
+  get endNode() {
+    return this._$AB;
+  }
+  _$AI(t, e = this) {
+    t = k(this, t, e), O(t) ? t === d || t == null || t === "" ? (this._$AH !== d && this._$AR(), this._$AH = d) : t !== this._$AH && t !== P && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Pt(t) ? this.k(t) : this._(t);
+  }
+  O(t) {
+    return this._$AA.parentNode.insertBefore(t, this._$AB);
+  }
+  T(t) {
+    this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
+  }
+  _(t) {
+    this._$AH !== d && O(this._$AH) ? this._$AA.nextSibling.data = t : this.T(w.createTextNode(t)), this._$AH = t;
+  }
+  $(t) {
+    var n;
+    const { values: e, _$litType$: s } = t, i = typeof s == "number" ? this._$AC(t) : (s.el === void 0 && (s.el = U.createElement(_t(s.h, s.h[0]), this.options)), s);
+    if (((n = this._$AH) == null ? void 0 : n._$AD) === i) this._$AH.p(e);
+    else {
+      const o = new Nt(i, this), h = o.u(this.options);
+      o.p(e), this.T(h), this._$AH = o;
+    }
+  }
+  _$AC(t) {
+    let e = ot.get(t.strings);
+    return e === void 0 && ot.set(t.strings, e = new U(t)), e;
+  }
+  k(t) {
+    J(this._$AH) || (this._$AH = [], this._$AR());
+    const e = this._$AH;
+    let s, i = 0;
+    for (const n of t) i === e.length ? e.push(s = new H(this.O(T()), this.O(T()), this, this.options)) : s = e[i], s._$AI(n), i++;
+    i < e.length && (this._$AR(s && s._$AB.nextSibling, i), e.length = i);
+  }
+  _$AR(t = this._$AA.nextSibling, e) {
+    var s;
+    for ((s = this._$AP) == null ? void 0 : s.call(this, !1, !0, e); t !== this._$AB; ) {
+      const i = tt(t).nextSibling;
+      tt(t).remove(), t = i;
+    }
+  }
+  setConnected(t) {
+    var e;
+    this._$AM === void 0 && (this._$Cv = t, (e = this._$AP) == null || e.call(this, t));
+  }
+}
+class G {
+  get tagName() {
+    return this.element.tagName;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  constructor(t, e, s, i, n) {
+    this.type = 1, this._$AH = d, this._$AN = void 0, this.element = t, this.name = e, this._$AM = i, this.options = n, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = d;
+  }
+  _$AI(t, e = this, s, i) {
+    const n = this.strings;
+    let o = !1;
+    if (n === void 0) t = k(this, t, e, 0), o = !O(t) || t !== this._$AH && t !== P, o && (this._$AH = t);
+    else {
+      const h = t;
+      let a, c;
+      for (t = n[0], a = 0; a < n.length - 1; a++) c = k(this, h[s + a], e, a), c === P && (c = this._$AH[a]), o || (o = !O(c) || c !== this._$AH[a]), c === d ? t = d : t !== d && (t += (c ?? "") + n[a + 1]), this._$AH[a] = c;
+    }
+    o && !i && this.j(t);
+  }
+  j(t) {
+    t === d ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+  }
+}
+class xt extends G {
+  constructor() {
+    super(...arguments), this.type = 3;
+  }
+  j(t) {
+    this.element[this.name] = t === d ? void 0 : t;
+  }
+}
+class Mt extends G {
+  constructor() {
+    super(...arguments), this.type = 4;
+  }
+  j(t) {
+    this.element.toggleAttribute(this.name, !!t && t !== d);
+  }
+}
+class Tt extends G {
+  constructor(t, e, s, i, n) {
+    super(t, e, s, i, n), this.type = 5;
+  }
+  _$AI(t, e = this) {
+    if ((t = k(this, t, e, 0) ?? d) === P) return;
+    const s = this._$AH, i = t === d && s !== d || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive, n = t !== d && (s === d || i);
+    i && this.element.removeEventListener(this.name, this, s), n && this.element.addEventListener(this.name, this, t), this._$AH = t;
+  }
+  handleEvent(t) {
+    var e;
+    typeof this._$AH == "function" ? this._$AH.call(((e = this.options) == null ? void 0 : e.host) ?? this.element, t) : this._$AH.handleEvent(t);
+  }
+}
+class Ot {
+  constructor(t, e, s) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = s;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  _$AI(t) {
+    k(this, t);
+  }
+}
+const B = x.litHtmlPolyfillSupport;
+B == null || B(U, H), (x.litHtmlVersions ?? (x.litHtmlVersions = [])).push("3.3.2");
+const Ut = (r, t, e) => {
+  const s = (e == null ? void 0 : e.renderBefore) ?? t;
+  let i = s._$litPart$;
+  if (i === void 0) {
+    const n = (e == null ? void 0 : e.renderBefore) ?? null;
+    s._$litPart$ = i = new H(t.insertBefore(T(), n), n, void 0, e ?? {});
+  }
+  return i._$AI(r), i;
+};
+/**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */const S=globalThis;class M extends b{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var e;const t=super.createRenderRoot();return(e=this.renderOptions).renderBefore??(e.renderBefore=t.firstChild),t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=Ut(e,this.renderRoot,this.renderOptions)}connectedCallback(){var t;super.connectedCallback(),(t=this._$Do)==null||t.setConnected(!0)}disconnectedCallback(){var t;super.disconnectedCallback(),(t=this._$Do)==null||t.setConnected(!1)}render(){return P}}var ht;M._$litElement$=!0,M.finalized=!0,(ht=S.litElementHydrateSupport)==null||ht.call(S,{LitElement:M});const V=S.litElementPolyfillSupport;V==null||V({LitElement:M});(S.litElementVersions??(S.litElementVersions=[])).push("4.2.2");/**
+ */
+const S = globalThis;
+class M extends b {
+  constructor() {
+    super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
+  }
+  createRenderRoot() {
+    var e;
+    const t = super.createRenderRoot();
+    return (e = this.renderOptions).renderBefore ?? (e.renderBefore = t.firstChild), t;
+  }
+  update(t) {
+    const e = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Ut(e, this.renderRoot, this.renderOptions);
+  }
+  connectedCallback() {
+    var t;
+    super.connectedCallback(), (t = this._$Do) == null || t.setConnected(!0);
+  }
+  disconnectedCallback() {
+    var t;
+    super.disconnectedCallback(), (t = this._$Do) == null || t.setConnected(!1);
+  }
+  render() {
+    return P;
+  }
+}
+var ht;
+M._$litElement$ = !0, M.finalized = !0, (ht = S.litElementHydrateSupport) == null || ht.call(S, { LitElement: M });
+const V = S.litElementPolyfillSupport;
+V == null || V({ LitElement: M });
+(S.litElementVersions ?? (S.litElementVersions = [])).push("4.2.2");
+/**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */const Ht=r=>(t,e)=>{e!==void 0?e.addInitializer(()=>{customElements.define(r,t)}):customElements.define(r,t)};/**
+ */
+const Ht = (r) => (t, e) => {
+  e !== void 0 ? e.addInitializer(() => {
+    customElements.define(r, t);
+  }) : customElements.define(r, t);
+};
+/**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */const Rt={attribute:!0,type:String,converter:D,reflect:!1,hasChanged:F},It=(r=Rt,t,e)=>{const{kind:s,metadata:i}=e;let n=globalThis.litPropertyMetadata.get(i);if(n===void 0&&globalThis.litPropertyMetadata.set(i,n=new Map),s==="setter"&&((r=Object.create(r)).wrapped=!0),n.set(e.name,r),s==="accessor"){const{name:o}=e;return{set(h){const a=t.get.call(this);t.set.call(this,h),this.requestUpdate(o,a,r,!0,h)},init(h){return h!==void 0&&this.C(o,void 0,r,h),h}}}if(s==="setter"){const{name:o}=e;return function(h){const a=this[o];t.call(this,h),this.requestUpdate(o,a,r,!0,h)}}throw Error("Unsupported decorator location: "+s)};function pt(r){return(t,e)=>typeof e=="object"?It(r,t,e):((s,i,n)=>{const o=i.hasOwnProperty(n);return i.constructor.createProperty(n,s),o?Object.getOwnPropertyDescriptor(i,n):void 0})(r,t,e)}/**
+ */
+const Rt = { attribute: !0, type: String, converter: D, reflect: !1, hasChanged: F }, It = (r = Rt, t, e) => {
+  const { kind: s, metadata: i } = e;
+  let n = globalThis.litPropertyMetadata.get(i);
+  if (n === void 0 && globalThis.litPropertyMetadata.set(i, n = /* @__PURE__ */ new Map()), s === "setter" && ((r = Object.create(r)).wrapped = !0), n.set(e.name, r), s === "accessor") {
+    const { name: o } = e;
+    return { set(h) {
+      const a = t.get.call(this);
+      t.set.call(this, h), this.requestUpdate(o, a, r, !0, h);
+    }, init(h) {
+      return h !== void 0 && this.C(o, void 0, r, h), h;
+    } };
+  }
+  if (s === "setter") {
+    const { name: o } = e;
+    return function(h) {
+      const a = this[o];
+      t.call(this, h), this.requestUpdate(o, a, r, !0, h);
+    };
+  }
+  throw Error("Unsupported decorator location: " + s);
+};
+function pt(r) {
+  return (t, e) => typeof e == "object" ? It(r, t, e) : ((s, i, n) => {
+    const o = i.hasOwnProperty(n);
+    return i.constructor.createProperty(n, s), o ? Object.getOwnPropertyDescriptor(i, n) : void 0;
+  })(r, t, e);
+}
+/**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */function f(r){return pt({...r,state:!0,attribute:!1})}var W=(r=>(r.GET_CONFIG="meraki_ha/get_config",r.SUBSCRIBE_MERAKI_DATA="meraki_ha/subscribe_meraki_data",r.GET_CAMERA_STREAM_URL="meraki_ha/get_camera_stream_url",r.GET_CAMERA_SNAPSHOT="meraki_ha/get_camera_snapshot",r.GET_VERSION="meraki_ha/get_version",r.GET_NETWORK_EVENTS="meraki_ha/get_network_events",r.UPDATE_ENABLED_NETWORKS="meraki_ha/update_enabled_networks",r.CREATE_GUEST_KEY="meraki_ha/ipsk/create",r.GET_GUEST_KEYS="meraki_ha/ipsk/get",r.REVOKE_GUEST_KEY="meraki_ha/ipsk/revoke",r.TIMED_ACCESS_GET_POLICIES="meraki_ha/timed_access/get_policies",r))(W||{});const at=async(r,t)=>{if(!r)throw new Error("Home Assistant object is not available.");try{if(typeof r.callWS=="function")return await r.callWS(t);if(r.connection&&typeof r.connection.sendMessagePromise=="function")return await r.connection.sendMessagePromise(t);throw new Error("Home Assistant WebSocket communication methods not found.")}catch(e){throw console.error(`Meraki HA: WebSocket error [${t.type}]:`,e),e}};var Dt=Object.defineProperty,jt=Object.getOwnPropertyDescriptor,p=(r,t,e,s)=>{for(var i=s>1?void 0:s?jt(t,e):t,n=r.length-1,o;n>=0;n--)(o=r[n])&&(i=(s?o(t,e,i):o(i))||i);return s&&i&&Dt(t,e,i),i};let u=class extends M{constructor(){super(...arguments),this._selectedNetwork="",this._selectedSsid="",this._selectedPolicy="",this._duration="60",this._customName="",this._customPassphrase="",this._creating=!1,this._error=null,this._success=null,this._networks=[],this._ssids=[],this._policies=[],this._loading=!0}setConfig(r){if(!r)throw new Error("Invalid configuration");this._config=r}static getStubConfig(){return{name:"Meraki Guest Access"}}static getConfigElement(){return document.createElement("div")}firstUpdated(r){super.firstUpdated(r),this._fetchInitialData()}updated(r){super.updated(r),r.has("hass")&&this.hass&&!this._networks.length&&this._fetchInitialData()}async _fetchInitialData(){var r;if(this.hass){this._loading=!0;try{const t=await this.hass.callWS({type:"config_entries/get",domain:"meraki_ha"}),e=((r=this._config)==null?void 0:r.config_entry_id)||(t.length>0?t[0].entry_id:null);if(!e){this._error="Meraki integration not found. Please configure it first.",this._loading=!1;return}const s=await at(this.hass,{type:W.GET_CONFIG,config_entry_id:e});this._networks=s.networks.filter(i=>{var n;return(n=i.productTypes)==null?void 0:n.includes("wireless")})||[],this._ssids=s.ssids||[],this._networks.length>0&&!this._selectedNetwork&&(this._selectedNetwork=this._networks[0].id,this._fetchPolicies(this._selectedNetwork,e))}catch(t){this._error=`Failed to fetch Meraki data: ${t.message||t}`}finally{this._loading=!1}}}async _fetchPolicies(r,t){var e;if(this.hass)try{let s=t||((e=this._config)==null?void 0:e.config_entry_id);if(!s){const n=await this.hass.callWS({type:"config_entries/get",domain:"meraki_ha"});s=n.length>0?n[0].entry_id:void 0}if(!s)return;const i=await at(this.hass,{type:W.TIMED_ACCESS_GET_POLICIES,config_entry_id:s,networkId:r});this._policies=i}catch(s){console.error("Failed to fetch policies:",s),this._policies=[]}}render(){var t,e;if(this._loading&&!this._networks.length)return v`
-        <ha-card .header="${((t=this._config)==null?void 0:t.name)||"Meraki Guest Access"}">
+ */
+function f(r) {
+  return pt({ ...r, state: !0, attribute: !1 });
+}
+var W = /* @__PURE__ */ ((r) => (r.GET_CONFIG = "meraki_ha/get_config", r.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", r.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", r.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", r.GET_VERSION = "meraki_ha/get_version", r.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", r.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", r.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", r.GET_GUEST_KEYS = "meraki_ha/ipsk/get", r.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", r.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", r))(W || {});
+const at = async (r, t) => {
+  if (!r)
+    throw new Error("Home Assistant object is not available.");
+  try {
+    if (typeof r.callWS == "function")
+      return await r.callWS(t);
+    if (r.connection && typeof r.connection.sendMessagePromise == "function")
+      return await r.connection.sendMessagePromise(t);
+    throw new Error("Home Assistant WebSocket communication methods not found.");
+  } catch (e) {
+    throw console.error(`Meraki HA: WebSocket error [${t.type}]:`, e), e;
+  }
+};
+var Dt = Object.defineProperty, jt = Object.getOwnPropertyDescriptor, p = (r, t, e, s) => {
+  for (var i = s > 1 ? void 0 : s ? jt(t, e) : t, n = r.length - 1, o; n >= 0; n--)
+    (o = r[n]) && (i = (s ? o(t, e, i) : o(i)) || i);
+  return s && i && Dt(t, e, i), i;
+};
+let u = class extends M {
+  constructor() {
+    super(...arguments), this._selectedNetwork = "", this._selectedSsid = "", this._selectedPolicy = "", this._duration = "60", this._customName = "", this._customPassphrase = "", this._creating = !1, this._error = null, this._success = null, this._networks = [], this._ssids = [], this._policies = [], this._loading = !0;
+  }
+  setConfig(r) {
+    if (!r)
+      throw new Error("Invalid configuration");
+    this._config = r;
+  }
+  static getStubConfig() {
+    return {
+      name: "Meraki Guest Access"
+    };
+  }
+  static getConfigElement() {
+    return document.createElement("div");
+  }
+  firstUpdated(r) {
+    super.firstUpdated(r), this._fetchInitialData();
+  }
+  updated(r) {
+    super.updated(r), r.has("hass") && this.hass && !this._networks.length && this._fetchInitialData();
+  }
+  async _fetchInitialData() {
+    var r;
+    if (this.hass) {
+      this._loading = !0;
+      try {
+        const t = await this.hass.callWS({
+          type: "config_entries/get",
+          domain: "meraki_ha"
+        }), e = ((r = this._config) == null ? void 0 : r.config_entry_id) || (t.length > 0 ? t[0].entry_id : null);
+        if (!e) {
+          this._error = "Meraki integration not found. Please configure it first.", this._loading = !1;
+          return;
+        }
+        const s = await at(this.hass, {
+          type: W.GET_CONFIG,
+          config_entry_id: e
+        });
+        this._networks = s.networks.filter((i) => {
+          var n;
+          return (n = i.productTypes) == null ? void 0 : n.includes("wireless");
+        }) || [], this._ssids = s.ssids || [], this._networks.length > 0 && !this._selectedNetwork && (this._selectedNetwork = this._networks[0].id, this._fetchPolicies(this._selectedNetwork, e));
+      } catch (t) {
+        this._error = `Failed to fetch Meraki data: ${t.message || t}`;
+      } finally {
+        this._loading = !1;
+      }
+    }
+  }
+  async _fetchPolicies(r, t) {
+    var e;
+    if (this.hass)
+      try {
+        let s = t || ((e = this._config) == null ? void 0 : e.config_entry_id);
+        if (!s) {
+          const n = await this.hass.callWS({
+            type: "config_entries/get",
+            domain: "meraki_ha"
+          });
+          s = n.length > 0 ? n[0].entry_id : void 0;
+        }
+        if (!s) return;
+        const i = await at(this.hass, {
+          type: W.TIMED_ACCESS_GET_POLICIES,
+          config_entry_id: s,
+          networkId: r
+        });
+        this._policies = i;
+      } catch (s) {
+        console.error("Failed to fetch policies:", s), this._policies = [];
+      }
+  }
+  render() {
+    var t, e;
+    if (this._loading && !this._networks.length)
+      return v`
+        <ha-card .header="${((t = this._config) == null ? void 0 : t.name) || "Meraki Guest Access"}">
           <div class="card-content flex justify-center p-8">
             <ha-circular-progress active></ha-circular-progress>
           </div>
         </ha-card>
-      `;const r=this._ssids.filter(s=>s.networkId===this._selectedNetwork);return v`
-      <ha-card .header="${((e=this._config)==null?void 0:e.name)||"Meraki Guest Access"}">
+      `;
+    const r = this._ssids.filter((s) => s.networkId === this._selectedNetwork);
+    return v`
+      <ha-card .header="${((e = this._config) == null ? void 0 : e.name) || "Meraki Guest Access"}">
         <div class="card-content">
-          ${this._error?v`
-                <ha-alert alert-type="error" dismissable @alert-dismissed-clicked="${()=>this._error=null}">
+          ${this._error ? v`
+                <ha-alert alert-type="error" dismissable @alert-dismissed-clicked="${() => this._error = null}">
                   ${this._error}
                 </ha-alert>
-              `:""}
-          ${this._success?v`
-                <ha-alert alert-type="success" dismissable @alert-dismissed-clicked="${()=>this._success=null}">
+              ` : ""}
+          ${this._success ? v`
+                <ha-alert alert-type="success" dismissable @alert-dismissed-clicked="${() => this._success = null}">
                   ${this._success}
                 </ha-alert>
-              `:""}
+              ` : ""}
 
           <div class="form-container">
             <ha-select
@@ -56,7 +727,9 @@
               fixedMenuPosition
               naturalMenuWidth
             >
-              ${this._networks.map(s=>v`<ha-list-item .value="${s.id}">${s.name}</ha-list-item>`)}
+              ${this._networks.map(
+      (s) => v`<ha-list-item .value="${s.id}">${s.name}</ha-list-item>`
+    )}
             </ha-select>
 
             <ha-select
@@ -67,25 +740,29 @@
               fixedMenuPosition
               naturalMenuWidth
             >
-              ${r.map(s=>v`<ha-list-item .value="${s.number.toString()}">${s.name} (SSID ${s.number})</ha-list-item>`)}
+              ${r.map(
+      (s) => v`<ha-list-item .value="${s.number.toString()}">${s.name} (SSID ${s.number})</ha-list-item>`
+    )}
             </ha-select>
 
             <ha-select
               label="Group Policy"
               .value="${this._selectedPolicy}"
               .disabled="${!this._selectedNetwork}"
-              @selected="${s=>this._selectedPolicy=s.target.value}"
+              @selected="${(s) => this._selectedPolicy = s.target.value}"
               fixedMenuPosition
               naturalMenuWidth
             >
               <ha-list-item value="">None (Default)</ha-list-item>
-              ${this._policies.map(s=>v`<ha-list-item .value="${s.groupPolicyId}">${s.name}</ha-list-item>`)}
+              ${this._policies.map(
+      (s) => v`<ha-list-item .value="${s.groupPolicyId}">${s.name}</ha-list-item>`
+    )}
             </ha-select>
 
             <ha-select
               label="Duration"
               .value="${this._duration}"
-              @selected="${s=>this._duration=s.target.value}"
+              @selected="${(s) => this._duration = s.target.value}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -100,27 +777,56 @@
               label="Name (Optional)"
               placeholder="e.g. Guest-John"
               .value="${this._customName}"
-              @input="${s=>this._customName=s.target.value}"
+              @input="${(s) => this._customName = s.target.value}"
             ></ha-textfield>
 
             <ha-textfield
               label="Passphrase (Optional)"
               placeholder="Leave empty to auto-generate"
               .value="${this._customPassphrase}"
-              @input="${s=>this._customPassphrase=s.target.value}"
+              @input="${(s) => this._customPassphrase = s.target.value}"
             ></ha-textfield>
 
             <ha-button
               raised
-              .disabled="${this._creating||!this._selectedNetwork||!this._selectedSsid}"
+              .disabled="${this._creating || !this._selectedNetwork || !this._selectedSsid}"
               @click="${this._handleCreate}"
             >
-              ${this._creating?"Creating...":"Generate access key"}
+              ${this._creating ? "Creating..." : "Generate access key"}
             </ha-button>
           </div>
         </div>
       </ha-card>
-    `}_handleNetworkChanged(r){const t=r.target.value;t!==this._selectedNetwork&&(this._selectedNetwork=t,this._selectedSsid="",this._selectedPolicy="",this._fetchPolicies(t))}_handleSsidChanged(r){this._selectedSsid=r.target.value}async _handleCreate(){if(!(!this._selectedNetwork||!this._selectedSsid)){this._creating=!0,this._error=null,this._success=null;try{await this.hass.callService("meraki_ha","create_guest_key",{network_id:this._selectedNetwork,ssid_number:parseInt(this._selectedSsid,10),duration_minutes:parseInt(this._duration,10),name:this._customName||void 0,passphrase:this._customPassphrase||void 0,group_policy_id:this._selectedPolicy||void 0}),this._success="Guest access key created successfully!",this._customName="",this._customPassphrase=""}catch(r){this._error=`Failed to create guest key: ${r.message||r}`}finally{this._creating=!1}}}};u.styles=$t`
+    `;
+  }
+  _handleNetworkChanged(r) {
+    const t = r.target.value;
+    t !== this._selectedNetwork && (this._selectedNetwork = t, this._selectedSsid = "", this._selectedPolicy = "", this._fetchPolicies(t));
+  }
+  _handleSsidChanged(r) {
+    this._selectedSsid = r.target.value;
+  }
+  async _handleCreate() {
+    if (!(!this._selectedNetwork || !this._selectedSsid)) {
+      this._creating = !0, this._error = null, this._success = null;
+      try {
+        await this.hass.callService("meraki_ha", "create_guest_key", {
+          network_id: this._selectedNetwork,
+          ssid_number: parseInt(this._selectedSsid, 10),
+          duration_minutes: parseInt(this._duration, 10),
+          name: this._customName || void 0,
+          passphrase: this._customPassphrase || void 0,
+          group_policy_id: this._selectedPolicy || void 0
+        }), this._success = "Guest access key created successfully!", this._customName = "", this._customPassphrase = "";
+      } catch (r) {
+        this._error = `Failed to create guest key: ${r.message || r}`;
+      } finally {
+        this._creating = !1;
+      }
+    }
+  }
+};
+u.styles = $t`
     :host {
       display: block;
     }
@@ -148,4 +854,55 @@
     .p-8 {
       padding: 32px;
     }
-  `;p([pt({attribute:!1})],u.prototype,"hass",2);p([f()],u.prototype,"_config",2);p([f()],u.prototype,"_selectedNetwork",2);p([f()],u.prototype,"_selectedSsid",2);p([f()],u.prototype,"_selectedPolicy",2);p([f()],u.prototype,"_duration",2);p([f()],u.prototype,"_customName",2);p([f()],u.prototype,"_customPassphrase",2);p([f()],u.prototype,"_creating",2);p([f()],u.prototype,"_error",2);p([f()],u.prototype,"_success",2);p([f()],u.prototype,"_networks",2);p([f()],u.prototype,"_ssids",2);p([f()],u.prototype,"_policies",2);p([f()],u.prototype,"_loading",2);u=p([Ht("meraki-guest-access-card")],u);
+  `;
+p([
+  pt({ attribute: !1 })
+], u.prototype, "hass", 2);
+p([
+  f()
+], u.prototype, "_config", 2);
+p([
+  f()
+], u.prototype, "_selectedNetwork", 2);
+p([
+  f()
+], u.prototype, "_selectedSsid", 2);
+p([
+  f()
+], u.prototype, "_selectedPolicy", 2);
+p([
+  f()
+], u.prototype, "_duration", 2);
+p([
+  f()
+], u.prototype, "_customName", 2);
+p([
+  f()
+], u.prototype, "_customPassphrase", 2);
+p([
+  f()
+], u.prototype, "_creating", 2);
+p([
+  f()
+], u.prototype, "_error", 2);
+p([
+  f()
+], u.prototype, "_success", 2);
+p([
+  f()
+], u.prototype, "_networks", 2);
+p([
+  f()
+], u.prototype, "_ssids", 2);
+p([
+  f()
+], u.prototype, "_policies", 2);
+p([
+  f()
+], u.prototype, "_loading", 2);
+u = p([
+  Ht("meraki-guest-access-card")
+], u);
+export {
+  u as MerakiGuestAccessCard
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1057 @@
+{
+  "name": "meraki-ha-frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meraki-ha-frontend",
+      "version": "1.0.0",
+      "dependencies": {
+        "lit": "^3.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "meraki-ha-frontend",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "dependencies": {
+    "lit": "^3.0.0"
+  }
+}

--- a/frontend/src/meraki-card.ts
+++ b/frontend/src/meraki-card.ts
@@ -1,0 +1,306 @@
+import { LitElement, html, css, PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { HomeAssistant } from './types/ha';
+import { Network, SSID } from './types/meraki';
+import { WsCommand } from './types/websocket';
+import { safeCallWS } from './utils/api';
+
+interface Config {
+  type: string;
+  name?: string;
+  config_entry_id?: string;
+}
+
+@customElement('meraki-guest-access-card')
+export class MerakiGuestAccessCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() private _config?: Config;
+
+  @state() private _selectedNetwork: string = '';
+  @state() private _selectedSsid: string = '';
+  @state() private _selectedPolicy: string = '';
+  @state() private _duration: string = '60';
+  @state() private _customName: string = '';
+  @state() private _customPassphrase: string = '';
+
+  @state() private _creating: boolean = false;
+  @state() private _error: string | null = null;
+  @state() private _success: string | null = null;
+
+  @state() private _networks: Network[] = [];
+  @state() private _ssids: SSID[] = [];
+  @state() private _policies: any[] = [];
+  @state() private _loading: boolean = true;
+
+  public setConfig(config: Config): void {
+    if (!config) {
+      throw new Error('Invalid configuration');
+    }
+    this._config = config;
+  }
+
+  public static getStubConfig(): Record<string, unknown> {
+    return {
+      name: 'Meraki Guest Access',
+    };
+  }
+
+  public static getConfigElement(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  protected firstUpdated(changedProperties: PropertyValues) {
+    super.firstUpdated(changedProperties);
+    this._fetchInitialData();
+  }
+
+  protected updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+    if (changedProperties.has('hass') && this.hass && !this._networks.length) {
+      this._fetchInitialData();
+    }
+  }
+
+  private async _fetchInitialData() {
+    if (!this.hass) return;
+    this._loading = true;
+    try {
+      const configEntries = await this.hass.callWS<any[]>({
+        type: 'config_entries/get',
+        domain: 'meraki_ha',
+      });
+
+      const entryId = this._config?.config_entry_id || (configEntries.length > 0 ? configEntries[0].entry_id : null);
+      if (!entryId) {
+        this._error = 'Meraki integration not found. Please configure it first.';
+        this._loading = false;
+        return;
+      }
+
+      const data = await safeCallWS<any>(this.hass, {
+        type: WsCommand.GET_CONFIG,
+        config_entry_id: entryId,
+      });
+
+      this._networks = data.networks.filter((n: any) => n.productTypes?.includes('wireless')) || [];
+      this._ssids = data.ssids || [];
+
+      if (this._networks.length > 0 && !this._selectedNetwork) {
+        this._selectedNetwork = this._networks[0].id;
+        this._fetchPolicies(this._selectedNetwork, entryId);
+      }
+    } catch (err: any) {
+      this._error = `Failed to fetch Meraki data: ${err.message || err}`;
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  private async _fetchPolicies(networkId: string, configEntryId?: string) {
+    if (!this.hass) return;
+    try {
+      let entryId = configEntryId || this._config?.config_entry_id;
+      if (!entryId) {
+        const configEntries = await this.hass.callWS<any[]>({
+          type: 'config_entries/get',
+          domain: 'meraki_ha',
+        });
+        entryId = configEntries.length > 0 ? configEntries[0].entry_id : undefined;
+      }
+
+      if (!entryId) return;
+
+      const policies = await safeCallWS<any[]>(this.hass, {
+        type: WsCommand.TIMED_ACCESS_GET_POLICIES,
+        config_entry_id: entryId,
+        networkId: networkId,
+      });
+      this._policies = policies;
+    } catch (err: any) {
+      console.error('Failed to fetch policies:', err);
+      this._policies = [];
+    }
+  }
+
+  protected render() {
+    if (this._loading && !this._networks.length) {
+      return html`
+        <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
+          <div class="card-content flex justify-center p-8">
+            <ha-circular-progress active></ha-circular-progress>
+          </div>
+        </ha-card>
+      `;
+    }
+
+    const filteredSsids = this._ssids.filter(s => s.networkId === this._selectedNetwork);
+
+    return html`
+      <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
+        <div class="card-content">
+          ${this._error
+            ? html`
+                <ha-alert alert-type="error" dismissable @alert-dismissed-clicked="${() => (this._error = null)}">
+                  ${this._error}
+                </ha-alert>
+              `
+            : ''}
+          ${this._success
+            ? html`
+                <ha-alert alert-type="success" dismissable @alert-dismissed-clicked="${() => (this._success = null)}">
+                  ${this._success}
+                </ha-alert>
+              `
+            : ''}
+
+          <div class="form-container">
+            <ha-select
+              label="Network"
+              .value="${this._selectedNetwork}"
+              @selected="${this._handleNetworkChanged}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              ${this._networks.map(
+                (n) => html`<ha-list-item .value="${n.id}">${n.name}</ha-list-item>`
+              )}
+            </ha-select>
+
+            <ha-select
+              label="SSID"
+              .value="${this._selectedSsid}"
+              .disabled="${!this._selectedNetwork}"
+              @selected="${this._handleSsidChanged}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              ${filteredSsids.map(
+                (s) => html`<ha-list-item .value="${s.number.toString()}">${s.name} (SSID ${s.number})</ha-list-item>`
+              )}
+            </ha-select>
+
+            <ha-select
+              label="Group Policy"
+              .value="${this._selectedPolicy}"
+              .disabled="${!this._selectedNetwork}"
+              @selected="${(e: any) => (this._selectedPolicy = e.target.value)}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              <ha-list-item value="">None (Default)</ha-list-item>
+              ${this._policies.map(
+                (p) => html`<ha-list-item .value="${p.groupPolicyId}">${p.name}</ha-list-item>`
+              )}
+            </ha-select>
+
+            <ha-select
+              label="Duration"
+              .value="${this._duration}"
+              @selected="${(e: any) => (this._duration = e.target.value)}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              <ha-list-item value="30">30 Minutes</ha-list-item>
+              <ha-list-item value="60">1 Hour</ha-list-item>
+              <ha-list-item value="240">4 Hours</ha-list-item>
+              <ha-list-item value="1440">24 Hours</ha-list-item>
+              <ha-list-item value="10080">7 Days</ha-list-item>
+            </ha-select>
+
+            <ha-textfield
+              label="Name (Optional)"
+              placeholder="e.g. Guest-John"
+              .value="${this._customName}"
+              @input="${(e: any) => (this._customName = e.target.value)}"
+            ></ha-textfield>
+
+            <ha-textfield
+              label="Passphrase (Optional)"
+              placeholder="Leave empty to auto-generate"
+              .value="${this._customPassphrase}"
+              @input="${(e: any) => (this._customPassphrase = e.target.value)}"
+            ></ha-textfield>
+
+            <ha-button
+              raised
+              .disabled="${this._creating || !this._selectedNetwork || !this._selectedSsid}"
+              @click="${this._handleCreate}"
+            >
+              ${this._creating ? 'Creating...' : 'Generate access key'}
+            </ha-button>
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  private _handleNetworkChanged(e: any) {
+    const newNetworkId = e.target.value;
+    if (newNetworkId === this._selectedNetwork) return;
+    this._selectedNetwork = newNetworkId;
+    this._selectedSsid = '';
+    this._selectedPolicy = '';
+    this._fetchPolicies(newNetworkId);
+  }
+
+  private _handleSsidChanged(e: any) {
+    this._selectedSsid = e.target.value;
+  }
+
+  private async _handleCreate() {
+    if (!this._selectedNetwork || !this._selectedSsid) return;
+
+    this._creating = true;
+    this._error = null;
+    this._success = null;
+
+    try {
+      await this.hass.callService('meraki_ha', 'create_guest_key', {
+        network_id: this._selectedNetwork,
+        ssid_number: parseInt(this._selectedSsid, 10),
+        duration_minutes: parseInt(this._duration, 10),
+        name: this._customName || undefined,
+        passphrase: this._customPassphrase || undefined,
+        group_policy_id: this._selectedPolicy || undefined,
+      });
+
+      this._success = 'Guest access key created successfully!';
+      this._customName = '';
+      this._customPassphrase = '';
+    } catch (err: any) {
+      this._error = `Failed to create guest key: ${err.message || err}`;
+    } finally {
+      this._creating = false;
+    }
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .card-content {
+      padding: 16px;
+    }
+    .form-container {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    ha-select, ha-textfield, ha-button {
+      width: 100%;
+    }
+    ha-alert {
+      display: block;
+      margin-bottom: 16px;
+    }
+    .flex {
+      display: flex;
+    }
+    .justify-center {
+      justify-content: center;
+    }
+    .p-8 {
+      padding: 32px;
+    }
+  `;
+}

--- a/frontend/src/types/ha.ts
+++ b/frontend/src/types/ha.ts
@@ -1,0 +1,8 @@
+export interface HomeAssistant {
+  callWS<T>(msg: { type: string; [key: string]: any }): Promise<T>;
+  callService(domain: string, service: string, serviceData?: object): Promise<void>;
+  config: {
+    components: string[];
+  };
+  connection: any;
+}

--- a/frontend/src/types/meraki.ts
+++ b/frontend/src/types/meraki.ts
@@ -1,0 +1,12 @@
+export interface Network {
+  id: string;
+  name: string;
+  productTypes: string[];
+}
+
+export interface SSID {
+  name: string;
+  number: number;
+  enabled: boolean;
+  networkId: string;
+}

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -1,0 +1,13 @@
+export enum WsCommand {
+  GET_CONFIG = "meraki_ha/get_config",
+  SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data",
+  GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url",
+  GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot",
+  GET_VERSION = "meraki_ha/get_version",
+  GET_NETWORK_EVENTS = "meraki_ha/get_network_events",
+  UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks",
+  CREATE_GUEST_KEY = "meraki_ha/ipsk/create",
+  GET_GUEST_KEYS = "meraki_ha/ipsk/get",
+  REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke",
+  TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies",
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,19 @@
+import { HomeAssistant } from '../types/ha';
+
+export const safeCallWS = async <T>(hass: HomeAssistant, msg: any): Promise<T> => {
+  if (!hass) {
+    throw new Error("Home Assistant object is not available.");
+  }
+  try {
+    if (typeof hass.callWS === "function") {
+      return await hass.callWS<T>(msg);
+    }
+    if (hass.connection && typeof hass.connection.sendMessagePromise === "function") {
+      return await hass.connection.sendMessagePromise(msg);
+    }
+    throw new Error("Home Assistant WebSocket communication methods not found.");
+  } catch (err) {
+    console.error(`Meraki HA: WebSocket error [${msg.type}]:`, err);
+    throw err;
+  }
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/meraki-card.ts'),
+      name: 'MerakiCard',
+      fileName: () => 'meraki-card.js',
+      formats: ['es'],
+    },
+    outDir: resolve(__dirname, '../custom_components/meraki_ha/www'),
+    emptyOutDir: false,
+    rollupOptions: {
+      output: {
+        entryFileNames: 'meraki-card.js',
+      },
+    },
+  },
+});


### PR DESCRIPTION
This submission restores a minimal frontend build pipeline specifically for the Meraki custom card. Following the removal of the heavy React panel, the card's source code was being served uncompiled, causing browser errors.

Key changes:
1. **Frontend Source Reconstruction**: Created a new `frontend/` directory with a structured `src/` folder containing the TypeScript source for the custom card, including necessary types and utilities.
2. **Minimal Build Pipeline**: Introduced a lightweight Vite-based build system that transpiles and bundles the TypeScript source into a single ES module. This resolves issues with bare imports (like `lit`) by bundling them into the output artifact.
3. **CI/CD Integration**: Updated the staging deployment workflow to automatically install dependencies and build the frontend card before deployment, ensuring the latest compiled version is always served.
4. **Artifact Generation**: The built `meraki-card.js` is now correctly outputted to the integration's static file directory (`custom_components/meraki_ha/www/`).

This approach maintains the lean integration footprint while ensuring the custom card remains functional and easy to maintain.

Fixes #2244

---
*PR created automatically by Jules for task [14325707459875320258](https://jules.google.com/task/14325707459875320258) started by @brewmarsh*