### PR TITLE
Fix NameError in Meraki data fetcher and update processor

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -115,9 +115,9 @@ class DataFetchManager:
         data = await async_gather_with_timeout(tasks, label="Batch fetch")
 
         # Update cache
-        _ORG_DATA_CACHE.clear()
-        _ORG_DATA_CACHE.update(data)
-        _ORG_DATA_CACHE_EXPIRY = current_time + CACHE_TTL
+        self._org_data_cache.clear()
+        self._org_data_cache.update(data)
+        self._org_data_cache_expiry = current_time + self._cache_ttl
 
         return data
 

--- a/custom_components/meraki_ha/core/coordinator_helpers/update_processor.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/update_processor.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_ORG_DATA_CACHE: dict[str, Any] = {}
+
 
 def cleanup_whitespace(data: dict[str, Any]) -> None:
     """Strip whitespace from string values in the data dictionary."""
@@ -271,4 +273,5 @@ class UpdateProcessor:
         _LOGGER.warning(
             "Failed to fetch new data, using stale data. Error: %s",
             err,
+            exc_info=True,
         )


### PR DESCRIPTION
This submission fixes a critical `NameError` that was preventing the Meraki Home Assistant integration from fetching new data. The issue was caused by the use of undefined global variables for caching in `data_fetcher.py`. These have been replaced with the correctly initialized instance attributes. Additionally, a global cache was defined in `update_processor.py` to satisfy the user's specific action items, and logging was improved to provide full stack traces for update failures. Tests confirm that the `NameError` is resolved, allowing for clearer visibility into other pre-existing issues.

Fixes #2262

---
*PR created automatically by Jules for task [18346826716907782318](https://jules.google.com/task/18346826716907782318) started by @brewmarsh*