### PR TITLE
Fix Meraki API Client ImportError and Protocol Implementation

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -37,7 +37,7 @@ from .protocol import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiApiClientProtocol:
+class MerakiAPIClient:
     """
     Facade for the Meraki Dashboard API client.
 

--- a/custom_components/meraki_ha/core/api/protocol.py
+++ b/custom_components/meraki_ha/core/api/protocol.py
@@ -484,3 +484,46 @@ class MerakiApiClientProtocol(Protocol):
     async def run_with_semaphore(self, coro: Awaitable[Any]) -> Any:
         """Run an awaitable with the semaphore."""
         ...
+
+    def mark_feature_disabled(
+        self, feature: str, network_id: str | None = None
+    ) -> None:
+        """Mark a feature as disabled for the current session."""
+        ...
+
+    def is_feature_disabled(self, feature: str, network_id: str | None = None) -> bool:
+        """Check if a feature is disabled for the current session."""
+        ...
+
+    async def register_webhook(
+        self, webhook_url: str, secret: str, config_entry_id: str
+    ) -> None:
+        """Register a webhook with the Meraki API."""
+        ...
+
+    async def unregister_webhook(self, config_entry_id: str) -> None:
+        """Unregister a webhook with the Meraki API."""
+        ...
+
+    async def async_reboot_device(self, serial: str) -> dict[str, Any]:
+        """Reboot a device."""
+        ...
+
+    async def async_get_switch_port_statuses(
+        self,
+        serial: str,
+    ) -> list[dict[str, Any]]:
+        """Get statuses for all ports of a switch."""
+        ...
+
+    async def async_cycle_switch_ports(
+        self,
+        serial: str,
+        ports: list[str],
+    ) -> dict[str, Any]:
+        """Cycle a set of switch ports."""
+        ...
+
+    async def async_setup(self) -> None:
+        """Perform asynchronous setup of the API client."""
+        ...

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -29,7 +29,7 @@ async def test_validate_meraki_credentials(hass: HomeAssistant) -> None:
 
     """
     with patch(
-        "custom_components.meraki_ha.authentication.MerakiAPIClient",
+        "custom_components.meraki_ha.authentication.create_api_client",
     ) as mock_client:
         mock_client.return_value.async_setup = AsyncMock()
         mock_client.return_value.organization.get_organization = AsyncMock(
@@ -51,7 +51,7 @@ async def test_validate_meraki_credentials_invalid_org(hass: HomeAssistant) -> N
     """
     with (
         patch(
-            "custom_components.meraki_ha.authentication.MerakiAPIClient",
+            "custom_components.meraki_ha.authentication.create_api_client",
         ) as mock_client,
         pytest.raises(InvalidOrgID),
     ):
@@ -74,7 +74,7 @@ async def test_validate_meraki_credentials_auth_failed(hass: HomeAssistant) -> N
     """
     with (
         patch(
-            "custom_components.meraki_ha.authentication.MerakiAPIClient",
+            "custom_components.meraki_ha.authentication.create_api_client",
         ) as mock_client,
         pytest.raises(ConfigEntryAuthFailed),
     ):
@@ -97,7 +97,7 @@ async def test_validate_meraki_credentials_no_dashboard(hass: HomeAssistant) -> 
     """
     with (
         patch(
-            "custom_components.meraki_ha.authentication.MerakiAPIClient",
+            "custom_components.meraki_ha.authentication.create_api_client",
         ) as mock_client,
         pytest.raises(MerakiConnectionError),
     ):

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -126,7 +126,7 @@ async def test_ssid_device_creation_and_unification(
 
     with (
         patch(
-            "custom_components.meraki_ha.MerakiAPIClient",
+            "custom_components.meraki_ha.create_api_client",
             return_value=mock_meraki_client,
         ),
         patch(
@@ -188,7 +188,7 @@ async def test_integration_reload(
 
     with (
         patch(
-            "custom_components.meraki_ha.MerakiAPIClient",
+            "custom_components.meraki_ha.create_api_client",
             return_value=mock_meraki_client,
         ),
         patch(

--- a/tests/test_static_path.py
+++ b/tests/test_static_path.py
@@ -18,7 +18,7 @@ async def test_static_path_registration(hass: HomeAssistant) -> None:
     # Ensure frontend is in components to trigger the registration block
     hass.config.components.add("frontend")
 
-    with patch("custom_components.meraki_ha.MerakiAPIClient"), \
+    with patch("custom_components.meraki_ha.create_api_client"), \
          patch("custom_components.meraki_ha.coordinators.base.DataFetchManager"), \
          patch("custom_components.meraki_ha.async_register_webhook", return_value=None):
 


### PR DESCRIPTION
Fixes a severe `ImportError` caused by a recent refactoring attempt where `MerakiAPIClient` was incorrectly named `MerakiApiClientProtocol` inside `client.py`. Also updates the `protocol.py` definitions and adjusts the unit tests to properly mock the new API factory (`create_api_client`) to ensure passing tests and restored functionality.

---
*PR created automatically by Jules for task [860340656752999269](https://jules.google.com/task/860340656752999269) started by @brewmarsh*