### PR TITLE
Relocate SSID Entities to Network Device

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/update_processor.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/update_processor.py
@@ -16,7 +16,6 @@ from ...const import DOMAIN
 from ...const_conf import CONF_IGNORED_NETWORKS, DEFAULT_IGNORED_NETWORKS
 from ..helpers.device_registry import (
     async_ensure_network_devices_exist,
-    async_ensure_ssid_devices_exist,
 )
 from ..managers import PollingManager
 from ..models.device import MerakiDevice
@@ -160,8 +159,6 @@ class UpdateProcessor:
         async_ensure_network_devices_exist(
             self.hass, self.config_entry, data.get("networks", [])
         )
-        if "ssids" in data:
-            async_ensure_ssid_devices_exist(self.hass, self.config_entry, data["ssids"])
 
         # Apply filters
         ignored_ids = self.config_entry.options.get(

--- a/custom_components/meraki_ha/core/helpers/device_registry.py
+++ b/custom_components/meraki_ha/core/helpers/device_registry.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.helpers import device_registry as dr
 
 from ...const import DOMAIN
-from ...core.const import get_ssid_identifier
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,58 +61,3 @@ def async_ensure_network_devices_exist(
         )
 
 
-def async_ensure_ssid_devices_exist(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    ssids: list[dict[str, Any]],
-) -> None:
-    """Pre-register SSID devices in the device registry.
-
-    Args:
-    ----
-        hass: The Home Assistant instance.
-        config_entry: The config entry.
-        ssids: The list of SSIDs to ensure exist.
-
-    """
-    device_registry = dr.async_get(hass)
-
-    for ssid in ssids:
-        network_id = ssid.get("networkId")
-        ssid_number = ssid.get("number")
-        ssid_name = ssid.get("name")
-
-        if not network_id or ssid_number is None:
-            continue
-
-        # Canonical Identifier
-        identifier_str = get_ssid_identifier(network_id, ssid_number)
-        identifier = (DOMAIN, identifier_str)
-
-        # Legacy ID Check (Cleanup Warning)
-        # Check if any device has the old ":ssid:" format for this SSID
-        legacy_identifier = f"{network_id}:ssid:{ssid_number}"
-        for device in dr.async_entries_for_config_entry(
-            device_registry, config_entry.entry_id
-        ):
-            if (DOMAIN, legacy_identifier) in device.identifiers:
-                _LOGGER.warning(
-                    "Legacy SSID device detected for SSID %s (ID: %s). "
-                    "Please consider removing it to avoid duplicates.",
-                    ssid_name,
-                    legacy_identifier,
-                )
-                break
-
-        # Canonical Name Policy: [SSID] Prefix
-        if ssid_name and not ssid_name.startswith("[SSID] "):
-            ssid_name = f"[SSID] {ssid_name}"
-
-        device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
-            identifiers={identifier},
-            name=ssid_name,
-            manufacturer="Cisco Meraki",
-            model="Wireless SSID",
-            via_device=(DOMAIN, f"network_{network_id}"),
-        )

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from ..const import DOMAIN
 from ..coordinators import MerakiMainCoordinator
 from ..core.api.client import MerakiAPIClient
 from ..helpers.device_info_helpers import resolve_device_info
@@ -47,7 +48,9 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
             icon="mdi:wifi-cog",
         )
 
-        self._attr_name = None
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
+        self._attr_name = f"{network_name} SSID {self._ssid_name} RF profile"
         self._attr_unique_id = f"{self._network_id}ssid{self._ssid_number}_rf_profile"
         self._attr_options: list[str] = []
         self._update_internal_state()
@@ -56,10 +59,9 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return device information to link this entity to the SSID 'device'."""
-        return resolve_device_info(
-            entity_data=self._ssid_data,
-            config_entry=self._config_entry,
+        """Return device information to link this entity to the Network device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"network_{self._network_id}")},
         )
 
     @property

--- a/custom_components/meraki_ha/sensor/network/base.py
+++ b/custom_components/meraki_ha/sensor/network/base.py
@@ -6,7 +6,9 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 
+from ...const import DOMAIN
 from ...coordinators import MerakiSwitchCoordinator
 from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
@@ -36,18 +38,19 @@ class MerakiSSIDBaseSensor(MerakiEntity, SensorEntity):
 
         # Unique ID is now handled by the dynamic @property method below
         self._attr_has_entity_name = True
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
         ssid_name = ssid_data.get("name", f"SSID {self._ssid_number}")
         if (
             hasattr(self, "entity_description")
             and self.entity_description
             and self.entity_description.name
         ):
-            self._attr_name = f"{ssid_name} {self.entity_description.name}"
+            self._attr_name = f"{network_name} SSID {ssid_name} {self.entity_description.name}"
 
-        # SSID entities are logical children of the "Virtual SSID Device"
-        self._attr_device_info = resolve_device_info(
-            entity_data=self._ssid_data_at_init,
-            config_entry=self._config_entry,
+        # SSID entities are logical children of the "Virtual SSID Device" (Network Device)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"network_{self._network_id}")},
         )
 
     def _get_current_ssid_data(self) -> dict[str, Any] | None:

--- a/custom_components/meraki_ha/sensor/network/ssid_availability.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_availability.py
@@ -41,7 +41,7 @@ class MerakiSSIDAvailabilitySensor(MerakiSSIDBaseSensor):
         """
         super().__init__(coordinator, config_entry, ssid_data, "enabled")
         self._attr_unique_id = (
-            f"{ssid_data['serial']}_MerakiSSIDAvailabilitySensor_"
-            f"{self.entity_description.key}"
+            f"{ssid_data.get('networkId')}_{ssid_data.get('number')}_"
+            f"MerakiSSIDAvailabilitySensor_{self.entity_description.key}"
         )
         self._attr_native_value = self._ssid_data_at_init.get("enabled")

--- a/custom_components/meraki_ha/sensor/network/ssid_details.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_details.py
@@ -9,8 +9,10 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfDataRate
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 
+from ...const import DOMAIN
 from ...coordinators import MerakiMainCoordinator
 from ...entity import MerakiEntity
 from ...helpers.device_info_helpers import resolve_device_info
@@ -38,14 +40,14 @@ class MerakiSSIDDetailSensor(MerakiEntity, SensorEntity):
         self._network_id = ssid_data.get("networkId")
         self._ssid_number = ssid_data.get("number")
         self._rf_profile = rf_profile
-        self._attr_device_info = resolve_device_info(
-            entity_data={"networkId": self._network_id},
-            config_entry=self._config_entry,
-            ssid_data=self._ssid_data,
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"network_{self._network_id}")},
         )
 
         # Rule 1: Use explicit naming to include SSID name for unique identification
-        self._attr_name = f"{ssid_data['name']} {self.entity_description.name}"
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
+        self._attr_name = f"{network_name} SSID {ssid_data['name']} {self.entity_description.name}"
 
         # Rule 2: Robust unique_id format (serial_classname_key)
         # For SSID-bound entities, we use network_id and ssid_number as the

--- a/custom_components/meraki_ha/sensor/network/ssid_per_ssid_bandwidth_limit.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_per_ssid_bandwidth_limit.py
@@ -47,5 +47,7 @@ class MerakiSSIDPerSsidBandwidthLimitSensor(MerakiSSIDBaseSensor):
         self._attr_native_value = self._ssid_data_at_init.get(attribute)
 
         # Robust unique_id format: serial_classname_key
-        serial = ssid_data.get("serial") or getattr(coordinator, "serial", "unknown")
-        self._attr_unique_id = f"{serial}_{self.__class__.__name__}_{attribute}"
+        # For SSID entities, we use a combination of networkId and SSID number
+        serial = ssid_data.get("networkId", "unknown")
+        number = ssid_data.get("number", "unknown")
+        self._attr_unique_id = f"{serial}_{number}_{self.__class__.__name__}_{attribute}"

--- a/custom_components/meraki_ha/switch/adult_content_filtering.py
+++ b/custom_components/meraki_ha/switch/adult_content_filtering.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 
+from ..const import DOMAIN
 from ..coordinators import MerakiSwitchCoordinator
 from ..entity import MerakiEntity
 from ..helpers.device_info_helpers import resolve_device_info
@@ -32,9 +33,11 @@ class MerakiAdultContentFilteringSwitch(MerakiEntity, SwitchEntity):
         self._ssid = ssid
         self._client = coordinator.api
 
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
         self.entity_description = SwitchEntityDescription(
             key="adult_content_filtering",
-            name=f"Adult Content Filtering on {ssid['name']}",
+            name=f"{network_name} SSID {ssid['name']} Adult Content Filtering",
         )
 
     @property
@@ -58,7 +61,9 @@ class MerakiAdultContentFilteringSwitch(MerakiEntity, SwitchEntity):
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return the device info."""
-        return resolve_device_info(self._ssid, self._config_entry)
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"network_{self._network_id}")},
+        )
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
@@ -9,6 +9,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 
+from ..const import DOMAIN
 from ..coordinators import MerakiSwitchCoordinator
 from ..core.api.client import MerakiAPIClient
 from ..core.utils.icon_utils import get_device_type_icon
@@ -109,11 +110,9 @@ class MerakiSSIDBaseSwitch(MerakiEntity, SwitchEntity):
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return device information to link this entity to the SSID device."""
-        return resolve_device_info(
-            entity_data={"networkId": self._network_id, "number": self._ssid_number},
-            config_entry=self._config_entry,
-            ssid_data=self._ssid_data_at_init,
+        """Return device information to link this entity to the Network device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"network_{self._network_id}")},
         )
 
     @property
@@ -202,7 +201,9 @@ class MerakiSSIDEnabledSwitch(MerakiSSIDBaseSwitch):
             "enabled",
             rf_profile,
         )
-        self._attr_name = f"{ssid_data['name']} enabled"
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
+        self._attr_name = f"{network_name} SSID {ssid_data['name']} Enabled"
 
     @property
     def available(self) -> bool:
@@ -233,4 +234,6 @@ class MerakiSSIDBroadcastSwitch(MerakiSSIDBaseSwitch):
             "visible",
             rf_profile,
         )
-        self._attr_name = f"{ssid_data['name']} broadcast"
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
+        self._attr_name = f"{network_name} SSID {ssid_data['name']} Broadcast"

--- a/custom_components/meraki_ha/text/meraki_ssid_name.py
+++ b/custom_components/meraki_ha/text/meraki_ssid_name.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from ..const import DOMAIN
 from ..coordinators import MerakiWirelessCoordinator
 from ..core.api.client import MerakiAPIClient
 from ..helpers.device_info_helpers import resolve_device_info
@@ -47,9 +48,11 @@ class MerakiSSIDNameText(CoordinatorEntity[MerakiWirelessCoordinator], TextEntit
         )  # Can be int or str depending on source
 
         # EntityDescription can be used for name, icon etc.
+        network = coordinator.get_network(self._network_id)
+        network_name = network.name if network else f"Network {self._network_id}"
         self.entity_description = TextEntityDescription(
             key=f"{self._network_id}ssid{self._ssid_number}_ssid_name",
-            name="SSID name",
+            name=f"{network_name} SSID {ssid_data.get('name')} name",
             icon="mdi:form-textbox",
             native_min=1,
             native_max=32,
@@ -64,11 +67,9 @@ class MerakiSSIDNameText(CoordinatorEntity[MerakiWirelessCoordinator], TextEntit
 
     @property
     def device_info(self) -> DeviceInfo | None:
-        """Return device information to link this entity to the SSID device."""
-        return resolve_device_info(
-            entity_data={"networkId": self._network_id},
-            config_entry=self._config_entry,
-            ssid_data=self._ssid_data,
+        """Return device information to link this entity to the Network device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"network_{self._network_id}")},
         )
 
     @property

--- a/tests/sensor/network/test_ssid_client_count.py
+++ b/tests/sensor/network/test_ssid_client_count.py
@@ -21,10 +21,12 @@ async def test_ssid_client_count_sensor_wireless_settings() -> None:
 
     # Setup initial coordinator data with new structure
     coordinator.data = {"wireless_settings": {"N_123": [ssid_data]}}
+    coordinator.get_network.return_value = MagicMock(name="Test Network")
+    coordinator.get_network.return_value.name = "Test Network"
 
     sensor = MerakiSSIDClientCountSensor(coordinator, config_entry, ssid_data)
 
-    assert sensor.name == "Test SSID client count"
+    assert sensor.name == "Test Network SSID Test SSID client count"
     assert sensor.native_value == 5
 
     # Test update


### PR DESCRIPTION
This change refactors the Meraki HA integration architecture to group SSID-related entities under their parent Network device instead of creating standalone devices for each SSID. This prevents the creation of empty/orphaned SSID devices and provides a cleaner device registry. All SSID entities now have descriptive names that include the Network name to maintain uniqueness and clarity. Additionally, unique_id generation for these entities has been hardened to use network identifiers instead of device serials, which SSIDs lack.

Fixes #2281

---
*PR created automatically by Jules for task [6557588795578968262](https://jules.google.com/task/6557588795578968262) started by @brewmarsh*