### PR TITLE
fix: correct assertion in test_naming_standardization for sensor prefix

### DIFF
--- a/tests/test_naming_standardization.py
+++ b/tests/test_naming_standardization.py
@@ -26,4 +26,4 @@ def test_format_device_name():
         "model": "MT14",
         "serial": "Q2XX-XXXX-XXXX",
     }
-    assert format_device_name(device_meraki_name, config) == "Meraki Kitchen"
+    assert format_device_name(device_meraki_name, config) == "[Sensor] Meraki Kitchen"


### PR DESCRIPTION
Updated `test_format_device_name` in `tests/test_naming_standardization.py` to correctly expect the `[Sensor]` prefix on `MT14` devices, even if their name begins with `Meraki `. This brings the test in line with recent modifications to `format_device_name` that enforce `[Sensor] ` prefixes for MT series devices regardless of the `Meraki` keyword.

---
*PR created automatically by Jules for task [3702600657171872545](https://jules.google.com/task/3702600657171872545) started by @brewmarsh*