### PR TITLE
Enable Meraki Camera Live Streaming

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -67,7 +67,6 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
     _attr_brand = "Cisco Meraki"
     _attr_has_entity_name = True
-    _attr_supported_features = CameraEntityFeature.STREAM
 
     coordinator: MerakiCameraCoordinator
 
@@ -185,17 +184,20 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
             return None
 
     @property
+    def supported_features(self) -> CameraEntityFeature:
+        """Return supported features."""
+        return CameraEntityFeature.STREAM
+
+    @property
     def is_streaming(self) -> bool:
         """Return True if the camera is streaming."""
         if self.device_data.rtsp_url is None:
             return False
         return True
 
-    async def stream_source(self) -> str | None:
+    async def async_stream_source(self) -> str | None:
         """Return the source of the stream."""
-        if self.device_data.rtsp_url is None:
-            return None
-        return self.device_data.rtsp_url
+        return await self._camera_service.get_video_stream_url(self._device_serial)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/camera/test_camera.py
+++ b/tests/camera/test_camera.py
@@ -26,14 +26,20 @@ def mock_camera(
     )
 
 
-async def test_camera_properties(mock_camera):
+async def test_camera_properties(mock_camera, mock_camera_service):
     """Test the properties of the camera entity."""
     assert mock_camera.name is None
     assert (
         mock_camera.unique_id == f"{MOCK_CAMERA_DEVICE.serial}_merakirtspstreamcamera"
     )
     assert mock_camera.is_streaming is True
-    assert await mock_camera.stream_source() == MOCK_CAMERA_DEVICE.rtsp_url
+
+    # Test async_stream_source calls the service
+    mock_camera_service.get_video_stream_url.return_value = "rtsp://test_service_url"
+    assert await mock_camera.async_stream_source() == "rtsp://test_service_url"
+    mock_camera_service.get_video_stream_url.assert_called_once_with(
+        MOCK_CAMERA_DEVICE.serial
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This change enables live video streaming for Meraki camera entities by adding the `CameraEntityFeature.STREAM` feature flag and implementing the `async_stream_source` method to fetch the stream URL from the Meraki API. Previously, clicking a camera entity in the UI threw an error because the stream service was not supported.

Fixes #2276

---
*PR created automatically by Jules for task [4136006115901400665](https://jules.google.com/task/4136006115901400665) started by @brewmarsh*