### PR TITLE
Handle Meraki API Errors gracefully in Camera Snapshots

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -170,18 +170,18 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
             _LOGGER.debug("Skipping snapshot for offline camera: %s", self.name)
             return None
 
-        url = await self._camera_service.generate_snapshot(self._device_serial)
-        if not url:
-            _LOGGER.debug("Failed to get snapshot URL for %s", self.name)
-            return None
-
         try:
+            url = await self._camera_service.generate_snapshot(self._device_serial)
+            if not url:
+                _LOGGER.debug("Failed to get snapshot URL for %s", self.name)
+                return None
+
             session = async_get_clientsession(self.hass)
             async with session.get(url) as response:
                 response.raise_for_status()
                 return await response.read()
-        except aiohttp.ClientError as e:
-            _LOGGER.error("Error fetching snapshot for %s: %s", self.name, e)
+        except Exception as err:
+            _LOGGER.warning("Failed to fetch camera snapshot: %s", err)
             return None
 
     @property

--- a/custom_components/meraki_ha/core/repositories/camera_repository.py
+++ b/custom_components/meraki_ha/core/repositories/camera_repository.py
@@ -139,7 +139,7 @@ class CameraRepository:
             )
             return snapshot_data.get("url")
         except Exception as e:
-            _LOGGER.error("Error generating snapshot for %s: %s", serial, e)
+            _LOGGER.warning("Error generating snapshot for %s: %s", serial, e)
             return None
 
     async def set_rtsp_stream_enabled(self, serial: str, enabled: bool) -> None:

--- a/tests/camera/test_snapshot_error_handling.py
+++ b/tests/camera/test_snapshot_error_handling.py
@@ -1,0 +1,71 @@
+"""Tests for the Meraki camera snapshot error handling."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from homeassistant.core import HomeAssistant
+from meraki.exceptions import APIError
+
+from custom_components.meraki_ha.camera import MerakiRTSPStreamCamera
+from tests.const import MOCK_CAMERA_DEVICE
+
+
+@pytest.fixture
+def mock_camera(
+    mock_coordinator: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_camera_service: AsyncMock,
+) -> MerakiRTSPStreamCamera:
+    """Create a mock MerakiRTSPStreamCamera entity."""
+    mock_coordinator.get_device.return_value = MOCK_CAMERA_DEVICE
+    return MerakiRTSPStreamCamera(
+        coordinator=mock_coordinator,
+        device=MOCK_CAMERA_DEVICE,
+        camera_service=mock_camera_service,
+        config_entry=mock_config_entry,
+    )
+
+
+@pytest.mark.asyncio
+async def test_camera_image_api_error(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+    mock_camera_service: AsyncMock,
+) -> None:
+    """Test that camera image returns None and logs warning on API error."""
+    mock_camera.hass = hass
+
+    # Mock generate_snapshot to raise an APIError (simulating Meraki 500)
+    mock_camera_service.generate_snapshot.side_effect = Exception("Meraki API Error 500")
+
+    with patch("custom_components.meraki_ha.camera._LOGGER") as mock_logger:
+        image = await mock_camera.async_camera_image()
+
+        assert image is None
+        mock_logger.warning.assert_called_once()
+        assert "Failed to fetch camera snapshot" in mock_logger.warning.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_camera_image_download_error(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+    mock_camera_service: AsyncMock,
+) -> None:
+    """Test that camera image returns None and logs warning on download error."""
+    mock_camera.hass = hass
+    mock_camera_service.generate_snapshot.return_value = "https://meraki.com/snapshot.jpg"
+
+    with patch(
+        "custom_components.meraki_ha.camera.async_get_clientsession",
+    ) as mock_session:
+        # Mock session.get to raise a ClientError
+        mock_session.return_value.get.side_effect = aiohttp.ClientError("Download failed")
+
+        with patch("custom_components.meraki_ha.camera._LOGGER") as mock_logger:
+            image = await mock_camera.async_camera_image()
+
+            assert image is None
+            mock_logger.warning.assert_called_once()
+            assert "Failed to fetch camera snapshot" in mock_logger.warning.call_args[0][0]


### PR DESCRIPTION
This PR addresses an issue where the Meraki API occasionally returns 500 HTML errors when generating camera snapshots, causing the Home Assistant frontend proxy to crash. 

The fix involves:
1. Wrapping the snapshot generation and image downloading logic in `custom_components/meraki_ha/camera.py` within a `try...except Exception` block.
2. Logging failures as `WARNING` instead of `ERROR` to reduce log noise for expected intermittent API issues.
3. Ensuring the method returns `None` upon failure, which informs Home Assistant that the image is temporarily unavailable, preventing the 500 proxy error.
4. Updating `custom_components/meraki_ha/core/repositories/camera_repository.py` to also use `WARNING` level for snapshot generation errors.
5. Adding comprehensive unit tests in `tests/camera/test_snapshot_error_handling.py` to simulate API and network failures.

Fixes #2269

---
*PR created automatically by Jules for task [14963675316339690772](https://jules.google.com/task/14963675316339690772) started by @brewmarsh*