### PR TITLE
Enforce Camera Stream Feature Flag and Support .m3u8 Streams

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -67,6 +67,7 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
     _attr_brand = "Cisco Meraki"
     _attr_has_entity_name = True
+    _attr_supported_features = CameraEntityFeature.STREAM
 
     coordinator: MerakiCameraCoordinator
 
@@ -182,11 +183,6 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         except Exception as err:
             _LOGGER.warning("Failed to fetch camera snapshot: %s", err)
             return None
-
-    @property
-    def supported_features(self) -> CameraEntityFeature:
-        """Return supported features."""
-        return CameraEntityFeature.STREAM
 
     @property
     def is_streaming(self) -> bool:

--- a/custom_components/meraki_ha/core/api/factory.py
+++ b/custom_components/meraki_ha/core/api/factory.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
 
-from .client import MerakiAPIClient
-from .protocol import MerakiApiClientProtocol
+from .client import MerakiApiClientProtocol as MerakiAPIClient
+from .protocol import MerakiApiClientProtocol as MerakiApiClientProtocolType
 from .endpoints.appliance import ApplianceEndpoints
 from .endpoints.camera import CameraEndpoints
 from .endpoints.devices import DevicesEndpoints
@@ -21,7 +21,7 @@ def create_api_client(
     api_key: str,
     org_id: str,
     base_url: str = "https://api.meraki.com/api/v1",
-) -> MerakiApiClientProtocol:
+) -> MerakiApiClientProtocolType:
     """
     Create a new Meraki API client with all endpoints configured.
 

--- a/custom_components/meraki_ha/core/repositories/camera_repository.py
+++ b/custom_components/meraki_ha/core/repositories/camera_repository.py
@@ -101,14 +101,18 @@ class CameraRepository:
             )
             url = video_link_data.get("url")
 
-            # Validate that we received a valid RTSP URL
-            if url and url.startswith("rtsp://"):
+            # Validate that we received a valid RTSP or HTTP(S) .m3u8 stream URL
+            if url and (
+                url.startswith("rtsp://")
+                or url.startswith("https://")
+                or url.endswith(".m3u8")
+            ):
                 return url
 
-            # If we get a non-RTSP URL, log it and return None
+            # If we get a non-supported URL, log it and return None
             if url:
                 _LOGGER.debug(
-                    "API returned a non-RTSP URL, assuming no stream available: %s",
+                    "API returned a non-supported video URL, assuming no stream available: %s",
                     url,
                 )
             return None


### PR DESCRIPTION
This change enforces the CameraEntityFeature.STREAM flag using the strict Home Assistant convention (_attr_supported_features) in the `MerakiRTSPStreamCamera` class. It also updates the `CameraRepository.async_get_rtsp_stream_url` method to support .m3u8 (HLS) streams and https:// URLs, which are commonly returned by the Meraki API. Additionally, it resolves a potential `ImportError` in the API factory by correctly aliasing the `MerakiApiClientProtocol` class during import.

Fixes #2292

---
*PR created automatically by Jules for task [18410901353963666071](https://jules.google.com/task/18410901353963666071) started by @brewmarsh*