### PR TITLE
Demote Meraki API Errors in Low-Level Client

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -150,21 +150,18 @@ class MerakiAPIClient:
                     if "VLANs" in error_msg:
                         raise MerakiVlansDisabledError(error_msg) from e
                     raise MerakiInformationalError(error_msg) from e
-                _LOGGER.error(
-                    "Meraki API Error encountered: %s",
-                    e,
-                    exc_info=True,
-                )
+                _LOGGER.warning("Meraki API Error encountered: %s", e)
+                _LOGGER.debug("Meraki API Error stack trace", exc_info=True)
                 raise ApiClientCommunicationError(
                     f"Error communicating with Meraki API: {e}"
                 ) from e
             except Exception as e:
-                _LOGGER.error(
+                _LOGGER.warning(
                     "An unexpected error occurred during API call: %s. Type: %s",
                     e,
                     type(e).__name__,
-                    exc_info=True,
                 )
+                _LOGGER.debug("Unexpected API error stack trace", exc_info=True)
                 if "JSON" in str(e):
                     raise ApiClientCommunicationError(
                         f"Invalid JSON response from Meraki API. "

--- a/custom_components/meraki_ha/core/utils/api/handlers.py
+++ b/custom_components/meraki_ha/core/utils/api/handlers.py
@@ -73,7 +73,7 @@ async def handle_rate_limit(
 ) -> None:
     """Handle rate limiting by sleeping and raising RetryRequest."""
     if attempt >= max_retries:
-        _LOGGER.error(
+        _LOGGER.warning(
             "Meraki API rate limit reached after %s retries: %s",
             max_retries,
             err,
@@ -106,7 +106,7 @@ async def handle_rate_limit(
 
 def handle_meraki_api_error(err: APIError) -> None:
     """Handle standard Meraki API errors."""
-    _LOGGER.error("Meraki API error: %s", err)
+    _LOGGER.warning("Meraki API error: %s", err)
     if is_auth_error(err):
         raise MerakiAuthenticationError(f"Authentication failed: {err}") from err
     if is_device_error(err):
@@ -121,7 +121,7 @@ def handle_unexpected_error(err: Exception) -> None:
     """Handle unexpected exceptions."""
     if isinstance(err, UpdateFailed):
         raise err
-    _LOGGER.error("Unexpected error: %s", err)
+    _LOGGER.warning("Unexpected error: %s", err)
     raise MerakiConnectionError(f"Unexpected error: {err}") from err
 
 


### PR DESCRIPTION
This change demotes Meraki API-related logging from ERROR to WARNING in the low-level client and utility handlers. It also ensures that large stack traces are only logged at the DEBUG level. This prevents Home Assistant logs from being cluttered with transient cloud errors while still allowing for detailed troubleshooting when DEBUG logging is enabled.

Fixes #2272

---
*PR created automatically by Jules for task [9569845946178505986](https://jules.google.com/task/9569845946178505986) started by @brewmarsh*