### PR TITLE
Fix WebSocket Schema Mismatch and Standardize to snake_case

### DIFF
--- a/custom_components/meraki_ha/api/commands_guest.py
+++ b/custom_components/meraki_ha/api/commands_guest.py
@@ -34,8 +34,8 @@ def async_register_guest_commands(hass: HomeAssistant) -> None:
         vol.Schema(
             {
                 vol.Required("type"): WS_CMD_GET_GUEST_KEYS,
-                vol.Optional("configEntryId"): str,
-                vol.Optional("networkId"): str,
+                vol.Optional("config_entry_id"): str,
+                vol.Optional("network_id"): str,
             },
             extra=vol.ALLOW_EXTRA,
         ),
@@ -47,13 +47,13 @@ def async_register_guest_commands(hass: HomeAssistant) -> None:
         vol.Schema(
             {
                 vol.Required("type"): WS_CMD_CREATE_GUEST_KEY,
-                vol.Required("configEntryId"): str,
-                vol.Required("networkId"): str,
-                vol.Required("ssidNumber"): str,
-                vol.Required("durationMinutes"): int,
+                vol.Required("config_entry_id"): str,
+                vol.Required("network_id"): str,
+                vol.Required("ssid_number"): str,
+                vol.Required("duration_minutes"): int,
                 vol.Optional("name"): str,
                 vol.Optional("passphrase"): str,
-                vol.Optional("groupPolicyId"): str,
+                vol.Optional("group_policy_id"): str,
             },
             extra=vol.ALLOW_EXTRA,
         ),
@@ -65,7 +65,7 @@ def async_register_guest_commands(hass: HomeAssistant) -> None:
         vol.Schema(
             {
                 vol.Required("type"): WS_CMD_REVOKE_GUEST_KEY,
-                vol.Required("identityPskId"): str,
+                vol.Required("identity_psk_id"): str,
             },
             extra=vol.ALLOW_EXTRA,
         ),
@@ -80,8 +80,8 @@ async def ws_get_guest_keys(
     msg: dict[str, Any],
 ) -> None:
     """Handle IPSK/get command."""
-    config_entry_id = msg.get("configEntryId")
-    network_id = msg.get("networkId")
+    config_entry_id = msg.get("config_entry_id")
+    network_id = msg.get("network_id")
 
     if "ipsk_manager" not in hass.data.get(DOMAIN, {}):
         connection.send_error(
@@ -112,13 +112,13 @@ async def ws_create_guest_key(
 
     try:
         key = await manager.create_guest_key(
-            config_entry_id=msg["configEntryId"],
-            network_id=msg["networkId"],
-            ssid_number=msg["ssidNumber"],
-            duration_minutes=msg["durationMinutes"],
+            config_entry_id=msg["config_entry_id"],
+            network_id=msg["network_id"],
+            ssid_number=msg["ssid_number"],
+            duration_minutes=msg["duration_minutes"],
             name=msg.get("name", "Guest User"),
             passphrase=msg.get("passphrase"),
-            group_policy_id=msg.get("groupPolicyId"),
+            group_policy_id=msg.get("group_policy_id"),
         )
         connection.send_result(msg["id"], to_serializable(key))
     except Exception as err:  # pylint: disable=broad-except
@@ -134,7 +134,7 @@ async def ws_revoke_guest_key(
     msg: dict[str, Any],
 ) -> None:
     """Handle IPSK/revoke command."""
-    identity_psk_id = msg["identityPskId"]
+    identity_psk_id = msg["identity_psk_id"]
 
     if "ipsk_manager" not in hass.data.get(DOMAIN, {}):
         connection.send_error(

--- a/custom_components/meraki_ha/api/commands_network.py
+++ b/custom_components/meraki_ha/api/commands_network.py
@@ -31,9 +31,7 @@ def async_register_network_commands(hass: HomeAssistant) -> None:
             {
                 vol.Required("type"): WS_CMD_GET_NETWORK_EVENTS,
                 vol.Required("config_entry_id"): str,
-                # Compatibility for both snack_case and camelCase
                 vol.Optional("network_id"): str,
-                vol.Optional("networkId"): str,
                 vol.Optional("per_page"): int,
                 vol.Optional("product_type"): str,
             },
@@ -47,8 +45,8 @@ def async_register_network_commands(hass: HomeAssistant) -> None:
         vol.Schema(
             {
                 vol.Required("type"): WS_CMD_TIMED_ACCESS_GET_POLICIES,
-                vol.Required("configEntryId"): str,
-                vol.Required("networkId"): str,
+                vol.Required("config_entry_id"): str,
+                vol.Required("network_id"): str,
             },
             extra=vol.ALLOW_EXTRA,
         ),
@@ -64,7 +62,7 @@ async def ws_get_network_events(
 ) -> None:
     """Handle get_network_events command."""
     config_entry_id = msg["config_entry_id"]
-    network_id = msg.get("network_id") or msg.get("networkId")
+    network_id = msg.get("network_id")
 
     if not network_id:
         connection.send_error(msg["id"], "invalid_payload", "Network ID is required")
@@ -94,8 +92,8 @@ async def ws_timed_access_get_policies(
     msg: dict[str, Any],
 ) -> None:
     """Handle timed_access/get_policies command."""
-    config_entry_id = msg["configEntryId"]
-    network_id = msg["networkId"]
+    config_entry_id = msg["config_entry_id"]
+    network_id = msg["network_id"]
 
     client: MerakiAPIClient | None = get_config_entry_data(
         hass, connection, msg, config_entry_id, DATA_CLIENT

--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -675,7 +675,7 @@ const Y = class Y extends M {
         const o = await ht(this.hass, {
           type: W.TIMED_ACCESS_GET_POLICIES,
           config_entry_id: s,
-          networkId: t
+          network_id: t
         });
         this._policies = Array.isArray(o) ? o : (o == null ? void 0 : o.policies) || [];
       } catch (s) {

--- a/frontend/src/meraki-card.ts
+++ b/frontend/src/meraki-card.ts
@@ -115,7 +115,7 @@ export class MerakiGuestAccessCard extends LitElement {
       const policies = await safeCallWS<any[]>(this.hass, {
         type: WsCommand.TIMED_ACCESS_GET_POLICIES,
         config_entry_id: entryId,
-        networkId: networkId,
+        network_id: networkId,
       });
       this._policies = Array.isArray(policies) ? policies : (policies as any)?.policies || [];
     } catch (err: any) {

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -235,7 +235,7 @@ async def test_ipsk_get_keys(
         {
             "id": 1,
             "type": "meraki_ha/ipsk/get",
-            "configEntryId": "test_entry",
+            "config_entry_id": "test_entry",
         }
     )
 
@@ -265,8 +265,8 @@ async def test_timed_access_get_policies(
         {
             "id": 1,
             "type": "meraki_ha/timed_access/get_policies",
-            "configEntryId": entry_id,
-            "networkId": "N_123",
+            "config_entry_id": entry_id,
+            "network_id": "N_123",
         }
     )
 
@@ -292,10 +292,10 @@ async def test_ipsk_create(
         {
             "id": 1,
             "type": "meraki_ha/ipsk/create",
-            "configEntryId": "test_entry",
-            "networkId": "N_123",
-            "ssidNumber": "0",
-            "durationMinutes": 60,
+            "config_entry_id": "test_entry",
+            "network_id": "N_123",
+            "ssid_number": "0",
+            "duration_minutes": 60,
             "name": "Guest",
         }
     )
@@ -330,7 +330,7 @@ async def test_ipsk_revoke(
         {
             "id": 1,
             "type": "meraki_ha/ipsk/revoke",
-            "identityPskId": "psk1",
+            "identity_psk_id": "psk1",
         }
     )
 


### PR DESCRIPTION
This change resolves a mismatch between the frontend and backend WebSocket API where the backend was enforcing camelCase keys while the frontend was sending standard Home Assistant snake_case keys. The fix standardizes all Meraki WebSocket command parameters to snake_case, aligning with Home Assistant core conventions. Specifically, `configEntryId`, `networkId`, `ssidNumber`, `durationMinutes`, `groupPolicyId`, and `identityPskId` were renamed. Both the backend handlers and the frontend TypeScript source were updated, and the custom card was rebuilt. Tests were also updated to ensure continuous validation of the new schema.

Fixes #2268

---
*PR created automatically by Jules for task [4932098028994240036](https://jules.google.com/task/4932098028994240036) started by @brewmarsh*