### PR TITLE
Handle Missing LAN IPs on MX Appliances

### DIFF
--- a/custom_components/meraki_ha/sensor/device/network_settings.py
+++ b/custom_components/meraki_ha/sensor/device/network_settings.py
@@ -93,7 +93,13 @@ class MerakiDeviceIPSensor(MerakiDeviceUplinkBaseSensor):
         """Update the sensor state."""
         device = self.coordinator.get_device(self._device_serial)
         if self._interface == "lanIp" and device:
-            self._attr_native_value = device.lan_ip
+            lan_ip = device.lan_ip
+            if (not lan_ip) and device.model and (
+                device.model.startswith("MX") or device.model.startswith("Z3")
+            ):
+                self._attr_native_value = "Multiple (VLANs)"
+            else:
+                self._attr_native_value = lan_ip
             return
         if self._interface == "publicIp" and device:
             self._attr_native_value = device.public_ip

--- a/tests/sensor/device/test_network_settings.py
+++ b/tests/sensor/device/test_network_settings.py
@@ -1,0 +1,103 @@
+"""Tests for the Meraki Network Settings Sensors."""
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.sensor.device.network_settings import (
+    MerakiDeviceIPSensor,
+)
+from custom_components.meraki_ha.types import MerakiDevice
+
+
+@pytest.fixture
+def mock_device_coordinator() -> MagicMock:
+    """Fixture for a mocked MerakiDeviceCoordinator."""
+    coordinator = MagicMock()
+
+    # Standard Wireless device with LAN IP
+    device1: MerakiDevice = MerakiDevice(
+        serial="Q2XX-XXXX-XXXX",
+        name="Device 1",
+        model="MR56",
+        mac="00:11:22:33:44:55",
+        status="online",
+        product_type="wireless",
+        lan_ip="192.168.1.1",
+    )
+
+    # MX Security Appliance with missing LAN IP
+    device2: MerakiDevice = MerakiDevice(
+        serial="Q2YY-YYYY-YYYY",
+        name="Device 2",
+        model="MX68",
+        mac="00:11:22:33:44:66",
+        status="online",
+        product_type="appliance",
+        lan_ip=None,
+    )
+
+    # Z3 Security Appliance with empty LAN IP
+    device3: MerakiDevice = MerakiDevice(
+        serial="Q2ZZ-ZZZZ-ZZZZ",
+        name="Device 3",
+        model="Z3",
+        mac="00:11:22:33:44:77",
+        status="online",
+        product_type="appliance",
+        lan_ip="",
+    )
+
+    # Standard Switch with missing LAN IP
+    device4: MerakiDevice = MerakiDevice(
+        serial="Q2WW-WWWW-WWWW",
+        name="Device 4",
+        model="MS120-8LP",
+        mac="00:11:22:33:44:88",
+        status="online",
+        product_type="switch",
+        lan_ip=None,
+    )
+
+    coordinator.data: dict[str, list[MerakiDevice]] = {"devices": [device1, device2, device3, device4]}
+
+    # Setup get_device return values
+    def get_device(serial: str) -> MerakiDevice | None:
+        for d in coordinator.data["devices"]:
+            if d.serial == serial:
+                return d
+        return None
+
+    coordinator.get_device.side_effect: Callable[[str], MerakiDevice | None] = (
+        get_device
+    )
+    coordinator.last_update_success = True
+
+    return coordinator
+
+
+def test_lan_ip_sensor_logic(mock_device_coordinator: MagicMock) -> None:
+    """Test the LAN IP sensor logic for different devices."""
+    config_entry: MagicMock = MagicMock()
+    config_entry.options = {}
+
+    # 1. MR56 - should show its LAN IP
+    device1 = mock_device_coordinator.data["devices"][0]
+    sensor1 = MerakiDeviceIPSensor(mock_device_coordinator, device1, config_entry, "lanIp")
+    assert sensor1.native_value == "192.168.1.1"
+
+    # 2. MX68 with None LAN IP - should show "Multiple (VLANs)" after fix
+    device2 = mock_device_coordinator.data["devices"][1]
+    sensor2 = MerakiDeviceIPSensor(mock_device_coordinator, device2, config_entry, "lanIp")
+    assert sensor2.native_value == "Multiple (VLANs)"
+
+    # 3. Z3 with empty LAN IP - should show "Multiple (VLANs)" after fix
+    device3 = mock_device_coordinator.data["devices"][2]
+    sensor3 = MerakiDeviceIPSensor(mock_device_coordinator, device3, config_entry, "lanIp")
+    assert sensor3.native_value == "Multiple (VLANs)"
+
+    # 4. MS120 with None LAN IP - should show None (Unknown)
+    device4 = mock_device_coordinator.data["devices"][3]
+    sensor4 = MerakiDeviceIPSensor(mock_device_coordinator, device4, config_entry, "lanIp")
+    assert sensor4.native_value is None


### PR DESCRIPTION
Updated `MerakiDeviceIPSensor` in `custom_components/meraki_ha/sensor/device/network_settings.py` to handle missing LAN IPs for MX and Z3 security appliances. When the `lan_ip` is missing or empty for these models, the sensor state is now set to "Multiple (VLANs)". Added a new test file `tests/sensor/device/test_network_settings.py` to verify this behavior and ensure no regressions for other device types.

Fixes #2274

---
*PR created automatically by Jules for task [12020077784530097259](https://jules.google.com/task/12020077784530097259) started by @brewmarsh*