### PR TITLE
Fix Payload Keys for Camera Sense and Video Settings Switch

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/camera.py
+++ b/custom_components/meraki_ha/core/api/endpoints/camera.py
@@ -78,10 +78,22 @@ class CameraEndpoints:
         self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Update video settings for a specific camera."""
+        # Map snake_case keys to camelCase keys for the Meraki API
+        payload = {}
+        mapping = {
+            "external_rtsp_enabled": "externalRtspEnabled",
+            "rtsp_enabled": "rtspEnabled",
+        }
+        for key, value in kwargs.items():
+            if key in mapping:
+                payload[mapping[key]] = value
+            else:
+                payload[key] = value
+
         result = await self._api_client.run_sync(
             self._api_client.dashboard.camera.updateDeviceCameraVideoSettings,
             serial=serial,
-            **kwargs,
+            **payload,
         )
         validated = validate_response(result)
         if not isinstance(validated, dict):
@@ -94,10 +106,24 @@ class CameraEndpoints:
         self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Update sense settings for a specific camera."""
+        # Map snake_case keys to camelCase keys for the Meraki API
+        payload = {}
+        mapping = {
+            "sense_enabled": "senseEnabled",
+            "mqtt_broker_id": "mqttBrokerId",
+            "audio_detection": "audioDetection",
+            "detection_model_id": "detectionModelId",
+        }
+        for key, value in kwargs.items():
+            if key in mapping:
+                payload[mapping[key]] = value
+            else:
+                payload[key] = value
+
         result = await self._api_client.run_sync(
             self._api_client.dashboard.camera.updateDeviceCameraSense,
             serial=serial,
-            **kwargs,
+            **payload,
         )
         validated = validate_response(result)
         if not isinstance(validated, dict):

--- a/tests/core/api/endpoints/test_camera.py
+++ b/tests/core/api/endpoints/test_camera.py
@@ -1,0 +1,56 @@
+"""Tests for the Camera Endpoints."""
+
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from custom_components.meraki_ha.core.api.endpoints.camera import CameraEndpoints
+
+@pytest.fixture
+def mock_client():
+    """Mock the Meraki API client."""
+    client = MagicMock()
+    client.dashboard = MagicMock()
+    client.run_sync = AsyncMock()
+    return client
+
+@pytest.fixture
+def camera_endpoints(mock_client):
+    """Fixture for the CameraEndpoints."""
+    return CameraEndpoints(mock_client)
+
+@pytest.mark.asyncio
+async def test_update_camera_sense_settings_repro(camera_endpoints, mock_client):
+    """Test update_camera_sense_settings reproduction of snake_case issue."""
+    serial = "cam123"
+
+    # Simulating what AnalyticsSwitch._async_update_setting does
+    await camera_endpoints.update_camera_sense_settings(
+        serial=serial,
+        sense_enabled=True,
+    )
+
+    mock_client.run_sync.assert_called_once()
+    args, kwargs = mock_client.run_sync.call_args
+    assert args[0] == mock_client.dashboard.camera.updateDeviceCameraSense
+    assert kwargs["serial"] == serial
+    # This should now PASS with the fix
+    assert "sense_enabled" not in kwargs
+    assert "senseEnabled" in kwargs
+    assert kwargs["senseEnabled"] is True
+
+@pytest.mark.asyncio
+async def test_update_camera_video_settings(camera_endpoints, mock_client):
+    """Test update_camera_video_settings correctly maps keys."""
+    serial = "cam123"
+
+    await camera_endpoints.update_camera_video_settings(
+        serial=serial,
+        external_rtsp_enabled=True,
+    )
+
+    mock_client.run_sync.assert_called_once()
+    args, kwargs = mock_client.run_sync.call_args
+    assert args[0] == mock_client.dashboard.camera.updateDeviceCameraVideoSettings
+    assert kwargs["serial"] == serial
+    assert "external_rtsp_enabled" not in kwargs
+    assert "externalRtspEnabled" in kwargs
+    assert kwargs["externalRtspEnabled"] is True


### PR DESCRIPTION
Fixed the 400 Bad Request error occurring when toggling the camera Sense switch by mapping snake_case payload keys to the required camelCase keys for the Meraki API. This fix was applied to both `update_camera_sense_settings` and `update_camera_video_settings` in `custom_components/meraki_ha/core/api/endpoints/camera.py`. New unit tests were added in `tests/core/api/endpoints/test_camera.py` to verify the fix and prevent regressions.

Fixes #2275

---
*PR created automatically by Jules for task [1179007786081978300](https://jules.google.com/task/1179007786081978300) started by @brewmarsh*