### PR TITLE
Fix TypeError in parse_appliance_data and add fallback logic

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -111,6 +111,9 @@ class DataFetchManager:
             tasks["switch_ports"] = self.client.run_with_semaphore(
                 self.client.organization.get_organization_switch_ports_statuses()
             )
+            tasks["appliance_uplink_statuses"] = self.client.run_with_semaphore(
+                self.client.appliance.get_organization_appliance_uplink_statuses()
+            )
 
         data = await async_gather_with_timeout(tasks, label="Batch fetch")
 
@@ -160,6 +163,8 @@ class DataFetchManager:
         self._distribute_networks(data, batch_data)
         self._distribute_devices(data, batch_data)
         self._parse_initial_statuses(data, batch_data)
+
+        data["appliance_uplink_statuses"] = batch_data.get("appliance_uplink_statuses")
 
         data["clients"] = []
         return data

--- a/custom_components/meraki_ha/core/parsers/appliance.py
+++ b/custom_components/meraki_ha/core/parsers/appliance.py
@@ -18,8 +18,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def parse_appliance_data(
     devices: list[MerakiDevice],
-    appliance_uplink_statuses: list[dict[str, Any]] | Exception | None,
-) -> None:
+    detail_data: dict[str, Any],
+    previous_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """
     Parse appliance-specific data and update device objects.
 
@@ -28,17 +29,26 @@ def parse_appliance_data(
 
     Args:
         devices: A list of device objects to update.
-        appliance_uplink_statuses: A list of appliance uplink statuses.
+        detail_data: Dictionary containing fetched data.
+        previous_data: Dictionary containing previous data for fallback.
+
+    Returns:
+        An empty dictionary.
     """
+    appliance_uplink_statuses = detail_data.get("appliance_uplink_statuses")
+
+    if appliance_uplink_statuses is None and previous_data:
+        appliance_uplink_statuses = previous_data.get("appliance_uplink_statuses")
+
     if isinstance(appliance_uplink_statuses, Exception):
         _LOGGER.warning(
             "Could not fetch appliance uplink statuses, data will be unavailable: %s",
             appliance_uplink_statuses,
         )
-        return
+        return {}
 
     if not appliance_uplink_statuses:
-        return
+        return {}
 
     _LOGGER.debug("Parsing appliance data for %s items", len(appliance_uplink_statuses))
 
@@ -56,6 +66,8 @@ def parse_appliance_data(
                 # will be enriched with performance metrics later
                 device.uplinks = uplinks
                 break
+
+    return {}
 
 
 def parse_appliance_ports(

--- a/tests/core/parsers/test_appliance_parser.py
+++ b/tests/core/parsers/test_appliance_parser.py
@@ -25,7 +25,7 @@ def test_parse_appliance_data_success(caplog):
         }
     ]
 
-    parse_appliance_data(devices, appliance_uplink_statuses)
+    parse_appliance_data(devices, {"appliance_uplink_statuses": appliance_uplink_statuses})
 
     # Verify the MX75 was updated
     assert devices[0].serial == "MX75-1"
@@ -48,7 +48,7 @@ def test_parse_appliance_data_no_serial(caplog):
     devices = [MerakiDevice(serial="MX75-1")]
     appliance_uplink_statuses = [{"uplinks": []}]  # No serial
 
-    parse_appliance_data(devices, appliance_uplink_statuses)
+    parse_appliance_data(devices, {"appliance_uplink_statuses": appliance_uplink_statuses})
 
     assert len(devices[0].appliance_uplink_statuses) == 0
     assert "Parsing appliance data for 1 items" in caplog.text
@@ -64,7 +64,7 @@ def test_parse_appliance_data_no_match(caplog):
         {"serial": "MX75-1", "uplinks": [{"interface": "wan1"}]}
     ]
 
-    parse_appliance_data(devices, appliance_uplink_statuses)
+    parse_appliance_data(devices, {"appliance_uplink_statuses": appliance_uplink_statuses})
 
     assert len(devices[0].appliance_uplink_statuses) == 0
     assert "Parsing appliance data for 1 items" in caplog.text
@@ -76,7 +76,29 @@ def test_parse_appliance_data_exception(caplog):
     devices = [MerakiDevice(serial="MX75-1")]
     appliance_uplink_statuses = Exception("API Error")
 
-    parse_appliance_data(devices, appliance_uplink_statuses)
+    parse_appliance_data(devices, {"appliance_uplink_statuses": appliance_uplink_statuses})
 
     assert len(devices[0].appliance_uplink_statuses) == 0
     assert "Could not fetch appliance uplink statuses" in caplog.text
+
+
+def test_parse_appliance_data_fallback(caplog):
+    """Test parsing with fallback to previous_data."""
+    caplog.set_level(logging.DEBUG)
+
+    devices = [MerakiDevice(serial="MX75-1")]
+    previous_data = {
+        "appliance_uplink_statuses": [
+            {
+                "serial": "MX75-1",
+                "uplinks": [{"interface": "wan1", "status": "active"}],
+            }
+        ]
+    }
+
+    # Pass empty detail_data
+    parse_appliance_data(devices, {}, previous_data)
+
+    assert len(devices[0].appliance_uplink_statuses) == 1
+    assert devices[0].appliance_uplink_statuses[0]["interface"] == "wan1"
+    assert "Matched uplink data for MX75-1" in caplog.text


### PR DESCRIPTION
This PR fixes a TypeError where `parse_appliance_data` was called with 3 arguments but only accepted 2. It also implements the requested state merging/fallback logic for appliance uplink statuses and ensures the data is actually fetched during organization-wide updates.

Fixes #2264

---
*PR created automatically by Jules for task [15363257549979151415](https://jules.google.com/task/15363257549979151415) started by @brewmarsh*