### PR TITLE
Deploy Blueprints to Home Assistant Config

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -47,12 +47,15 @@ jobs:
         run: |
           SourceComponentDir="${GITHUB_WORKSPACE}/custom_components/meraki_ha/"
           DestinationPath="${DEPLOY_PATH}"
+          SourceBlueprintsDir="${SourceComponentDir}blueprints/"
+          DestinationBlueprintsPath="${{ env.HA_CONFIG_DIR }}/blueprints/"
 
           echo "Starting staging deployment..."
           echo "Source: ${SourceComponentDir}"
           echo "Destination: ${DestinationPath}"
 
           sudo mkdir -p "${DestinationPath}"
+          sudo mkdir -p "${DestinationBlueprintsPath}"
 
           # Sync files (Restored --inplace to fix Docker bind mount temp file errors)
           sudo rsync -rcvltpD --inplace --delete \
@@ -63,6 +66,13 @@ jobs:
             --exclude '__pycache__' \
             --exclude '.DS_Store' \
             "${SourceComponentDir}" "${DestinationPath}"
+
+          # Sync blueprints to the root /config/blueprints/ directory (No --delete to avoid wiping others)
+          echo "Syncing blueprints..."
+          echo "Source Blueprints: ${SourceBlueprintsDir}"
+          echo "Destination Blueprints: ${DestinationBlueprintsPath}"
+          sudo rsync -rcvltpD --inplace \
+            "${SourceBlueprintsDir}" "${DestinationBlueprintsPath}"
 
           echo "Deployment to staging complete."
 


### PR DESCRIPTION
Updated the `deploy-staging.yaml` workflow to include a second `rsync` command that copies the integration's automation blueprints to the standard Home Assistant blueprints directory (`/ha_config/blueprints/`). This ensures that blueprints included with the integration are correctly discovered and made available in the Home Assistant UI. The sync command for blueprints avoids using the `--delete` flag to prevent removing blueprints from other integrations or user-created ones in the shared directory.

Fixes #2256

---
*PR created automatically by Jules for task [14843294890035036710](https://jules.google.com/task/14843294890035036710) started by @brewmarsh*