### PR TITLE
fix: update naming standardization test for MT sensor prefix

### DIFF
--- a/tests/test_naming_standardization.py
+++ b/tests/test_naming_standardization.py
@@ -26,4 +26,4 @@ def test_format_device_name():
         "model": "MT14",
         "serial": "Q2XX-XXXX-XXXX",
     }
-    assert format_device_name(device_meraki_name, config) == "Meraki Kitchen"
+    assert format_device_name(device_meraki_name, config) == "[Sensor] Meraki Kitchen"


### PR DESCRIPTION
Updated the assertion in `test_format_device_name` to correctly expect the `[Sensor] ` prefix for MT series devices (e.g., MT14). This aligns the test with the recent refactoring in `naming_utils.py` that enforces this prefix for environmental sensors.

---
*PR created automatically by Jules for task [5775382173850114521](https://jules.google.com/task/5775382173850114521) started by @brewmarsh*