### PR TITLE
Fix Dropdown Interactivity and Array Safeguards in Meraki Guest Card

### DIFF
--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -4,221 +4,221 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const I = globalThis, K = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, q = Symbol(), Y = /* @__PURE__ */ new WeakMap();
-let lt = class {
-  constructor(t, e, s) {
+let le = class {
+  constructor(e, t, s) {
     if (this._$cssResult$ = !0, s !== q) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
-    this.cssText = t, this.t = e;
+    this.cssText = e, this.t = t;
   }
   get styleSheet() {
-    let t = this.o;
-    const e = this.t;
-    if (K && t === void 0) {
-      const s = e !== void 0 && e.length === 1;
-      s && (t = Y.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), s && Y.set(e, t));
+    let e = this.o;
+    const t = this.t;
+    if (K && e === void 0) {
+      const s = t !== void 0 && t.length === 1;
+      s && (e = Y.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), s && Y.set(t, e));
     }
-    return t;
+    return e;
   }
   toString() {
     return this.cssText;
   }
 };
-const $t = (r) => new lt(typeof r == "string" ? r : r + "", void 0, q), ft = (r, ...t) => {
-  const e = r.length === 1 ? r[0] : t.reduce((s, i, n) => s + ((o) => {
-    if (o._$cssResult$ === !0) return o.cssText;
-    if (typeof o == "number") return o;
-    throw Error("Value passed to 'css' function must be a 'css' function result: " + o + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(i) + r[n + 1], r[0]);
-  return new lt(e, r, q);
-}, mt = (r, t) => {
-  if (K) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
-  else for (const e of t) {
+const $e = (r) => new le(typeof r == "string" ? r : r + "", void 0, q), fe = (r, ...e) => {
+  const t = r.length === 1 ? r[0] : e.reduce((s, i, o) => s + ((n) => {
+    if (n._$cssResult$ === !0) return n.cssText;
+    if (typeof n == "number") return n;
+    throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+  })(i) + r[o + 1], r[0]);
+  return new le(t, r, q);
+}, me = (r, e) => {
+  if (K) r.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
+  else for (const t of e) {
     const s = document.createElement("style"), i = I.litNonce;
-    i !== void 0 && s.setAttribute("nonce", i), s.textContent = e.cssText, r.appendChild(s);
+    i !== void 0 && s.setAttribute("nonce", i), s.textContent = t.cssText, r.appendChild(s);
   }
-}, Z = K ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
-  let e = "";
-  for (const s of t.cssRules) e += s.cssText;
-  return $t(e);
+}, Z = K ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((e) => {
+  let t = "";
+  for (const s of e.cssRules) t += s.cssText;
+  return $e(t);
 })(r) : r;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: gt, defineProperty: yt, getOwnPropertyDescriptor: At, getOwnPropertyNames: vt, getOwnPropertySymbols: wt, getPrototypeOf: Et } = Object, y = globalThis, Q = y.trustedTypes, St = Q ? Q.emptyScript : "", L = y.reactiveElementPolyfillSupport, N = (r, t) => r, D = { toAttribute(r, t) {
-  switch (t) {
+const { is: ge, defineProperty: ye, getOwnPropertyDescriptor: Ae, getOwnPropertyNames: ve, getOwnPropertySymbols: Ee, getPrototypeOf: Se } = Object, y = globalThis, Q = y.trustedTypes, we = Q ? Q.emptyScript : "", L = y.reactiveElementPolyfillSupport, N = (r, e) => r, D = { toAttribute(r, e) {
+  switch (e) {
     case Boolean:
-      r = r ? St : null;
+      r = r ? we : null;
       break;
     case Object:
     case Array:
       r = r == null ? r : JSON.stringify(r);
   }
   return r;
-}, fromAttribute(r, t) {
-  let e = r;
-  switch (t) {
+}, fromAttribute(r, e) {
+  let t = r;
+  switch (e) {
     case Boolean:
-      e = r !== null;
+      t = r !== null;
       break;
     case Number:
-      e = r === null ? null : Number(r);
+      t = r === null ? null : Number(r);
       break;
     case Object:
     case Array:
       try {
-        e = JSON.parse(r);
+        t = JSON.parse(r);
       } catch {
-        e = null;
+        t = null;
       }
   }
-  return e;
-} }, F = (r, t) => !gt(r, t), X = { attribute: !0, type: String, converter: D, reflect: !1, useDefault: !1, hasChanged: F };
+  return t;
+} }, F = (r, e) => !ge(r, e), X = { attribute: !0, type: String, converter: D, reflect: !1, useDefault: !1, hasChanged: F };
 Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), y.litPropertyMetadata ?? (y.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
 let b = class extends HTMLElement {
-  static addInitializer(t) {
-    this._$Ei(), (this.l ?? (this.l = [])).push(t);
+  static addInitializer(e) {
+    this._$Ei(), (this.l ?? (this.l = [])).push(e);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = X) {
-    if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
-      const s = Symbol(), i = this.getPropertyDescriptor(t, s, e);
-      i !== void 0 && yt(this.prototype, t, i);
+  static createProperty(e, t = X) {
+    if (t.state && (t.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(e) && ((t = Object.create(t)).wrapped = !0), this.elementProperties.set(e, t), !t.noAccessor) {
+      const s = Symbol(), i = this.getPropertyDescriptor(e, s, t);
+      i !== void 0 && ye(this.prototype, e, i);
     }
   }
-  static getPropertyDescriptor(t, e, s) {
-    const { get: i, set: n } = At(this.prototype, t) ?? { get() {
-      return this[e];
-    }, set(o) {
-      this[e] = o;
+  static getPropertyDescriptor(e, t, s) {
+    const { get: i, set: o } = Ae(this.prototype, e) ?? { get() {
+      return this[t];
+    }, set(n) {
+      this[t] = n;
     } };
-    return { get: i, set(o) {
+    return { get: i, set(n) {
       const h = i == null ? void 0 : i.call(this);
-      n == null || n.call(this, o), this.requestUpdate(t, h, s);
+      o == null || o.call(this, n), this.requestUpdate(e, h, s);
     }, configurable: !0, enumerable: !0 };
   }
-  static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? X;
+  static getPropertyOptions(e) {
+    return this.elementProperties.get(e) ?? X;
   }
   static _$Ei() {
     if (this.hasOwnProperty(N("elementProperties"))) return;
-    const t = Et(this);
-    t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
+    const e = Se(this);
+    e.finalize(), e.l !== void 0 && (this.l = [...e.l]), this.elementProperties = new Map(e.elementProperties);
   }
   static finalize() {
     if (this.hasOwnProperty(N("finalized"))) return;
     if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(N("properties"))) {
-      const e = this.properties, s = [...vt(e), ...wt(e)];
-      for (const i of s) this.createProperty(i, e[i]);
+      const t = this.properties, s = [...ve(t), ...Ee(t)];
+      for (const i of s) this.createProperty(i, t[i]);
     }
-    const t = this[Symbol.metadata];
-    if (t !== null) {
-      const e = litPropertyMetadata.get(t);
-      if (e !== void 0) for (const [s, i] of e) this.elementProperties.set(s, i);
+    const e = this[Symbol.metadata];
+    if (e !== null) {
+      const t = litPropertyMetadata.get(e);
+      if (t !== void 0) for (const [s, i] of t) this.elementProperties.set(s, i);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [e, s] of this.elementProperties) {
-      const i = this._$Eu(e, s);
-      i !== void 0 && this._$Eh.set(i, e);
+    for (const [t, s] of this.elementProperties) {
+      const i = this._$Eu(t, s);
+      i !== void 0 && this._$Eh.set(i, t);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
-  static finalizeStyles(t) {
-    const e = [];
-    if (Array.isArray(t)) {
-      const s = new Set(t.flat(1 / 0).reverse());
-      for (const i of s) e.unshift(Z(i));
-    } else t !== void 0 && e.push(Z(t));
-    return e;
+  static finalizeStyles(e) {
+    const t = [];
+    if (Array.isArray(e)) {
+      const s = new Set(e.flat(1 / 0).reverse());
+      for (const i of s) t.unshift(Z(i));
+    } else e !== void 0 && t.push(Z(e));
+    return t;
   }
-  static _$Eu(t, e) {
-    const s = e.attribute;
-    return s === !1 ? void 0 : typeof s == "string" ? s : typeof t == "string" ? t.toLowerCase() : void 0;
+  static _$Eu(e, t) {
+    const s = t.attribute;
+    return s === !1 ? void 0 : typeof s == "string" ? s : typeof e == "string" ? e.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
   }
   _$Ev() {
+    var e;
+    this._$ES = new Promise((t) => this.enableUpdating = t), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), (e = this.constructor.l) == null || e.forEach((t) => t(this));
+  }
+  addController(e) {
     var t;
-    this._$ES = new Promise((e) => this.enableUpdating = e), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), (t = this.constructor.l) == null || t.forEach((e) => e(this));
+    (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(e), this.renderRoot !== void 0 && this.isConnected && ((t = e.hostConnected) == null || t.call(e));
   }
-  addController(t) {
-    var e;
-    (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(t), this.renderRoot !== void 0 && this.isConnected && ((e = t.hostConnected) == null || e.call(t));
-  }
-  removeController(t) {
-    var e;
-    (e = this._$EO) == null || e.delete(t);
+  removeController(e) {
+    var t;
+    (t = this._$EO) == null || t.delete(e);
   }
   _$E_() {
-    const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
-    for (const s of e.keys()) this.hasOwnProperty(s) && (t.set(s, this[s]), delete this[s]);
-    t.size > 0 && (this._$Ep = t);
+    const e = /* @__PURE__ */ new Map(), t = this.constructor.elementProperties;
+    for (const s of t.keys()) this.hasOwnProperty(s) && (e.set(s, this[s]), delete this[s]);
+    e.size > 0 && (this._$Ep = e);
   }
   createRenderRoot() {
-    const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return mt(t, this.constructor.elementStyles), t;
+    const e = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
+    return me(e, this.constructor.elementStyles), e;
   }
   connectedCallback() {
-    var t;
-    this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (t = this._$EO) == null || t.forEach((e) => {
+    var e;
+    this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (e = this._$EO) == null || e.forEach((t) => {
       var s;
-      return (s = e.hostConnected) == null ? void 0 : s.call(e);
+      return (s = t.hostConnected) == null ? void 0 : s.call(t);
     });
   }
-  enableUpdating(t) {
+  enableUpdating(e) {
   }
   disconnectedCallback() {
-    var t;
-    (t = this._$EO) == null || t.forEach((e) => {
+    var e;
+    (e = this._$EO) == null || e.forEach((t) => {
       var s;
-      return (s = e.hostDisconnected) == null ? void 0 : s.call(e);
+      return (s = t.hostDisconnected) == null ? void 0 : s.call(t);
     });
   }
-  attributeChangedCallback(t, e, s) {
-    this._$AK(t, s);
+  attributeChangedCallback(e, t, s) {
+    this._$AK(e, s);
   }
-  _$ET(t, e) {
-    var n;
-    const s = this.constructor.elementProperties.get(t), i = this.constructor._$Eu(t, s);
-    if (i !== void 0 && s.reflect === !0) {
-      const o = (((n = s.converter) == null ? void 0 : n.toAttribute) !== void 0 ? s.converter : D).toAttribute(e, s.type);
-      this._$Em = t, o == null ? this.removeAttribute(i) : this.setAttribute(i, o), this._$Em = null;
-    }
-  }
-  _$AK(t, e) {
-    var n, o;
-    const s = this.constructor, i = s._$Eh.get(t);
-    if (i !== void 0 && this._$Em !== i) {
-      const h = s.getPropertyOptions(i), a = typeof h.converter == "function" ? { fromAttribute: h.converter } : ((n = h.converter) == null ? void 0 : n.fromAttribute) !== void 0 ? h.converter : D;
-      this._$Em = i;
-      const c = a.fromAttribute(e, h.type);
-      this[i] = c ?? ((o = this._$Ej) == null ? void 0 : o.get(i)) ?? c, this._$Em = null;
-    }
-  }
-  requestUpdate(t, e, s, i = !1, n) {
+  _$ET(e, t) {
     var o;
-    if (t !== void 0) {
+    const s = this.constructor.elementProperties.get(e), i = this.constructor._$Eu(e, s);
+    if (i !== void 0 && s.reflect === !0) {
+      const n = (((o = s.converter) == null ? void 0 : o.toAttribute) !== void 0 ? s.converter : D).toAttribute(t, s.type);
+      this._$Em = e, n == null ? this.removeAttribute(i) : this.setAttribute(i, n), this._$Em = null;
+    }
+  }
+  _$AK(e, t) {
+    var o, n;
+    const s = this.constructor, i = s._$Eh.get(e);
+    if (i !== void 0 && this._$Em !== i) {
+      const h = s.getPropertyOptions(i), a = typeof h.converter == "function" ? { fromAttribute: h.converter } : ((o = h.converter) == null ? void 0 : o.fromAttribute) !== void 0 ? h.converter : D;
+      this._$Em = i;
+      const c = a.fromAttribute(t, h.type);
+      this[i] = c ?? ((n = this._$Ej) == null ? void 0 : n.get(i)) ?? c, this._$Em = null;
+    }
+  }
+  requestUpdate(e, t, s, i = !1, o) {
+    var n;
+    if (e !== void 0) {
       const h = this.constructor;
-      if (i === !1 && (n = this[t]), s ?? (s = h.getPropertyOptions(t)), !((s.hasChanged ?? F)(n, e) || s.useDefault && s.reflect && n === ((o = this._$Ej) == null ? void 0 : o.get(t)) && !this.hasAttribute(h._$Eu(t, s)))) return;
-      this.C(t, e, s);
+      if (i === !1 && (o = this[e]), s ?? (s = h.getPropertyOptions(e)), !((s.hasChanged ?? F)(o, t) || s.useDefault && s.reflect && o === ((n = this._$Ej) == null ? void 0 : n.get(e)) && !this.hasAttribute(h._$Eu(e, s)))) return;
+      this.C(e, t, s);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(t, e, { useDefault: s, reflect: i, wrapped: n }, o) {
-    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t) && (this._$Ej.set(t, o ?? e ?? this[t]), n !== !0 || o !== void 0) || (this._$AL.has(t) || (this.hasUpdated || s || (e = void 0), this._$AL.set(t, e)), i === !0 && this._$Em !== t && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t));
+  C(e, t, { useDefault: s, reflect: i, wrapped: o }, n) {
+    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(e) && (this._$Ej.set(e, n ?? t ?? this[e]), o !== !0 || n !== void 0) || (this._$AL.has(e) || (this.hasUpdated || s || (t = void 0), this._$AL.set(e, t)), i === !0 && this._$Em !== e && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(e));
   }
   async _$EP() {
     this.isUpdatePending = !0;
     try {
       await this._$ES;
-    } catch (e) {
-      Promise.reject(e);
+    } catch (t) {
+      Promise.reject(t);
     }
-    const t = this.scheduleUpdate();
-    return t != null && await t, !this.isUpdatePending;
+    const e = this.scheduleUpdate();
+    return e != null && await e, !this.isUpdatePending;
   }
   scheduleUpdate() {
     return this.performUpdate();
@@ -228,35 +228,35 @@ let b = class extends HTMLElement {
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
-        for (const [n, o] of this._$Ep) this[n] = o;
+        for (const [o, n] of this._$Ep) this[o] = n;
         this._$Ep = void 0;
       }
       const i = this.constructor.elementProperties;
-      if (i.size > 0) for (const [n, o] of i) {
-        const { wrapped: h } = o, a = this[n];
-        h !== !0 || this._$AL.has(n) || a === void 0 || this.C(n, void 0, o, a);
+      if (i.size > 0) for (const [o, n] of i) {
+        const { wrapped: h } = n, a = this[o];
+        h !== !0 || this._$AL.has(o) || a === void 0 || this.C(o, void 0, n, a);
       }
     }
-    let t = !1;
-    const e = this._$AL;
+    let e = !1;
+    const t = this._$AL;
     try {
-      t = this.shouldUpdate(e), t ? (this.willUpdate(e), (s = this._$EO) == null || s.forEach((i) => {
-        var n;
-        return (n = i.hostUpdate) == null ? void 0 : n.call(i);
-      }), this.update(e)) : this._$EM();
+      e = this.shouldUpdate(t), e ? (this.willUpdate(t), (s = this._$EO) == null || s.forEach((i) => {
+        var o;
+        return (o = i.hostUpdate) == null ? void 0 : o.call(i);
+      }), this.update(t)) : this._$EM();
     } catch (i) {
-      throw t = !1, this._$EM(), i;
+      throw e = !1, this._$EM(), i;
     }
-    t && this._$AE(e);
+    e && this._$AE(t);
   }
-  willUpdate(t) {
+  willUpdate(e) {
   }
-  _$AE(t) {
-    var e;
-    (e = this._$EO) == null || e.forEach((s) => {
+  _$AE(e) {
+    var t;
+    (t = this._$EO) == null || t.forEach((s) => {
       var i;
       return (i = s.hostUpdated) == null ? void 0 : i.call(s);
-    }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
+    }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(e)), this.updated(e);
   }
   _$EM() {
     this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = !1;
@@ -267,15 +267,15 @@ let b = class extends HTMLElement {
   getUpdateComplete() {
     return this._$ES;
   }
-  shouldUpdate(t) {
+  shouldUpdate(e) {
     return !0;
   }
-  update(t) {
-    this._$Eq && (this._$Eq = this._$Eq.forEach((e) => this._$ET(e, this[e]))), this._$EM();
+  update(e) {
+    this._$Eq && (this._$Eq = this._$Eq.forEach((t) => this._$ET(t, this[t]))), this._$EM();
   }
-  updated(t) {
+  updated(e) {
   }
-  firstUpdated(t) {
+  firstUpdated(e) {
   }
 };
 b.elementStyles = [], b.shadowRootOptions = { mode: "open" }, b[N("elementProperties")] = /* @__PURE__ */ new Map(), b[N("finalized")] = /* @__PURE__ */ new Map(), L == null || L({ ReactiveElement: b }), (y.reactiveElementVersions ?? (y.reactiveElementVersions = [])).push("2.1.2");
@@ -284,72 +284,72 @@ b.elementStyles = [], b.shadowRootOptions = { mode: "open" }, b[N("elementProper
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const x = globalThis, tt = (r) => r, j = x.trustedTypes, et = j ? j.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, ct = "$lit$", g = `lit$${Math.random().toFixed(9).slice(2)}$`, dt = "?" + g, bt = `<${dt}>`, S = document, T = () => S.createComment(""), O = (r) => r === null || typeof r != "object" && typeof r != "function", J = Array.isArray, kt = (r) => J(r) || typeof (r == null ? void 0 : r[Symbol.iterator]) == "function", z = `[
-\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, st = /-->/g, it = />/g, A = RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^
-\f\r"'\`<>=]|("|')|))|$)`, "g"), rt = /'/g, nt = /"/g, ut = /^(?:script|style|textarea|title)$/i, Pt = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), v = Pt(1), k = Symbol.for("lit-noChange"), d = Symbol.for("lit-nothing"), ot = /* @__PURE__ */ new WeakMap(), w = S.createTreeWalker(S, 129);
-function pt(r, t) {
+const x = globalThis, ee = (r) => r, j = x.trustedTypes, te = j ? j.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, ce = "$lit$", g = `lit$${Math.random().toFixed(9).slice(2)}$`, de = "?" + g, be = `<${de}>`, w = document, T = () => w.createComment(""), O = (r) => r === null || typeof r != "object" && typeof r != "function", J = Array.isArray, ke = (r) => J(r) || typeof (r == null ? void 0 : r[Symbol.iterator]) == "function", z = `[
+\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, se = /-->/g, ie = />/g, A = RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^
+\f\r"'\`<>=]|("|')|))|$)`, "g"), re = /'/g, oe = /"/g, ue = /^(?:script|style|textarea|title)$/i, Pe = (r) => (e, ...t) => ({ _$litType$: r, strings: e, values: t }), v = Pe(1), k = Symbol.for("lit-noChange"), d = Symbol.for("lit-nothing"), ne = /* @__PURE__ */ new WeakMap(), E = w.createTreeWalker(w, 129);
+function pe(r, e) {
   if (!J(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return et !== void 0 ? et.createHTML(t) : t;
+  return te !== void 0 ? te.createHTML(e) : e;
 }
-const Ct = (r, t) => {
-  const e = r.length - 1, s = [];
-  let i, n = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = C;
-  for (let h = 0; h < e; h++) {
+const Ce = (r, e) => {
+  const t = r.length - 1, s = [];
+  let i, o = e === 2 ? "<svg>" : e === 3 ? "<math>" : "", n = C;
+  for (let h = 0; h < t; h++) {
     const a = r[h];
     let c, p, l = -1, f = 0;
-    for (; f < a.length && (o.lastIndex = f, p = o.exec(a), p !== null); ) f = o.lastIndex, o === C ? p[1] === "!--" ? o = st : p[1] !== void 0 ? o = it : p[2] !== void 0 ? (ut.test(p[2]) && (i = RegExp("</" + p[2], "g")), o = A) : p[3] !== void 0 && (o = A) : o === A ? p[0] === ">" ? (o = i ?? C, l = -1) : p[1] === void 0 ? l = -2 : (l = o.lastIndex - p[2].length, c = p[1], o = p[3] === void 0 ? A : p[3] === '"' ? nt : rt) : o === nt || o === rt ? o = A : o === st || o === it ? o = C : (o = A, i = void 0);
-    const m = o === A && r[h + 1].startsWith("/>") ? " " : "";
-    n += o === C ? a + bt : l >= 0 ? (s.push(c), a.slice(0, l) + ct + a.slice(l) + g + m) : a + g + (l === -2 ? h : m);
+    for (; f < a.length && (n.lastIndex = f, p = n.exec(a), p !== null); ) f = n.lastIndex, n === C ? p[1] === "!--" ? n = se : p[1] !== void 0 ? n = ie : p[2] !== void 0 ? (ue.test(p[2]) && (i = RegExp("</" + p[2], "g")), n = A) : p[3] !== void 0 && (n = A) : n === A ? p[0] === ">" ? (n = i ?? C, l = -1) : p[1] === void 0 ? l = -2 : (l = n.lastIndex - p[2].length, c = p[1], n = p[3] === void 0 ? A : p[3] === '"' ? oe : re) : n === oe || n === re ? n = A : n === se || n === ie ? n = C : (n = A, i = void 0);
+    const m = n === A && r[h + 1].startsWith("/>") ? " " : "";
+    o += n === C ? a + be : l >= 0 ? (s.push(c), a.slice(0, l) + ce + a.slice(l) + g + m) : a + g + (l === -2 ? h : m);
   }
-  return [pt(r, n + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), s];
+  return [pe(r, o + (r[t] || "<?>") + (e === 2 ? "</svg>" : e === 3 ? "</math>" : "")), s];
 };
 class U {
-  constructor({ strings: t, _$litType$: e }, s) {
+  constructor({ strings: e, _$litType$: t }, s) {
     let i;
     this.parts = [];
-    let n = 0, o = 0;
-    const h = t.length - 1, a = this.parts, [c, p] = Ct(t, e);
-    if (this.el = U.createElement(c, s), w.currentNode = this.el.content, e === 2 || e === 3) {
+    let o = 0, n = 0;
+    const h = e.length - 1, a = this.parts, [c, p] = Ce(e, t);
+    if (this.el = U.createElement(c, s), E.currentNode = this.el.content, t === 2 || t === 3) {
       const l = this.el.content.firstChild;
       l.replaceWith(...l.childNodes);
     }
-    for (; (i = w.nextNode()) !== null && a.length < h; ) {
+    for (; (i = E.nextNode()) !== null && a.length < h; ) {
       if (i.nodeType === 1) {
-        if (i.hasAttributes()) for (const l of i.getAttributeNames()) if (l.endsWith(ct)) {
-          const f = p[o++], m = i.getAttribute(l).split(g), R = /([.?@])?(.*)/.exec(f);
-          a.push({ type: 1, index: n, name: R[2], strings: m, ctor: R[1] === "." ? xt : R[1] === "?" ? Mt : R[1] === "@" ? Tt : G }), i.removeAttribute(l);
-        } else l.startsWith(g) && (a.push({ type: 6, index: n }), i.removeAttribute(l));
-        if (ut.test(i.tagName)) {
+        if (i.hasAttributes()) for (const l of i.getAttributeNames()) if (l.endsWith(ce)) {
+          const f = p[n++], m = i.getAttribute(l).split(g), R = /([.?@])?(.*)/.exec(f);
+          a.push({ type: 1, index: o, name: R[2], strings: m, ctor: R[1] === "." ? xe : R[1] === "?" ? Me : R[1] === "@" ? Te : G }), i.removeAttribute(l);
+        } else l.startsWith(g) && (a.push({ type: 6, index: o }), i.removeAttribute(l));
+        if (ue.test(i.tagName)) {
           const l = i.textContent.split(g), f = l.length - 1;
           if (f > 0) {
             i.textContent = j ? j.emptyScript : "";
-            for (let m = 0; m < f; m++) i.append(l[m], T()), w.nextNode(), a.push({ type: 2, index: ++n });
+            for (let m = 0; m < f; m++) i.append(l[m], T()), E.nextNode(), a.push({ type: 2, index: ++o });
             i.append(l[f], T());
           }
         }
-      } else if (i.nodeType === 8) if (i.data === dt) a.push({ type: 2, index: n });
+      } else if (i.nodeType === 8) if (i.data === de) a.push({ type: 2, index: o });
       else {
         let l = -1;
-        for (; (l = i.data.indexOf(g, l + 1)) !== -1; ) a.push({ type: 7, index: n }), l += g.length - 1;
+        for (; (l = i.data.indexOf(g, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += g.length - 1;
       }
-      n++;
+      o++;
     }
   }
-  static createElement(t, e) {
-    const s = S.createElement("template");
-    return s.innerHTML = t, s;
+  static createElement(e, t) {
+    const s = w.createElement("template");
+    return s.innerHTML = e, s;
   }
 }
-function P(r, t, e = r, s) {
-  var o, h;
-  if (t === k) return t;
-  let i = s !== void 0 ? (o = e._$Co) == null ? void 0 : o[s] : e._$Cl;
-  const n = O(t) ? void 0 : t._$litDirective$;
-  return (i == null ? void 0 : i.constructor) !== n && ((h = i == null ? void 0 : i._$AO) == null || h.call(i, !1), n === void 0 ? i = void 0 : (i = new n(r), i._$AT(r, e, s)), s !== void 0 ? (e._$Co ?? (e._$Co = []))[s] = i : e._$Cl = i), i !== void 0 && (t = P(r, i._$AS(r, t.values), i, s)), t;
+function P(r, e, t = r, s) {
+  var n, h;
+  if (e === k) return e;
+  let i = s !== void 0 ? (n = t._$Co) == null ? void 0 : n[s] : t._$Cl;
+  const o = O(e) ? void 0 : e._$litDirective$;
+  return (i == null ? void 0 : i.constructor) !== o && ((h = i == null ? void 0 : i._$AO) == null || h.call(i, !1), o === void 0 ? i = void 0 : (i = new o(r), i._$AT(r, t, s)), s !== void 0 ? (t._$Co ?? (t._$Co = []))[s] = i : t._$Cl = i), i !== void 0 && (e = P(r, i._$AS(r, e.values), i, s)), e;
 }
-class Nt {
-  constructor(t, e) {
-    this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
+class Ne {
+  constructor(e, t) {
+    this._$AV = [], this._$AN = void 0, this._$AD = e, this._$AM = t;
   }
   get parentNode() {
     return this._$AM.parentNode;
@@ -357,36 +357,36 @@ class Nt {
   get _$AU() {
     return this._$AM._$AU;
   }
-  u(t) {
-    const { el: { content: e }, parts: s } = this._$AD, i = ((t == null ? void 0 : t.creationScope) ?? S).importNode(e, !0);
-    w.currentNode = i;
-    let n = w.nextNode(), o = 0, h = 0, a = s[0];
+  u(e) {
+    const { el: { content: t }, parts: s } = this._$AD, i = ((e == null ? void 0 : e.creationScope) ?? w).importNode(t, !0);
+    E.currentNode = i;
+    let o = E.nextNode(), n = 0, h = 0, a = s[0];
     for (; a !== void 0; ) {
-      if (o === a.index) {
+      if (n === a.index) {
         let c;
-        a.type === 2 ? c = new H(n, n.nextSibling, this, t) : a.type === 1 ? c = new a.ctor(n, a.name, a.strings, this, t) : a.type === 6 && (c = new Ot(n, this, t)), this._$AV.push(c), a = s[++h];
+        a.type === 2 ? c = new H(o, o.nextSibling, this, e) : a.type === 1 ? c = new a.ctor(o, a.name, a.strings, this, e) : a.type === 6 && (c = new Oe(o, this, e)), this._$AV.push(c), a = s[++h];
       }
-      o !== (a == null ? void 0 : a.index) && (n = w.nextNode(), o++);
+      n !== (a == null ? void 0 : a.index) && (o = E.nextNode(), n++);
     }
-    return w.currentNode = S, i;
+    return E.currentNode = w, i;
   }
-  p(t) {
-    let e = 0;
-    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(t, s, e), e += s.strings.length - 2) : s._$AI(t[e])), e++;
+  p(e) {
+    let t = 0;
+    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(e, s, t), t += s.strings.length - 2) : s._$AI(e[t])), t++;
   }
 }
 class H {
   get _$AU() {
-    var t;
-    return ((t = this._$AM) == null ? void 0 : t._$AU) ?? this._$Cv;
+    var e;
+    return ((e = this._$AM) == null ? void 0 : e._$AU) ?? this._$Cv;
   }
-  constructor(t, e, s, i) {
-    this.type = 2, this._$AH = d, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = s, this.options = i, this._$Cv = (i == null ? void 0 : i.isConnected) ?? !0;
+  constructor(e, t, s, i) {
+    this.type = 2, this._$AH = d, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = s, this.options = i, this._$Cv = (i == null ? void 0 : i.isConnected) ?? !0;
   }
   get parentNode() {
-    let t = this._$AA.parentNode;
-    const e = this._$AM;
-    return e !== void 0 && (t == null ? void 0 : t.nodeType) === 11 && (t = e.parentNode), t;
+    let e = this._$AA.parentNode;
+    const t = this._$AM;
+    return t !== void 0 && (e == null ? void 0 : e.nodeType) === 11 && (e = t.parentNode), e;
   }
   get startNode() {
     return this._$AA;
@@ -394,48 +394,48 @@ class H {
   get endNode() {
     return this._$AB;
   }
-  _$AI(t, e = this) {
-    t = P(this, t, e), O(t) ? t === d || t == null || t === "" ? (this._$AH !== d && this._$AR(), this._$AH = d) : t !== this._$AH && t !== k && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : kt(t) ? this.k(t) : this._(t);
+  _$AI(e, t = this) {
+    e = P(this, e, t), O(e) ? e === d || e == null || e === "" ? (this._$AH !== d && this._$AR(), this._$AH = d) : e !== this._$AH && e !== k && this._(e) : e._$litType$ !== void 0 ? this.$(e) : e.nodeType !== void 0 ? this.T(e) : ke(e) ? this.k(e) : this._(e);
   }
-  O(t) {
-    return this._$AA.parentNode.insertBefore(t, this._$AB);
+  O(e) {
+    return this._$AA.parentNode.insertBefore(e, this._$AB);
   }
-  T(t) {
-    this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
+  T(e) {
+    this._$AH !== e && (this._$AR(), this._$AH = this.O(e));
   }
-  _(t) {
-    this._$AH !== d && O(this._$AH) ? this._$AA.nextSibling.data = t : this.T(S.createTextNode(t)), this._$AH = t;
+  _(e) {
+    this._$AH !== d && O(this._$AH) ? this._$AA.nextSibling.data = e : this.T(w.createTextNode(e)), this._$AH = e;
   }
-  $(t) {
-    var n;
-    const { values: e, _$litType$: s } = t, i = typeof s == "number" ? this._$AC(t) : (s.el === void 0 && (s.el = U.createElement(pt(s.h, s.h[0]), this.options)), s);
-    if (((n = this._$AH) == null ? void 0 : n._$AD) === i) this._$AH.p(e);
+  $(e) {
+    var o;
+    const { values: t, _$litType$: s } = e, i = typeof s == "number" ? this._$AC(e) : (s.el === void 0 && (s.el = U.createElement(pe(s.h, s.h[0]), this.options)), s);
+    if (((o = this._$AH) == null ? void 0 : o._$AD) === i) this._$AH.p(t);
     else {
-      const o = new Nt(i, this), h = o.u(this.options);
-      o.p(e), this.T(h), this._$AH = o;
+      const n = new Ne(i, this), h = n.u(this.options);
+      n.p(t), this.T(h), this._$AH = n;
     }
   }
-  _$AC(t) {
-    let e = ot.get(t.strings);
-    return e === void 0 && ot.set(t.strings, e = new U(t)), e;
+  _$AC(e) {
+    let t = ne.get(e.strings);
+    return t === void 0 && ne.set(e.strings, t = new U(e)), t;
   }
-  k(t) {
+  k(e) {
     J(this._$AH) || (this._$AH = [], this._$AR());
-    const e = this._$AH;
+    const t = this._$AH;
     let s, i = 0;
-    for (const n of t) i === e.length ? e.push(s = new H(this.O(T()), this.O(T()), this, this.options)) : s = e[i], s._$AI(n), i++;
-    i < e.length && (this._$AR(s && s._$AB.nextSibling, i), e.length = i);
+    for (const o of e) i === t.length ? t.push(s = new H(this.O(T()), this.O(T()), this, this.options)) : s = t[i], s._$AI(o), i++;
+    i < t.length && (this._$AR(s && s._$AB.nextSibling, i), t.length = i);
   }
-  _$AR(t = this._$AA.nextSibling, e) {
+  _$AR(e = this._$AA.nextSibling, t) {
     var s;
-    for ((s = this._$AP) == null ? void 0 : s.call(this, !1, !0, e); t !== this._$AB; ) {
-      const i = tt(t).nextSibling;
-      tt(t).remove(), t = i;
+    for ((s = this._$AP) == null ? void 0 : s.call(this, !1, !0, t); e !== this._$AB; ) {
+      const i = ee(e).nextSibling;
+      ee(e).remove(), e = i;
     }
   }
-  setConnected(t) {
-    var e;
-    this._$AM === void 0 && (this._$Cv = t, (e = this._$AP) == null || e.call(this, t));
+  setConnected(e) {
+    var t;
+    this._$AM === void 0 && (this._$Cv = e, (t = this._$AP) == null || t.call(this, e));
   }
 }
 class G {
@@ -445,73 +445,73 @@ class G {
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(t, e, s, i, n) {
-    this.type = 1, this._$AH = d, this._$AN = void 0, this.element = t, this.name = e, this._$AM = i, this.options = n, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = d;
+  constructor(e, t, s, i, o) {
+    this.type = 1, this._$AH = d, this._$AN = void 0, this.element = e, this.name = t, this._$AM = i, this.options = o, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = d;
   }
-  _$AI(t, e = this, s, i) {
-    const n = this.strings;
-    let o = !1;
-    if (n === void 0) t = P(this, t, e, 0), o = !O(t) || t !== this._$AH && t !== k, o && (this._$AH = t);
+  _$AI(e, t = this, s, i) {
+    const o = this.strings;
+    let n = !1;
+    if (o === void 0) e = P(this, e, t, 0), n = !O(e) || e !== this._$AH && e !== k, n && (this._$AH = e);
     else {
-      const h = t;
+      const h = e;
       let a, c;
-      for (t = n[0], a = 0; a < n.length - 1; a++) c = P(this, h[s + a], e, a), c === k && (c = this._$AH[a]), o || (o = !O(c) || c !== this._$AH[a]), c === d ? t = d : t !== d && (t += (c ?? "") + n[a + 1]), this._$AH[a] = c;
+      for (e = o[0], a = 0; a < o.length - 1; a++) c = P(this, h[s + a], t, a), c === k && (c = this._$AH[a]), n || (n = !O(c) || c !== this._$AH[a]), c === d ? e = d : e !== d && (e += (c ?? "") + o[a + 1]), this._$AH[a] = c;
     }
-    o && !i && this.j(t);
+    n && !i && this.j(e);
   }
-  j(t) {
-    t === d ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+  j(e) {
+    e === d ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
   }
 }
-class xt extends G {
+class xe extends G {
   constructor() {
     super(...arguments), this.type = 3;
   }
-  j(t) {
-    this.element[this.name] = t === d ? void 0 : t;
+  j(e) {
+    this.element[this.name] = e === d ? void 0 : e;
   }
 }
-class Mt extends G {
+class Me extends G {
   constructor() {
     super(...arguments), this.type = 4;
   }
-  j(t) {
-    this.element.toggleAttribute(this.name, !!t && t !== d);
+  j(e) {
+    this.element.toggleAttribute(this.name, !!e && e !== d);
   }
 }
-class Tt extends G {
-  constructor(t, e, s, i, n) {
-    super(t, e, s, i, n), this.type = 5;
+class Te extends G {
+  constructor(e, t, s, i, o) {
+    super(e, t, s, i, o), this.type = 5;
   }
-  _$AI(t, e = this) {
-    if ((t = P(this, t, e, 0) ?? d) === k) return;
-    const s = this._$AH, i = t === d && s !== d || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive, n = t !== d && (s === d || i);
-    i && this.element.removeEventListener(this.name, this, s), n && this.element.addEventListener(this.name, this, t), this._$AH = t;
+  _$AI(e, t = this) {
+    if ((e = P(this, e, t, 0) ?? d) === k) return;
+    const s = this._$AH, i = e === d && s !== d || e.capture !== s.capture || e.once !== s.once || e.passive !== s.passive, o = e !== d && (s === d || i);
+    i && this.element.removeEventListener(this.name, this, s), o && this.element.addEventListener(this.name, this, e), this._$AH = e;
   }
-  handleEvent(t) {
-    var e;
-    typeof this._$AH == "function" ? this._$AH.call(((e = this.options) == null ? void 0 : e.host) ?? this.element, t) : this._$AH.handleEvent(t);
+  handleEvent(e) {
+    var t;
+    typeof this._$AH == "function" ? this._$AH.call(((t = this.options) == null ? void 0 : t.host) ?? this.element, e) : this._$AH.handleEvent(e);
   }
 }
-class Ot {
-  constructor(t, e, s) {
-    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = s;
+class Oe {
+  constructor(e, t, s) {
+    this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = s;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  _$AI(t) {
-    P(this, t);
+  _$AI(e) {
+    P(this, e);
   }
 }
 const B = x.litHtmlPolyfillSupport;
 B == null || B(U, H), (x.litHtmlVersions ?? (x.litHtmlVersions = [])).push("3.3.2");
-const Ut = (r, t, e) => {
-  const s = (e == null ? void 0 : e.renderBefore) ?? t;
+const Ue = (r, e, t) => {
+  const s = (t == null ? void 0 : t.renderBefore) ?? e;
   let i = s._$litPart$;
   if (i === void 0) {
-    const n = (e == null ? void 0 : e.renderBefore) ?? null;
-    s._$litPart$ = i = new H(t.insertBefore(T(), n), n, void 0, e ?? {});
+    const o = (t == null ? void 0 : t.renderBefore) ?? null;
+    s._$litPart$ = i = new H(e.insertBefore(T(), o), o, void 0, t ?? {});
   }
   return i._$AI(r), i;
 };
@@ -520,78 +520,78 @@ const Ut = (r, t, e) => {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const E = globalThis;
+const S = globalThis;
 class M extends b {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
   createRenderRoot() {
-    var e;
-    const t = super.createRenderRoot();
-    return (e = this.renderOptions).renderBefore ?? (e.renderBefore = t.firstChild), t;
+    var t;
+    const e = super.createRenderRoot();
+    return (t = this.renderOptions).renderBefore ?? (t.renderBefore = e.firstChild), e;
   }
-  update(t) {
-    const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Ut(e, this.renderRoot, this.renderOptions);
+  update(e) {
+    const t = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Ue(t, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
-    var t;
-    super.connectedCallback(), (t = this._$Do) == null || t.setConnected(!0);
+    var e;
+    super.connectedCallback(), (e = this._$Do) == null || e.setConnected(!0);
   }
   disconnectedCallback() {
-    var t;
-    super.disconnectedCallback(), (t = this._$Do) == null || t.setConnected(!1);
+    var e;
+    super.disconnectedCallback(), (e = this._$Do) == null || e.setConnected(!1);
   }
   render() {
     return k;
   }
 }
-var ht;
-M._$litElement$ = !0, M.finalized = !0, (ht = E.litElementHydrateSupport) == null || ht.call(E, { LitElement: M });
-const V = E.litElementPolyfillSupport;
+var he;
+M._$litElement$ = !0, M.finalized = !0, (he = S.litElementHydrateSupport) == null || he.call(S, { LitElement: M });
+const V = S.litElementPolyfillSupport;
 V == null || V({ LitElement: M });
-(E.litElementVersions ?? (E.litElementVersions = [])).push("4.2.2");
+(S.litElementVersions ?? (S.litElementVersions = [])).push("4.2.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Ht = (r) => (t, e) => {
-  e !== void 0 ? e.addInitializer(() => {
-    customElements.define(r, t);
-  }) : customElements.define(r, t);
+const He = (r) => (e, t) => {
+  t !== void 0 ? t.addInitializer(() => {
+    customElements.define(r, e);
+  }) : customElements.define(r, e);
 };
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Rt = { attribute: !0, type: String, converter: D, reflect: !1, hasChanged: F }, It = (r = Rt, t, e) => {
-  const { kind: s, metadata: i } = e;
-  let n = globalThis.litPropertyMetadata.get(i);
-  if (n === void 0 && globalThis.litPropertyMetadata.set(i, n = /* @__PURE__ */ new Map()), s === "setter" && ((r = Object.create(r)).wrapped = !0), n.set(e.name, r), s === "accessor") {
-    const { name: o } = e;
+const Re = { attribute: !0, type: String, converter: D, reflect: !1, hasChanged: F }, Ie = (r = Re, e, t) => {
+  const { kind: s, metadata: i } = t;
+  let o = globalThis.litPropertyMetadata.get(i);
+  if (o === void 0 && globalThis.litPropertyMetadata.set(i, o = /* @__PURE__ */ new Map()), s === "setter" && ((r = Object.create(r)).wrapped = !0), o.set(t.name, r), s === "accessor") {
+    const { name: n } = t;
     return { set(h) {
-      const a = t.get.call(this);
-      t.set.call(this, h), this.requestUpdate(o, a, r, !0, h);
+      const a = e.get.call(this);
+      e.set.call(this, h), this.requestUpdate(n, a, r, !0, h);
     }, init(h) {
-      return h !== void 0 && this.C(o, void 0, r, h), h;
+      return h !== void 0 && this.C(n, void 0, r, h), h;
     } };
   }
   if (s === "setter") {
-    const { name: o } = e;
+    const { name: n } = t;
     return function(h) {
-      const a = this[o];
-      t.call(this, h), this.requestUpdate(o, a, r, !0, h);
+      const a = this[n];
+      e.call(this, h), this.requestUpdate(n, a, r, !0, h);
     };
   }
   throw Error("Unsupported decorator location: " + s);
 };
-function _t(r) {
-  return (t, e) => typeof e == "object" ? It(r, t, e) : ((s, i, n) => {
-    const o = i.hasOwnProperty(n);
-    return i.constructor.createProperty(n, s), o ? Object.getOwnPropertyDescriptor(i, n) : void 0;
-  })(r, t, e);
+function _e(r) {
+  return (e, t) => typeof t == "object" ? Ie(r, e, t) : ((s, i, o) => {
+    const n = i.hasOwnProperty(o);
+    return i.constructor.createProperty(o, s), n ? Object.getOwnPropertyDescriptor(i, o) : void 0;
+  })(r, e, t);
 }
 /**
  * @license
@@ -599,26 +599,26 @@ function _t(r) {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 function $(r) {
-  return _t({ ...r, state: !0, attribute: !1 });
+  return _e({ ...r, state: !0, attribute: !1 });
 }
 var W = /* @__PURE__ */ ((r) => (r.GET_CONFIG = "meraki_ha/get_config", r.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", r.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", r.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", r.GET_VERSION = "meraki_ha/get_version", r.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", r.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", r.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", r.GET_GUEST_KEYS = "meraki_ha/ipsk/get", r.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", r.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", r))(W || {});
-const at = async (r, t) => {
+const ae = async (r, e) => {
   if (!r)
     throw new Error("Home Assistant object is not available.");
   try {
     if (typeof r.callWS == "function")
-      return await r.callWS(t);
+      return await r.callWS(e);
     if (r.connection && typeof r.connection.sendMessagePromise == "function")
-      return await r.connection.sendMessagePromise(t);
+      return await r.connection.sendMessagePromise(e);
     throw new Error("Home Assistant WebSocket communication methods not found.");
-  } catch (e) {
-    throw console.error(`Meraki HA: WebSocket error [${t.type}]:`, e), e;
+  } catch (t) {
+    throw console.error(`Meraki HA: WebSocket error [${e.type}]:`, t), t;
   }
 };
-var Dt = Object.defineProperty, jt = Object.getOwnPropertyDescriptor, _ = (r, t, e, s) => {
-  for (var i = s > 1 ? void 0 : s ? jt(t, e) : t, n = r.length - 1, o; n >= 0; n--)
-    (o = r[n]) && (i = (s ? o(t, e, i) : o(i)) || i);
-  return s && i && Dt(t, e, i), i;
+var De = Object.defineProperty, je = Object.getOwnPropertyDescriptor, _ = (r, e, t, s) => {
+  for (var i = s > 1 ? void 0 : s ? je(e, t) : e, o = r.length - 1, n; o >= 0; o--)
+    (n = r[o]) && (i = (s ? n(e, t, i) : n(i)) || i);
+  return s && i && De(e, t, i), i;
 };
 let u = class extends M {
   constructor() {
@@ -645,65 +645,65 @@ let u = class extends M {
     if (this.hass) {
       this._loading = !0;
       try {
-        const t = await this.hass.callWS({
+        const e = await this.hass.callWS({
           type: "config_entries/get",
           domain: "meraki_ha"
-        }), e = ((r = this._config) == null ? void 0 : r.config_entry_id) || (t.length > 0 ? t[0].entry_id : null);
-        if (!e) {
+        }), t = ((r = this._config) == null ? void 0 : r.config_entry_id) || (e.length > 0 ? e[0].entry_id : null);
+        if (!t) {
           this._error = "Meraki integration not found. Please configure it first.", this._loading = !1;
           return;
         }
-        const s = await at(this.hass, {
+        const s = await ae(this.hass, {
           type: W.GET_CONFIG,
-          config_entry_id: e
+          config_entry_id: t
         });
-        this._networks = s.networks.filter((i) => {
-          var n;
-          return (n = i.productTypes) == null ? void 0 : n.includes("wireless");
-        }) || [], this._ssids = s.ssids || [], this._networks.length > 0 && !this._selectedNetwork && (this._selectedNetwork = this._networks[0].id, this._fetchPolicies(this._selectedNetwork, e));
-      } catch (t) {
-        this._error = `Failed to fetch Meraki data: ${t.message || t}`;
+        this._networks = (Array.isArray(s.networks) ? s.networks : []).filter((i) => {
+          var o;
+          return (o = i.productTypes) == null ? void 0 : o.includes("wireless");
+        }), this._ssids = Array.isArray(s.ssids) ? s.ssids : [], this._networks.length > 0 && !this._selectedNetwork && (this._selectedNetwork = this._networks[0].id, this._fetchPolicies(this._selectedNetwork, t));
+      } catch (e) {
+        this._error = `Failed to fetch Meraki data: ${e.message || e}`;
       } finally {
         this._loading = !1;
       }
     }
   }
-  async _fetchPolicies(r, t) {
-    var e;
+  async _fetchPolicies(r, e) {
+    var t;
     if (this.hass)
       try {
-        let s = t || ((e = this._config) == null ? void 0 : e.config_entry_id);
+        let s = e || ((t = this._config) == null ? void 0 : t.config_entry_id);
         if (!s) {
-          const n = await this.hass.callWS({
+          const o = await this.hass.callWS({
             type: "config_entries/get",
             domain: "meraki_ha"
           });
-          s = n.length > 0 ? n[0].entry_id : void 0;
+          s = o.length > 0 ? o[0].entry_id : void 0;
         }
         if (!s) return;
-        const i = await at(this.hass, {
+        const i = await ae(this.hass, {
           type: W.TIMED_ACCESS_GET_POLICIES,
           config_entry_id: s,
           networkId: r
         });
-        this._policies = i;
+        this._policies = Array.isArray(i) ? i : (i == null ? void 0 : i.policies) || [];
       } catch (s) {
         console.error("Failed to fetch policies:", s), this._policies = [];
       }
   }
   render() {
-    var t, e;
+    var e, t;
     if (this._loading && !this._networks.length)
       return v`
-        <ha-card .header="${((t = this._config) == null ? void 0 : t.name) || "Meraki Guest Access"}">
+        <ha-card .header="${((e = this._config) == null ? void 0 : e.name) || "Meraki Guest Access"}">
           <div class="card-content flex justify-center p-8">
             <ha-circular-progress active></ha-circular-progress>
           </div>
         </ha-card>
       `;
-    const r = this._ssids.filter((s) => s.networkId === this._selectedNetwork);
+    const r = (this._ssids || []).filter((s) => s.networkId === this._selectedNetwork);
     return v`
-      <ha-card .header="${((e = this._config) == null ? void 0 : e.name) || "Meraki Guest Access"}">
+      <ha-card .header="${((t = this._config) == null ? void 0 : t.name) || "Meraki Guest Access"}">
         <div class="card-content">
           ${this._error ? v`
                 <ha-alert alert-type="error" dismissable @alert-dismissed-clicked="${() => this._error = null}">
@@ -724,8 +724,8 @@ let u = class extends M {
               fixedMenuPosition
               naturalMenuWidth
             >
-              ${this._networks.map(
-      (s) => v`<mwc-list-item .value="${s.id}">${s.name}</mwc-list-item>`
+              ${(this._networks || []).map(
+      (s) => v`<md-select-option .value="${String(s.id)}">${s.name}</md-select-option>`
     )}
             </ha-select>
 
@@ -737,8 +737,8 @@ let u = class extends M {
               fixedMenuPosition
               naturalMenuWidth
             >
-              ${r.map(
-      (s) => v`<mwc-list-item .value="${s.number.toString()}">${s.name} (SSID ${s.number})</mwc-list-item>`
+              ${(r || []).map(
+      (s) => v`<md-select-option .value="${String(s.number)}">${s.name} (SSID ${s.number})</md-select-option>`
     )}
             </ha-select>
 
@@ -750,9 +750,9 @@ let u = class extends M {
               fixedMenuPosition
               naturalMenuWidth
             >
-              <mwc-list-item .value="">None (Default)</mwc-list-item>
-              ${this._policies.map(
-      (s) => v`<mwc-list-item .value="${s.groupPolicyId}">${s.name}</mwc-list-item>`
+              <md-select-option .value="">None (Default)</md-select-option>
+              ${(this._policies || []).map(
+      (s) => v`<md-select-option .value="${String(s.groupPolicyId)}">${s.name}</md-select-option>`
     )}
             </ha-select>
 
@@ -763,11 +763,11 @@ let u = class extends M {
               fixedMenuPosition
               naturalMenuWidth
             >
-              <mwc-list-item .value="${"30"}">30 Minutes</mwc-list-item>
-              <mwc-list-item .value="${"60"}">1 Hour</mwc-list-item>
-              <mwc-list-item .value="${"240"}">4 Hours</mwc-list-item>
-              <mwc-list-item .value="${"1440"}">24 Hours</mwc-list-item>
-              <mwc-list-item .value="${"10080"}">7 Days</mwc-list-item>
+              <md-select-option .value="${"30"}">30 Minutes</md-select-option>
+              <md-select-option .value="${"60"}">1 Hour</md-select-option>
+              <md-select-option .value="${"240"}">4 Hours</md-select-option>
+              <md-select-option .value="${"1440"}">24 Hours</md-select-option>
+              <md-select-option .value="${"10080"}">7 Days</md-select-option>
             </ha-select>
 
             <ha-textfield
@@ -797,8 +797,8 @@ let u = class extends M {
     `;
   }
   _handleNetworkChanged(r) {
-    const t = r.target.value;
-    t !== this._selectedNetwork && (this._selectedNetwork = t, this._selectedSsid = "", this._selectedPolicy = "", this._fetchPolicies(t));
+    const e = r.target.value;
+    e !== this._selectedNetwork && (this._selectedNetwork = e, this._selectedSsid = "", this._selectedPolicy = "", this._fetchPolicies(e));
   }
   _handleSsidChanged(r) {
     this._selectedSsid = r.target.value;
@@ -823,7 +823,7 @@ let u = class extends M {
     }
   }
 };
-u.styles = ft`
+u.styles = fe`
     :host {
       display: block;
     }
@@ -853,7 +853,7 @@ u.styles = ft`
     }
   `;
 _([
-  _t({ attribute: !1 })
+  _e({ attribute: !1 })
 ], u.prototype, "hass", 2);
 _([
   $()
@@ -898,7 +898,7 @@ _([
   $()
 ], u.prototype, "_loading", 2);
 u = _([
-  Ht("meraki-guest-access-card")
+  He("meraki-guest-access-card")
 ], u);
 window.customCards = window.customCards || [];
 window.customCards.push({

--- a/frontend/src/meraki-card.ts
+++ b/frontend/src/meraki-card.ts
@@ -78,8 +78,8 @@ export class MerakiGuestAccessCard extends LitElement {
         config_entry_id: entryId,
       });
 
-      this._networks = data.networks.filter((n: any) => n.productTypes?.includes('wireless')) || [];
-      this._ssids = data.ssids || [];
+      this._networks = (Array.isArray(data.networks) ? data.networks : []).filter((n: any) => n.productTypes?.includes('wireless'));
+      this._ssids = Array.isArray(data.ssids) ? data.ssids : [];
 
       if (this._networks.length > 0 && !this._selectedNetwork) {
         this._selectedNetwork = this._networks[0].id;
@@ -111,7 +111,7 @@ export class MerakiGuestAccessCard extends LitElement {
         config_entry_id: entryId,
         networkId: networkId,
       });
-      this._policies = policies;
+      this._policies = Array.isArray(policies) ? policies : (policies as any)?.policies || [];
     } catch (err: any) {
       console.error('Failed to fetch policies:', err);
       this._policies = [];
@@ -129,7 +129,7 @@ export class MerakiGuestAccessCard extends LitElement {
       `;
     }
 
-    const filteredSsids = this._ssids.filter(s => s.networkId === this._selectedNetwork);
+    const filteredSsids = (this._ssids || []).filter(s => s.networkId === this._selectedNetwork);
 
     return html`
       <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
@@ -157,8 +157,8 @@ export class MerakiGuestAccessCard extends LitElement {
               fixedMenuPosition
               naturalMenuWidth
             >
-              ${this._networks.map(
-                (n) => html`<mwc-list-item .value="${n.id}">${n.name}</mwc-list-item>`
+              ${(this._networks || []).map(
+                (n) => html`<md-select-option .value="${String(n.id)}">${n.name}</md-select-option>`
               )}
             </ha-select>
 
@@ -170,8 +170,8 @@ export class MerakiGuestAccessCard extends LitElement {
               fixedMenuPosition
               naturalMenuWidth
             >
-              ${filteredSsids.map(
-                (s) => html`<mwc-list-item .value="${s.number.toString()}">${s.name} (SSID ${s.number})</mwc-list-item>`
+              ${(filteredSsids || []).map(
+                (s) => html`<md-select-option .value="${String(s.number)}">${s.name} (SSID ${s.number})</md-select-option>`
               )}
             </ha-select>
 
@@ -183,9 +183,9 @@ export class MerakiGuestAccessCard extends LitElement {
               fixedMenuPosition
               naturalMenuWidth
             >
-              <mwc-list-item .value="">None (Default)</mwc-list-item>
-              ${this._policies.map(
-                (p) => html`<mwc-list-item .value="${p.groupPolicyId}">${p.name}</mwc-list-item>`
+              <md-select-option .value="">None (Default)</md-select-option>
+              ${(this._policies || []).map(
+                (p) => html`<md-select-option .value="${String(p.groupPolicyId)}">${p.name}</md-select-option>`
               )}
             </ha-select>
 
@@ -196,11 +196,11 @@ export class MerakiGuestAccessCard extends LitElement {
               fixedMenuPosition
               naturalMenuWidth
             >
-              <mwc-list-item .value="${"30"}">30 Minutes</mwc-list-item>
-              <mwc-list-item .value="${"60"}">1 Hour</mwc-list-item>
-              <mwc-list-item .value="${"240"}">4 Hours</mwc-list-item>
-              <mwc-list-item .value="${"1440"}">24 Hours</mwc-list-item>
-              <mwc-list-item .value="${"10080"}">7 Days</mwc-list-item>
+              <md-select-option .value="${"30"}">30 Minutes</md-select-option>
+              <md-select-option .value="${"60"}">1 Hour</md-select-option>
+              <md-select-option .value="${"240"}">4 Hours</md-select-option>
+              <md-select-option .value="${"1440"}">24 Hours</md-select-option>
+              <md-select-option .value="${"10080"}">7 Days</md-select-option>
             </ha-select>
 
             <ha-textfield


### PR DESCRIPTION
This PR fixes several issues in the `meraki-guest-access-card` frontend component:
1. **Dropdown Interactivity**: Changed `<mwc-list-item>` to `<md-select-option>` which resolves issues with dropdowns being unclickable or freezing on load.
2. **Type Safety**: Ensured that all values passed to list item components are explicitly cast to strings.
3. **Robustness**: Added defensive array safeguards (`(array || [])`) to all template mappings and ensured API fetch responses are explicitly cast to arrays before assignment. This prevents the component from crashing if the Meraki API returns unexpected or empty data.
4. **Cleanup**: Verified that `getConfigElement` is not present, preventing unnecessary warnings in the Home Assistant Lovelace editor.

The frontend has been rebuilt, and the updated `meraki-card.js` artifact is included in the integration's `www` directory.

Fixes #2253

---
*PR created automatically by Jules for task [16706516778487033884](https://jules.google.com/task/16706516778487033884) started by @brewmarsh*