### PR TITLE
Fix Frontend Request Loop and Registration Crash

### DIFF
--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -3,260 +3,260 @@
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const I = globalThis, K = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, q = Symbol(), Y = /* @__PURE__ */ new WeakMap();
-let le = class {
-  constructor(e, t, s) {
-    if (this._$cssResult$ = !0, s !== q) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
-    this.cssText = e, this.t = t;
+const I = globalThis, K = I.ShadowRoot && (I.ShadyCSS === void 0 || I.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, q = Symbol(), Z = /* @__PURE__ */ new WeakMap();
+let ct = class {
+  constructor(t, e, i) {
+    if (this._$cssResult$ = !0, i !== q) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    this.cssText = t, this.t = e;
   }
   get styleSheet() {
-    let e = this.o;
-    const t = this.t;
-    if (K && e === void 0) {
-      const s = t !== void 0 && t.length === 1;
-      s && (e = Y.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), s && Y.set(t, e));
+    let t = this.o;
+    const e = this.t;
+    if (K && t === void 0) {
+      const i = e !== void 0 && e.length === 1;
+      i && (t = Z.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), i && Z.set(e, t));
     }
-    return e;
+    return t;
   }
   toString() {
     return this.cssText;
   }
 };
-const $e = (r) => new le(typeof r == "string" ? r : r + "", void 0, q), fe = (r, ...e) => {
-  const t = r.length === 1 ? r[0] : e.reduce((s, i, o) => s + ((n) => {
+const ft = (r) => new ct(typeof r == "string" ? r : r + "", void 0, q), mt = (r, ...t) => {
+  const e = r.length === 1 ? r[0] : t.reduce((i, s, o) => i + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(i) + r[o + 1], r[0]);
-  return new le(t, r, q);
-}, me = (r, e) => {
-  if (K) r.adoptedStyleSheets = e.map((t) => t instanceof CSSStyleSheet ? t : t.styleSheet);
-  else for (const t of e) {
-    const s = document.createElement("style"), i = I.litNonce;
-    i !== void 0 && s.setAttribute("nonce", i), s.textContent = t.cssText, r.appendChild(s);
+  })(s) + r[o + 1], r[0]);
+  return new ct(e, r, q);
+}, gt = (r, t) => {
+  if (K) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  else for (const e of t) {
+    const i = document.createElement("style"), s = I.litNonce;
+    s !== void 0 && i.setAttribute("nonce", s), i.textContent = e.cssText, r.appendChild(i);
   }
-}, Z = K ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((e) => {
-  let t = "";
-  for (const s of e.cssRules) t += s.cssText;
-  return $e(t);
+}, Q = K ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
+  let e = "";
+  for (const i of t.cssRules) e += i.cssText;
+  return ft(e);
 })(r) : r;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: ge, defineProperty: ye, getOwnPropertyDescriptor: Ae, getOwnPropertyNames: ve, getOwnPropertySymbols: Ee, getPrototypeOf: Se } = Object, y = globalThis, Q = y.trustedTypes, we = Q ? Q.emptyScript : "", L = y.reactiveElementPolyfillSupport, N = (r, e) => r, D = { toAttribute(r, e) {
-  switch (e) {
+const { is: yt, defineProperty: At, getOwnPropertyDescriptor: vt, getOwnPropertyNames: Et, getOwnPropertySymbols: St, getPrototypeOf: wt } = Object, y = globalThis, X = y.trustedTypes, bt = X ? X.emptyScript : "", G = y.reactiveElementPolyfillSupport, N = (r, t) => r, D = { toAttribute(r, t) {
+  switch (t) {
     case Boolean:
-      r = r ? we : null;
+      r = r ? bt : null;
       break;
     case Object:
     case Array:
       r = r == null ? r : JSON.stringify(r);
   }
   return r;
-}, fromAttribute(r, e) {
-  let t = r;
-  switch (e) {
+}, fromAttribute(r, t) {
+  let e = r;
+  switch (t) {
     case Boolean:
-      t = r !== null;
+      e = r !== null;
       break;
     case Number:
-      t = r === null ? null : Number(r);
+      e = r === null ? null : Number(r);
       break;
     case Object:
     case Array:
       try {
-        t = JSON.parse(r);
+        e = JSON.parse(r);
       } catch {
-        t = null;
+        e = null;
       }
   }
-  return t;
-} }, F = (r, e) => !ge(r, e), X = { attribute: !0, type: String, converter: D, reflect: !1, useDefault: !1, hasChanged: F };
+  return e;
+} }, F = (r, t) => !yt(r, t), tt = { attribute: !0, type: String, converter: D, reflect: !1, useDefault: !1, hasChanged: F };
 Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), y.litPropertyMetadata ?? (y.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
 let b = class extends HTMLElement {
-  static addInitializer(e) {
-    this._$Ei(), (this.l ?? (this.l = [])).push(e);
+  static addInitializer(t) {
+    this._$Ei(), (this.l ?? (this.l = [])).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(e, t = X) {
-    if (t.state && (t.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(e) && ((t = Object.create(t)).wrapped = !0), this.elementProperties.set(e, t), !t.noAccessor) {
-      const s = Symbol(), i = this.getPropertyDescriptor(e, s, t);
-      i !== void 0 && ye(this.prototype, e, i);
+  static createProperty(t, e = tt) {
+    if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
+      const i = Symbol(), s = this.getPropertyDescriptor(t, i, e);
+      s !== void 0 && At(this.prototype, t, s);
     }
   }
-  static getPropertyDescriptor(e, t, s) {
-    const { get: i, set: o } = Ae(this.prototype, e) ?? { get() {
-      return this[t];
+  static getPropertyDescriptor(t, e, i) {
+    const { get: s, set: o } = vt(this.prototype, t) ?? { get() {
+      return this[e];
     }, set(n) {
-      this[t] = n;
+      this[e] = n;
     } };
-    return { get: i, set(n) {
-      const h = i == null ? void 0 : i.call(this);
-      o == null || o.call(this, n), this.requestUpdate(e, h, s);
+    return { get: s, set(n) {
+      const h = s == null ? void 0 : s.call(this);
+      o == null || o.call(this, n), this.requestUpdate(t, h, i);
     }, configurable: !0, enumerable: !0 };
   }
-  static getPropertyOptions(e) {
-    return this.elementProperties.get(e) ?? X;
+  static getPropertyOptions(t) {
+    return this.elementProperties.get(t) ?? tt;
   }
   static _$Ei() {
     if (this.hasOwnProperty(N("elementProperties"))) return;
-    const e = Se(this);
-    e.finalize(), e.l !== void 0 && (this.l = [...e.l]), this.elementProperties = new Map(e.elementProperties);
+    const t = wt(this);
+    t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
     if (this.hasOwnProperty(N("finalized"))) return;
     if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(N("properties"))) {
-      const t = this.properties, s = [...ve(t), ...Ee(t)];
-      for (const i of s) this.createProperty(i, t[i]);
+      const e = this.properties, i = [...Et(e), ...St(e)];
+      for (const s of i) this.createProperty(s, e[s]);
     }
-    const e = this[Symbol.metadata];
-    if (e !== null) {
-      const t = litPropertyMetadata.get(e);
-      if (t !== void 0) for (const [s, i] of t) this.elementProperties.set(s, i);
+    const t = this[Symbol.metadata];
+    if (t !== null) {
+      const e = litPropertyMetadata.get(t);
+      if (e !== void 0) for (const [i, s] of e) this.elementProperties.set(i, s);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [t, s] of this.elementProperties) {
-      const i = this._$Eu(t, s);
-      i !== void 0 && this._$Eh.set(i, t);
+    for (const [e, i] of this.elementProperties) {
+      const s = this._$Eu(e, i);
+      s !== void 0 && this._$Eh.set(s, e);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
-  static finalizeStyles(e) {
-    const t = [];
-    if (Array.isArray(e)) {
-      const s = new Set(e.flat(1 / 0).reverse());
-      for (const i of s) t.unshift(Z(i));
-    } else e !== void 0 && t.push(Z(e));
-    return t;
+  static finalizeStyles(t) {
+    const e = [];
+    if (Array.isArray(t)) {
+      const i = new Set(t.flat(1 / 0).reverse());
+      for (const s of i) e.unshift(Q(s));
+    } else t !== void 0 && e.push(Q(t));
+    return e;
   }
-  static _$Eu(e, t) {
-    const s = t.attribute;
-    return s === !1 ? void 0 : typeof s == "string" ? s : typeof e == "string" ? e.toLowerCase() : void 0;
+  static _$Eu(t, e) {
+    const i = e.attribute;
+    return i === !1 ? void 0 : typeof i == "string" ? i : typeof t == "string" ? t.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
   }
   _$Ev() {
+    var t;
+    this._$ES = new Promise((e) => this.enableUpdating = e), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), (t = this.constructor.l) == null || t.forEach((e) => e(this));
+  }
+  addController(t) {
     var e;
-    this._$ES = new Promise((t) => this.enableUpdating = t), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), (e = this.constructor.l) == null || e.forEach((t) => t(this));
+    (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(t), this.renderRoot !== void 0 && this.isConnected && ((e = t.hostConnected) == null || e.call(t));
   }
-  addController(e) {
-    var t;
-    (this._$EO ?? (this._$EO = /* @__PURE__ */ new Set())).add(e), this.renderRoot !== void 0 && this.isConnected && ((t = e.hostConnected) == null || t.call(e));
-  }
-  removeController(e) {
-    var t;
-    (t = this._$EO) == null || t.delete(e);
+  removeController(t) {
+    var e;
+    (e = this._$EO) == null || e.delete(t);
   }
   _$E_() {
-    const e = /* @__PURE__ */ new Map(), t = this.constructor.elementProperties;
-    for (const s of t.keys()) this.hasOwnProperty(s) && (e.set(s, this[s]), delete this[s]);
-    e.size > 0 && (this._$Ep = e);
+    const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
+    for (const i of e.keys()) this.hasOwnProperty(i) && (t.set(i, this[i]), delete this[i]);
+    t.size > 0 && (this._$Ep = t);
   }
   createRenderRoot() {
-    const e = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return me(e, this.constructor.elementStyles), e;
+    const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
+    return gt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
-    var e;
-    this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (e = this._$EO) == null || e.forEach((t) => {
-      var s;
-      return (s = t.hostConnected) == null ? void 0 : s.call(t);
+    var t;
+    this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (t = this._$EO) == null || t.forEach((e) => {
+      var i;
+      return (i = e.hostConnected) == null ? void 0 : i.call(e);
     });
   }
-  enableUpdating(e) {
+  enableUpdating(t) {
   }
   disconnectedCallback() {
-    var e;
-    (e = this._$EO) == null || e.forEach((t) => {
-      var s;
-      return (s = t.hostDisconnected) == null ? void 0 : s.call(t);
+    var t;
+    (t = this._$EO) == null || t.forEach((e) => {
+      var i;
+      return (i = e.hostDisconnected) == null ? void 0 : i.call(e);
     });
   }
-  attributeChangedCallback(e, t, s) {
-    this._$AK(e, s);
+  attributeChangedCallback(t, e, i) {
+    this._$AK(t, i);
   }
-  _$ET(e, t) {
+  _$ET(t, e) {
     var o;
-    const s = this.constructor.elementProperties.get(e), i = this.constructor._$Eu(e, s);
-    if (i !== void 0 && s.reflect === !0) {
-      const n = (((o = s.converter) == null ? void 0 : o.toAttribute) !== void 0 ? s.converter : D).toAttribute(t, s.type);
-      this._$Em = e, n == null ? this.removeAttribute(i) : this.setAttribute(i, n), this._$Em = null;
+    const i = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, i);
+    if (s !== void 0 && i.reflect === !0) {
+      const n = (((o = i.converter) == null ? void 0 : o.toAttribute) !== void 0 ? i.converter : D).toAttribute(e, i.type);
+      this._$Em = t, n == null ? this.removeAttribute(s) : this.setAttribute(s, n), this._$Em = null;
     }
   }
-  _$AK(e, t) {
+  _$AK(t, e) {
     var o, n;
-    const s = this.constructor, i = s._$Eh.get(e);
-    if (i !== void 0 && this._$Em !== i) {
-      const h = s.getPropertyOptions(i), a = typeof h.converter == "function" ? { fromAttribute: h.converter } : ((o = h.converter) == null ? void 0 : o.fromAttribute) !== void 0 ? h.converter : D;
-      this._$Em = i;
-      const c = a.fromAttribute(t, h.type);
-      this[i] = c ?? ((n = this._$Ej) == null ? void 0 : n.get(i)) ?? c, this._$Em = null;
+    const i = this.constructor, s = i._$Eh.get(t);
+    if (s !== void 0 && this._$Em !== s) {
+      const h = i.getPropertyOptions(s), a = typeof h.converter == "function" ? { fromAttribute: h.converter } : ((o = h.converter) == null ? void 0 : o.fromAttribute) !== void 0 ? h.converter : D;
+      this._$Em = s;
+      const c = a.fromAttribute(e, h.type);
+      this[s] = c ?? ((n = this._$Ej) == null ? void 0 : n.get(s)) ?? c, this._$Em = null;
     }
   }
-  requestUpdate(e, t, s, i = !1, o) {
+  requestUpdate(t, e, i, s = !1, o) {
     var n;
-    if (e !== void 0) {
+    if (t !== void 0) {
       const h = this.constructor;
-      if (i === !1 && (o = this[e]), s ?? (s = h.getPropertyOptions(e)), !((s.hasChanged ?? F)(o, t) || s.useDefault && s.reflect && o === ((n = this._$Ej) == null ? void 0 : n.get(e)) && !this.hasAttribute(h._$Eu(e, s)))) return;
-      this.C(e, t, s);
+      if (s === !1 && (o = this[t]), i ?? (i = h.getPropertyOptions(t)), !((i.hasChanged ?? F)(o, e) || i.useDefault && i.reflect && o === ((n = this._$Ej) == null ? void 0 : n.get(t)) && !this.hasAttribute(h._$Eu(t, i)))) return;
+      this.C(t, e, i);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(e, t, { useDefault: s, reflect: i, wrapped: o }, n) {
-    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(e) && (this._$Ej.set(e, n ?? t ?? this[e]), o !== !0 || n !== void 0) || (this._$AL.has(e) || (this.hasUpdated || s || (t = void 0), this._$AL.set(e, t)), i === !0 && this._$Em !== e && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(e));
+  C(t, e, { useDefault: i, reflect: s, wrapped: o }, n) {
+    i && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || i || (e = void 0), this._$AL.set(t, e)), s === !0 && this._$Em !== t && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t));
   }
   async _$EP() {
     this.isUpdatePending = !0;
     try {
       await this._$ES;
-    } catch (t) {
-      Promise.reject(t);
+    } catch (e) {
+      Promise.reject(e);
     }
-    const e = this.scheduleUpdate();
-    return e != null && await e, !this.isUpdatePending;
+    const t = this.scheduleUpdate();
+    return t != null && await t, !this.isUpdatePending;
   }
   scheduleUpdate() {
     return this.performUpdate();
   }
   performUpdate() {
-    var s;
+    var i;
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
         for (const [o, n] of this._$Ep) this[o] = n;
         this._$Ep = void 0;
       }
-      const i = this.constructor.elementProperties;
-      if (i.size > 0) for (const [o, n] of i) {
+      const s = this.constructor.elementProperties;
+      if (s.size > 0) for (const [o, n] of s) {
         const { wrapped: h } = n, a = this[o];
         h !== !0 || this._$AL.has(o) || a === void 0 || this.C(o, void 0, n, a);
       }
     }
-    let e = !1;
-    const t = this._$AL;
+    let t = !1;
+    const e = this._$AL;
     try {
-      e = this.shouldUpdate(t), e ? (this.willUpdate(t), (s = this._$EO) == null || s.forEach((i) => {
+      t = this.shouldUpdate(e), t ? (this.willUpdate(e), (i = this._$EO) == null || i.forEach((s) => {
         var o;
-        return (o = i.hostUpdate) == null ? void 0 : o.call(i);
-      }), this.update(t)) : this._$EM();
-    } catch (i) {
-      throw e = !1, this._$EM(), i;
+        return (o = s.hostUpdate) == null ? void 0 : o.call(s);
+      }), this.update(e)) : this._$EM();
+    } catch (s) {
+      throw t = !1, this._$EM(), s;
     }
-    e && this._$AE(t);
+    t && this._$AE(e);
   }
-  willUpdate(e) {
+  willUpdate(t) {
   }
-  _$AE(e) {
-    var t;
-    (t = this._$EO) == null || t.forEach((s) => {
-      var i;
-      return (i = s.hostUpdated) == null ? void 0 : i.call(s);
-    }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(e)), this.updated(e);
+  _$AE(t) {
+    var e;
+    (e = this._$EO) == null || e.forEach((i) => {
+      var s;
+      return (s = i.hostUpdated) == null ? void 0 : s.call(i);
+    }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
   }
   _$EM() {
     this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = !1;
@@ -267,21 +267,639 @@ let b = class extends HTMLElement {
   getUpdateComplete() {
     return this._$ES;
   }
-  shouldUpdate(e) {
+  shouldUpdate(t) {
     return !0;
   }
-  update(e) {
-    this._$Eq && (this._$Eq = this._$Eq.forEach((t) => this._$ET(t, this[t]))), this._$EM();
+  update(t) {
+    this._$Eq && (this._$Eq = this._$Eq.forEach((e) => this._$ET(e, this[e]))), this._$EM();
   }
-  updated(e) {
+  updated(t) {
   }
-  firstUpdated(e) {
+  firstUpdated(t) {
   }
 };
-b.elementStyles = [], b.shadowRootOptions = { mode: "open" }, b[N("elementProperties")] = /* @__PURE__ */ new Map(), b[N("finalized")] = /* @__PURE__ */ new Map(), L == null || L({ ReactiveElement: b }), (y.reactiveElementVersions ?? (y.reactiveElementVersions = [])).push("2.1.2");
+b.elementStyles = [], b.shadowRootOptions = { mode: "open" }, b[N("elementProperties")] = /* @__PURE__ */ new Map(), b[N("finalized")] = /* @__PURE__ */ new Map(), G == null || G({ ReactiveElement: b }), (y.reactiveElementVersions ?? (y.reactiveElementVersions = [])).push("2.1.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const x = globalThis, ee = (r) => r, j = x.trustedTypes, te = j ? j.createPolicy("
+const x = globalThis, et = (r) => r, j = x.trustedTypes, st = j ? j.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, dt = "$lit$", g = `lit$${Math.random().toFixed(9).slice(2)}$`, ut = "?" + g, kt = `<${ut}>`, w = document, T = () => w.createComment(""), O = (r) => r === null || typeof r != "object" && typeof r != "function", J = Array.isArray, Pt = (r) => J(r) || typeof (r == null ? void 0 : r[Symbol.iterator]) == "function", z = `[
+\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, it = /-->/g, rt = />/g, A = RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^
+\f\r"'\`<>=]|("|')|))|$)`, "g"), ot = /'/g, nt = /"/g, pt = /^(?:script|style|textarea|title)$/i, Ct = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), v = Ct(1), k = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), at = /* @__PURE__ */ new WeakMap(), E = w.createTreeWalker(w, 129);
+function _t(r, t) {
+  if (!J(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return st !== void 0 ? st.createHTML(t) : t;
+}
+const Nt = (r, t) => {
+  const e = r.length - 1, i = [];
+  let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = C;
+  for (let h = 0; h < e; h++) {
+    const a = r[h];
+    let c, p, l = -1, f = 0;
+    for (; f < a.length && (n.lastIndex = f, p = n.exec(a), p !== null); ) f = n.lastIndex, n === C ? p[1] === "!--" ? n = it : p[1] !== void 0 ? n = rt : p[2] !== void 0 ? (pt.test(p[2]) && (s = RegExp("</" + p[2], "g")), n = A) : p[3] !== void 0 && (n = A) : n === A ? p[0] === ">" ? (n = s ?? C, l = -1) : p[1] === void 0 ? l = -2 : (l = n.lastIndex - p[2].length, c = p[1], n = p[3] === void 0 ? A : p[3] === '"' ? nt : ot) : n === nt || n === ot ? n = A : n === it || n === rt ? n = C : (n = A, s = void 0);
+    const m = n === A && r[h + 1].startsWith("/>") ? " " : "";
+    o += n === C ? a + kt : l >= 0 ? (i.push(c), a.slice(0, l) + dt + a.slice(l) + g + m) : a + g + (l === -2 ? h : m);
+  }
+  return [_t(r, o + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), i];
+};
+class U {
+  constructor({ strings: t, _$litType$: e }, i) {
+    let s;
+    this.parts = [];
+    let o = 0, n = 0;
+    const h = t.length - 1, a = this.parts, [c, p] = Nt(t, e);
+    if (this.el = U.createElement(c, i), E.currentNode = this.el.content, e === 2 || e === 3) {
+      const l = this.el.content.firstChild;
+      l.replaceWith(...l.childNodes);
+    }
+    for (; (s = E.nextNode()) !== null && a.length < h; ) {
+      if (s.nodeType === 1) {
+        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith(dt)) {
+          const f = p[n++], m = s.getAttribute(l).split(g), R = /([.?@])?(.*)/.exec(f);
+          a.push({ type: 1, index: o, name: R[2], strings: m, ctor: R[1] === "." ? Mt : R[1] === "?" ? Tt : R[1] === "@" ? Ot : L }), s.removeAttribute(l);
+        } else l.startsWith(g) && (a.push({ type: 6, index: o }), s.removeAttribute(l));
+        if (pt.test(s.tagName)) {
+          const l = s.textContent.split(g), f = l.length - 1;
+          if (f > 0) {
+            s.textContent = j ? j.emptyScript : "";
+            for (let m = 0; m < f; m++) s.append(l[m], T()), E.nextNode(), a.push({ type: 2, index: ++o });
+            s.append(l[f], T());
+          }
+        }
+      } else if (s.nodeType === 8) if (s.data === ut) a.push({ type: 2, index: o });
+      else {
+        let l = -1;
+        for (; (l = s.data.indexOf(g, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += g.length - 1;
+      }
+      o++;
+    }
+  }
+  static createElement(t, e) {
+    const i = w.createElement("template");
+    return i.innerHTML = t, i;
+  }
+}
+function P(r, t, e = r, i) {
+  var n, h;
+  if (t === k) return t;
+  let s = i !== void 0 ? (n = e._$Co) == null ? void 0 : n[i] : e._$Cl;
+  const o = O(t) ? void 0 : t._$litDirective$;
+  return (s == null ? void 0 : s.constructor) !== o && ((h = s == null ? void 0 : s._$AO) == null || h.call(s, !1), o === void 0 ? s = void 0 : (s = new o(r), s._$AT(r, e, i)), i !== void 0 ? (e._$Co ?? (e._$Co = []))[i] = s : e._$Cl = s), s !== void 0 && (t = P(r, s._$AS(r, t.values), s, i)), t;
+}
+class xt {
+  constructor(t, e) {
+    this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
+  }
+  get parentNode() {
+    return this._$AM.parentNode;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  u(t) {
+    const { el: { content: e }, parts: i } = this._$AD, s = ((t == null ? void 0 : t.creationScope) ?? w).importNode(e, !0);
+    E.currentNode = s;
+    let o = E.nextNode(), n = 0, h = 0, a = i[0];
+    for (; a !== void 0; ) {
+      if (n === a.index) {
+        let c;
+        a.type === 2 ? c = new H(o, o.nextSibling, this, t) : a.type === 1 ? c = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (c = new Ut(o, this, t)), this._$AV.push(c), a = i[++h];
+      }
+      n !== (a == null ? void 0 : a.index) && (o = E.nextNode(), n++);
+    }
+    return E.currentNode = w, s;
+  }
+  p(t) {
+    let e = 0;
+    for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(t, i, e), e += i.strings.length - 2) : i._$AI(t[e])), e++;
+  }
+}
+class H {
+  get _$AU() {
+    var t;
+    return ((t = this._$AM) == null ? void 0 : t._$AU) ?? this._$Cv;
+  }
+  constructor(t, e, i, s) {
+    this.type = 2, this._$AH = u, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = i, this.options = s, this._$Cv = (s == null ? void 0 : s.isConnected) ?? !0;
+  }
+  get parentNode() {
+    let t = this._$AA.parentNode;
+    const e = this._$AM;
+    return e !== void 0 && (t == null ? void 0 : t.nodeType) === 11 && (t = e.parentNode), t;
+  }
+  get startNode() {
+    return this._$AA;
+  }
+  get endNode() {
+    return this._$AB;
+  }
+  _$AI(t, e = this) {
+    t = P(this, t, e), O(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== k && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Pt(t) ? this.k(t) : this._(t);
+  }
+  O(t) {
+    return this._$AA.parentNode.insertBefore(t, this._$AB);
+  }
+  T(t) {
+    this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
+  }
+  _(t) {
+    this._$AH !== u && O(this._$AH) ? this._$AA.nextSibling.data = t : this.T(w.createTextNode(t)), this._$AH = t;
+  }
+  $(t) {
+    var o;
+    const { values: e, _$litType$: i } = t, s = typeof i == "number" ? this._$AC(t) : (i.el === void 0 && (i.el = U.createElement(_t(i.h, i.h[0]), this.options)), i);
+    if (((o = this._$AH) == null ? void 0 : o._$AD) === s) this._$AH.p(e);
+    else {
+      const n = new xt(s, this), h = n.u(this.options);
+      n.p(e), this.T(h), this._$AH = n;
+    }
+  }
+  _$AC(t) {
+    let e = at.get(t.strings);
+    return e === void 0 && at.set(t.strings, e = new U(t)), e;
+  }
+  k(t) {
+    J(this._$AH) || (this._$AH = [], this._$AR());
+    const e = this._$AH;
+    let i, s = 0;
+    for (const o of t) s === e.length ? e.push(i = new H(this.O(T()), this.O(T()), this, this.options)) : i = e[s], i._$AI(o), s++;
+    s < e.length && (this._$AR(i && i._$AB.nextSibling, s), e.length = s);
+  }
+  _$AR(t = this._$AA.nextSibling, e) {
+    var i;
+    for ((i = this._$AP) == null ? void 0 : i.call(this, !1, !0, e); t !== this._$AB; ) {
+      const s = et(t).nextSibling;
+      et(t).remove(), t = s;
+    }
+  }
+  setConnected(t) {
+    var e;
+    this._$AM === void 0 && (this._$Cv = t, (e = this._$AP) == null || e.call(this, t));
+  }
+}
+class L {
+  get tagName() {
+    return this.element.tagName;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  constructor(t, e, i, s, o) {
+    this.type = 1, this._$AH = u, this._$AN = void 0, this.element = t, this.name = e, this._$AM = s, this.options = o, i.length > 2 || i[0] !== "" || i[1] !== "" ? (this._$AH = Array(i.length - 1).fill(new String()), this.strings = i) : this._$AH = u;
+  }
+  _$AI(t, e = this, i, s) {
+    const o = this.strings;
+    let n = !1;
+    if (o === void 0) t = P(this, t, e, 0), n = !O(t) || t !== this._$AH && t !== k, n && (this._$AH = t);
+    else {
+      const h = t;
+      let a, c;
+      for (t = o[0], a = 0; a < o.length - 1; a++) c = P(this, h[i + a], e, a), c === k && (c = this._$AH[a]), n || (n = !O(c) || c !== this._$AH[a]), c === u ? t = u : t !== u && (t += (c ?? "") + o[a + 1]), this._$AH[a] = c;
+    }
+    n && !s && this.j(t);
+  }
+  j(t) {
+    t === u ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+  }
+}
+class Mt extends L {
+  constructor() {
+    super(...arguments), this.type = 3;
+  }
+  j(t) {
+    this.element[this.name] = t === u ? void 0 : t;
+  }
+}
+class Tt extends L {
+  constructor() {
+    super(...arguments), this.type = 4;
+  }
+  j(t) {
+    this.element.toggleAttribute(this.name, !!t && t !== u);
+  }
+}
+class Ot extends L {
+  constructor(t, e, i, s, o) {
+    super(t, e, i, s, o), this.type = 5;
+  }
+  _$AI(t, e = this) {
+    if ((t = P(this, t, e, 0) ?? u) === k) return;
+    const i = this._$AH, s = t === u && i !== u || t.capture !== i.capture || t.once !== i.once || t.passive !== i.passive, o = t !== u && (i === u || s);
+    s && this.element.removeEventListener(this.name, this, i), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
+  }
+  handleEvent(t) {
+    var e;
+    typeof this._$AH == "function" ? this._$AH.call(((e = this.options) == null ? void 0 : e.host) ?? this.element, t) : this._$AH.handleEvent(t);
+  }
+}
+class Ut {
+  constructor(t, e, i) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = i;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  _$AI(t) {
+    P(this, t);
+  }
+}
+const B = x.litHtmlPolyfillSupport;
+B == null || B(U, H), (x.litHtmlVersions ?? (x.litHtmlVersions = [])).push("3.3.2");
+const Ht = (r, t, e) => {
+  const i = (e == null ? void 0 : e.renderBefore) ?? t;
+  let s = i._$litPart$;
+  if (s === void 0) {
+    const o = (e == null ? void 0 : e.renderBefore) ?? null;
+    i._$litPart$ = s = new H(t.insertBefore(T(), o), o, void 0, e ?? {});
+  }
+  return s._$AI(r), s;
+};
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+const S = globalThis;
+class M extends b {
+  constructor() {
+    super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
+  }
+  createRenderRoot() {
+    var e;
+    const t = super.createRenderRoot();
+    return (e = this.renderOptions).renderBefore ?? (e.renderBefore = t.firstChild), t;
+  }
+  update(t) {
+    const e = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Ht(e, this.renderRoot, this.renderOptions);
+  }
+  connectedCallback() {
+    var t;
+    super.connectedCallback(), (t = this._$Do) == null || t.setConnected(!0);
+  }
+  disconnectedCallback() {
+    var t;
+    super.disconnectedCallback(), (t = this._$Do) == null || t.setConnected(!1);
+  }
+  render() {
+    return k;
+  }
+}
+var lt;
+M._$litElement$ = !0, M.finalized = !0, (lt = S.litElementHydrateSupport) == null || lt.call(S, { LitElement: M });
+const V = S.litElementPolyfillSupport;
+V == null || V({ LitElement: M });
+(S.litElementVersions ?? (S.litElementVersions = [])).push("4.2.2");
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+const Rt = { attribute: !0, type: String, converter: D, reflect: !1, hasChanged: F }, It = (r = Rt, t, e) => {
+  const { kind: i, metadata: s } = e;
+  let o = globalThis.litPropertyMetadata.get(s);
+  if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), i === "setter" && ((r = Object.create(r)).wrapped = !0), o.set(e.name, r), i === "accessor") {
+    const { name: n } = e;
+    return { set(h) {
+      const a = t.get.call(this);
+      t.set.call(this, h), this.requestUpdate(n, a, r, !0, h);
+    }, init(h) {
+      return h !== void 0 && this.C(n, void 0, r, h), h;
+    } };
+  }
+  if (i === "setter") {
+    const { name: n } = e;
+    return function(h) {
+      const a = this[n];
+      t.call(this, h), this.requestUpdate(n, a, r, !0, h);
+    };
+  }
+  throw Error("Unsupported decorator location: " + i);
+};
+function $t(r) {
+  return (t, e) => typeof e == "object" ? It(r, t, e) : ((i, s, o) => {
+    const n = s.hasOwnProperty(o);
+    return s.constructor.createProperty(o, i), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
+  })(r, t, e);
+}
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+function $(r) {
+  return $t({ ...r, state: !0, attribute: !1 });
+}
+var W = /* @__PURE__ */ ((r) => (r.GET_CONFIG = "meraki_ha/get_config", r.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", r.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", r.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", r.GET_VERSION = "meraki_ha/get_version", r.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", r.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", r.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", r.GET_GUEST_KEYS = "meraki_ha/ipsk/get", r.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", r.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", r))(W || {});
+const ht = async (r, t) => {
+  if (!r)
+    throw new Error("Home Assistant object is not available.");
+  try {
+    if (typeof r.callWS == "function")
+      return await r.callWS(t);
+    if (r.connection && typeof r.connection.sendMessagePromise == "function")
+      return await r.connection.sendMessagePromise(t);
+    throw new Error("Home Assistant WebSocket communication methods not found.");
+  } catch (e) {
+    throw console.error(`Meraki HA: WebSocket error [${t.type}]:`, e), e;
+  }
+};
+var Dt = Object.defineProperty, _ = (r, t, e, i) => {
+  for (var s = void 0, o = r.length - 1, n; o >= 0; o--)
+    (n = r[o]) && (s = n(t, e, s) || s);
+  return s && Dt(t, e, s), s;
+};
+const Y = class Y extends M {
+  constructor() {
+    super(...arguments), this._selectedNetwork = "", this._selectedSsid = "", this._selectedPolicy = "", this._duration = "60", this._customName = "", this._customPassphrase = "", this._creating = !1, this._error = null, this._success = null, this._networks = [], this._ssids = [], this._policies = [], this._loading = !0, this._initDone = !1;
+  }
+  setConfig(t) {
+    if (!t)
+      throw new Error("Invalid configuration");
+    this._config = t;
+  }
+  static getStubConfig() {
+    return {
+      name: "Meraki Guest Access"
+    };
+  }
+  firstUpdated(t) {
+    super.firstUpdated(t), this._fetchInitialData();
+  }
+  updated(t) {
+    var e;
+    super.updated(t), t.has("hass") && this.hass && (!this._initDone && this.hass && this._fetchInitialData(), (e = this.hass.user) != null && e.name && !this._customName && (this._customName = this.hass.user.name));
+  }
+  async _fetchInitialData() {
+    var t;
+    if (this._initDone = !0, !!this.hass) {
+      this._loading = !0;
+      try {
+        const e = await this.hass.callWS({
+          type: "config_entries/get",
+          domain: "meraki_ha"
+        }), i = ((t = this._config) == null ? void 0 : t.config_entry_id) || (e.length > 0 ? e[0].entry_id : null);
+        if (!i) {
+          this._error = "Meraki integration not found. Please configure it first.", this._loading = !1;
+          return;
+        }
+        const s = await ht(this.hass, {
+          type: W.GET_CONFIG,
+          config_entry_id: i
+        });
+        this._networks = (Array.isArray(s.networks) ? s.networks : []).filter((o) => {
+          var n;
+          return (n = o.productTypes) == null ? void 0 : n.includes("wireless");
+        }), this._ssids = Array.isArray(s.ssids) ? s.ssids : [], this._networks.length > 0 && !this._selectedNetwork && (this._selectedNetwork = this._networks[0].id, this._fetchPolicies(this._selectedNetwork, i));
+      } catch (e) {
+        this._error = `Failed to fetch Meraki data: ${e.message || e}`;
+      } finally {
+        this._loading = !1;
+      }
+    }
+  }
+  async _fetchPolicies(t, e) {
+    var i;
+    if (this.hass)
+      try {
+        let s = e || ((i = this._config) == null ? void 0 : i.config_entry_id);
+        if (!s) {
+          const n = await this.hass.callWS({
+            type: "config_entries/get",
+            domain: "meraki_ha"
+          });
+          s = n.length > 0 ? n[0].entry_id : void 0;
+        }
+        if (!s) return;
+        const o = await ht(this.hass, {
+          type: W.TIMED_ACCESS_GET_POLICIES,
+          config_entry_id: s,
+          networkId: t
+        });
+        this._policies = Array.isArray(o) ? o : (o == null ? void 0 : o.policies) || [];
+      } catch (s) {
+        console.error("Failed to fetch policies:", s), this._policies = [];
+      }
+  }
+  render() {
+    var e, i;
+    if (this._loading && !this._networks.length)
+      return v`
+        <ha-card .header="${((e = this._config) == null ? void 0 : e.name) || "Meraki Guest Access"}">
+          <div class="card-content flex justify-center p-8">
+            <ha-circular-progress active></ha-circular-progress>
+          </div>
+        </ha-card>
+      `;
+    const t = (this._ssids || []).filter((s) => s.networkId === this._selectedNetwork);
+    return v`
+      <ha-card .header="${((i = this._config) == null ? void 0 : i.name) || "Meraki Guest Access"}">
+        <div class="card-content">
+          ${this._error ? v`
+                <ha-alert alert-type="error" dismissable @alert-dismissed-clicked="${() => this._error = null}">
+                  ${this._error}
+                </ha-alert>
+              ` : ""}
+          ${this._success ? v`
+                <ha-alert alert-type="success" dismissable @alert-dismissed-clicked="${() => this._success = null}">
+                  ${this._success}
+                </ha-alert>
+              ` : ""}
+
+          <div class="form-container">
+            <ha-select
+              label="Network"
+              .value="${this._selectedNetwork}"
+              @selected="${this._handleNetworkChanged}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              ${(this._networks || []).map(
+      (s) => v`<md-select-option .value="${String(s.id)}">${s.name}</md-select-option>`
+    )}
+            </ha-select>
+
+            <ha-select
+              label="SSID"
+              .value="${this._selectedSsid}"
+              .disabled="${!this._selectedNetwork}"
+              @selected="${this._handleSsidChanged}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              ${(t || []).map(
+      (s) => v`<md-select-option .value="${String(s.number)}">${s.name} (SSID ${s.number})</md-select-option>`
+    )}
+            </ha-select>
+
+            <ha-select
+              label="Group Policy"
+              .value="${this._selectedPolicy}"
+              .disabled="${!this._selectedNetwork}"
+              @selected="${(s) => this._selectedPolicy = s.target.value}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              <md-select-option .value="">None (Default)</md-select-option>
+              ${(this._policies || []).map(
+      (s) => v`<md-select-option .value="${String(s.groupPolicyId)}">${s.name}</md-select-option>`
+    )}
+            </ha-select>
+
+            <ha-select
+              label="Duration"
+              .value="${this._duration}"
+              @selected="${(s) => this._duration = s.target.value}"
+              fixedMenuPosition
+              naturalMenuWidth
+            >
+              <md-select-option .value="${"30"}">30 Minutes</md-select-option>
+              <md-select-option .value="${"60"}">1 Hour</md-select-option>
+              <md-select-option .value="${"240"}">4 Hours</md-select-option>
+              <md-select-option .value="${"1440"}">24 Hours</md-select-option>
+              <md-select-option .value="${"10080"}">7 Days</md-select-option>
+            </ha-select>
+
+            <ha-textfield
+              label="Name (Optional)"
+              placeholder="e.g. Guest-John"
+              .value="${this._customName}"
+              @input="${(s) => this._customName = s.target.value}"
+            ></ha-textfield>
+
+            <ha-textfield
+              label="Passphrase (Optional)"
+              placeholder="Leave empty to auto-generate"
+              .value="${this._customPassphrase}"
+              @input="${(s) => this._customPassphrase = s.target.value}"
+            ></ha-textfield>
+
+            <ha-button
+              raised
+              .disabled="${this._creating || !this._selectedNetwork || !this._selectedSsid}"
+              @click="${this._handleCreate}"
+            >
+              ${this._creating ? "Creating..." : "Generate access key"}
+            </ha-button>
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+  _handleNetworkChanged(t) {
+    const e = t.target.value;
+    e !== this._selectedNetwork && (this._selectedNetwork = e, this._selectedSsid = "", this._selectedPolicy = "", this._fetchPolicies(e));
+  }
+  _handleSsidChanged(t) {
+    this._selectedSsid = t.target.value;
+  }
+  async _handleCreate() {
+    if (!(!this._selectedNetwork || !this._selectedSsid)) {
+      this._creating = !0, this._error = null, this._success = null;
+      try {
+        await this.hass.callService("meraki_ha", "create_guest_key", {
+          network_id: this._selectedNetwork,
+          ssid_number: parseInt(this._selectedSsid, 10),
+          duration_minutes: parseInt(this._duration, 10),
+          name: this._customName || void 0,
+          passphrase: this._customPassphrase || void 0,
+          group_policy_id: this._selectedPolicy || void 0
+        }), this._success = "Guest access key created successfully!", this._customName = "", this._customPassphrase = "";
+      } catch (t) {
+        this._error = `Failed to create guest key: ${t.message || t}`;
+      } finally {
+        this._creating = !1;
+      }
+    }
+  }
+};
+Y.styles = mt`
+    :host {
+      display: block;
+    }
+    .card-content {
+      padding: 16px;
+    }
+    .form-container {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    ha-select, ha-textfield, ha-button {
+      width: 100%;
+    }
+    ha-alert {
+      display: block;
+      margin-bottom: 16px;
+    }
+    .flex {
+      display: flex;
+    }
+    .justify-center {
+      justify-content: center;
+    }
+    .p-8 {
+      padding: 32px;
+    }
+  `;
+let d = Y;
+_([
+  $t({ attribute: !1 })
+], d.prototype, "hass");
+_([
+  $()
+], d.prototype, "_config");
+_([
+  $()
+], d.prototype, "_selectedNetwork");
+_([
+  $()
+], d.prototype, "_selectedSsid");
+_([
+  $()
+], d.prototype, "_selectedPolicy");
+_([
+  $()
+], d.prototype, "_duration");
+_([
+  $()
+], d.prototype, "_customName");
+_([
+  $()
+], d.prototype, "_customPassphrase");
+_([
+  $()
+], d.prototype, "_creating");
+_([
+  $()
+], d.prototype, "_error");
+_([
+  $()
+], d.prototype, "_success");
+_([
+  $()
+], d.prototype, "_networks");
+_([
+  $()
+], d.prototype, "_ssids");
+_([
+  $()
+], d.prototype, "_policies");
+_([
+  $()
+], d.prototype, "_loading");
+_([
+  $()
+], d.prototype, "_initDone");
+customElements.get("meraki-guest-access-card") || customElements.define("meraki-guest-access-card", d);
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "meraki-guest-access-card",
+  name: "Meraki Guest Access",
+  description: "Create and manage Meraki IPSK guest access keys.",
+  preview: !0
+});
+export {
+  d as MerakiGuestAccessCard
+};

--- a/frontend/src/meraki-card.ts
+++ b/frontend/src/meraki-card.ts
@@ -11,7 +11,6 @@ interface Config {
   config_entry_id?: string;
 }
 
-@customElement('meraki-guest-access-card')
 export class MerakiGuestAccessCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -31,6 +30,7 @@ export class MerakiGuestAccessCard extends LitElement {
   @state() private _ssids: SSID[] = [];
   @state() private _policies: any[] = [];
   @state() private _loading: boolean = true;
+  @state() private _initDone: boolean = false;
 
   public setConfig(config: Config): void {
     if (!config) {
@@ -53,7 +53,7 @@ export class MerakiGuestAccessCard extends LitElement {
   protected updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
     if (changedProperties.has('hass') && this.hass) {
-      if (!this._networks.length) {
+      if (!this._initDone && this.hass) {
         this._fetchInitialData();
       }
       if (this.hass.user?.name && !this._customName) {
@@ -63,6 +63,7 @@ export class MerakiGuestAccessCard extends LitElement {
   }
 
   private async _fetchInitialData() {
+    this._initDone = true;
     if (!this.hass) return;
     this._loading = true;
     try {
@@ -305,6 +306,11 @@ export class MerakiGuestAccessCard extends LitElement {
     }
   `;
 }
+
+if (!customElements.get("meraki-guest-access-card")) {
+  customElements.define("meraki-guest-access-card", MerakiGuestAccessCard);
+}
+
 // Register the card in the Home Assistant Lovelace UI picker
 (window as any).customCards = (window as any).customCards || [];
 (window as any).customCards.push({


### PR DESCRIPTION
This change addresses two critical issues in the `meraki-guest-access-card`:
1. **Infinite Request Loop:** The card was continuously calling `_fetchInitialData()` because it was checking `!this._networks.length` in the `updated()` method. Since the API might fail or return an empty list, this condition could remain true indefinitely. We now use a dedicated `_initDone` state property that is set to `true` as soon as the first fetch attempt begins.
2. **Registration Crash:** Using the `@customElement` decorator causes a `DOMException` if the script is loaded more than once (e.g., during development or if multiple card instances are present). We replaced it with a safe registration check using `customElements.get()`.

The changes were applied to `frontend/src/meraki-card.ts` and the card was rebuilt to update `custom_components/meraki_ha/www/meraki-card.js`.

Fixes #2259

---
*PR created automatically by Jules for task [14425673651643574163](https://jules.google.com/task/14425673651643574163) started by @brewmarsh*