### PR TITLE
Fix Unclickable Dropdowns via HA Native Elements

### DIFF
--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -710,8 +710,8 @@ const Y = class Y extends M {
           <div class="form-container">
             <ha-select
               label="Network"
-              .value="${this._selectedNetwork}"
-              @selected="${this._handleNetworkChanged}"
+              value="${this._selectedNetwork}"
+              @closed="${this._handleNetworkChanged}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -722,9 +722,9 @@ const Y = class Y extends M {
 
             <ha-select
               label="SSID"
-              .value="${this._selectedSsid}"
+              value="${this._selectedSsid}"
               .disabled="${!this._selectedNetwork}"
-              @selected="${this._handleSsidChanged}"
+              @closed="${this._handleSsidChanged}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -735,9 +735,9 @@ const Y = class Y extends M {
 
             <ha-select
               label="Group Policy"
-              .value="${this._selectedPolicy}"
+              value="${this._selectedPolicy}"
               .disabled="${!this._selectedNetwork}"
-              @selected="${(s) => this._selectedPolicy = s.target.value}"
+              @closed="${(s) => this._selectedPolicy = s.target.value}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -749,8 +749,8 @@ const Y = class Y extends M {
 
             <ha-select
               label="Duration"
-              .value="${this._duration}"
-              @selected="${(s) => this._duration = s.target.value}"
+              value="${this._duration}"
+              @closed="${(s) => this._duration = s.target.value}"
               fixedMenuPosition
               naturalMenuWidth
             >

--- a/frontend/src/meraki-card.ts
+++ b/frontend/src/meraki-card.ts
@@ -158,8 +158,8 @@ export class MerakiGuestAccessCard extends LitElement {
           <div class="form-container">
             <ha-select
               label="Network"
-              .value="${this._selectedNetwork}"
-              @selected="${this._handleNetworkChanged}"
+              value="${this._selectedNetwork}"
+              @closed="${this._handleNetworkChanged}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -170,9 +170,9 @@ export class MerakiGuestAccessCard extends LitElement {
 
             <ha-select
               label="SSID"
-              .value="${this._selectedSsid}"
+              value="${this._selectedSsid}"
               .disabled="${!this._selectedNetwork}"
-              @selected="${this._handleSsidChanged}"
+              @closed="${this._handleSsidChanged}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -183,9 +183,9 @@ export class MerakiGuestAccessCard extends LitElement {
 
             <ha-select
               label="Group Policy"
-              .value="${this._selectedPolicy}"
+              value="${this._selectedPolicy}"
               .disabled="${!this._selectedNetwork}"
-              @selected="${(e: any) => (this._selectedPolicy = e.target.value)}"
+              @closed="${(e: any) => (this._selectedPolicy = e.target.value)}"
               fixedMenuPosition
               naturalMenuWidth
             >
@@ -197,8 +197,8 @@ export class MerakiGuestAccessCard extends LitElement {
 
             <ha-select
               label="Duration"
-              .value="${this._duration}"
-              @selected="${(e: any) => (this._duration = e.target.value)}"
+              value="${this._duration}"
+              @closed="${(e: any) => (this._duration = e.target.value)}"
               fixedMenuPosition
               naturalMenuWidth
             >


### PR DESCRIPTION
This change fixes a Material Design version conflict in the Meraki guest access card that caused dropdown menus to be unclickable. By switching to Home Assistant's native `<ha-select>` behavior (binding to the `@closed` event and using attribute-based value binding), interaction detection is restored. The TypeScript source and built JavaScript artifacts have both been updated.

Fixes #2288

---
*PR created automatically by Jules for task [14753721741052365297](https://jules.google.com/task/14753721741052365297) started by @brewmarsh*