### PR TITLE
Add Meraki Dual-WAN Failover Alert Blueprint

### DIFF
--- a/custom_components/meraki_ha/blueprints/automation/meraki_wan_failover.yaml
+++ b/custom_components/meraki_ha/blueprints/automation/meraki_wan_failover.yaml
@@ -1,0 +1,38 @@
+blueprint:
+  name: Meraki Dual-WAN Failover Alert
+  description: Send a critical notification when the primary WAN link fails and the network fails over to the secondary link.
+  domain: automation
+  input:
+    primary_wan_sensor:
+      name: Primary WAN Sensor
+      description: The sensor tracking your WAN1 uplink status.
+      selector:
+        entity:
+          domain: sensor
+    secondary_wan_sensor:
+      name: Secondary WAN Sensor
+      description: (Optional) The sensor tracking your WAN2 or Cellular uplink status.
+      default: []
+      selector:
+        entity:
+          domain: sensor
+    notify_device:
+      name: Notification Device
+      description: The device to receive the failover alert.
+      selector:
+        device:
+          integration: mobile_app
+
+trigger:
+  - platform: state
+    entity_id: !input primary_wan_sensor
+    to:
+      - "failed"
+      - "offline"
+
+action:
+  - device_id: !input notify_device
+    domain: mobile_app
+    type: notify
+    title: "Meraki Network Alert"
+    message: "Primary internet has failed. The network is now running on the backup link."

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -206,6 +206,7 @@
   - [x] **IPSK WebSocket API:** Implement a strict WebSocket API contract for IPSK management with camelCase payload keys and centralized command definitions.
   - [x] **IPSK Native Service Action:** Expose IPSK creation functionality as a standard Home Assistant Service Action, allowing users to create timed guest keys without the custom frontend panel.
   - [x] **Guest Wi-Fi Blueprint:** Provide a plug-and-play automation template for creating temporary guest keys via the `meraki_ha.create_guest_key` action.
+  - [x] **Dual-WAN Failover Blueprint:** Provide an automation template for critical alerts when the primary internet connection fails on Meraki MX appliances.
   - [x] **IPSK Native UX Overhaul:** Rebuilt the TimedAccess.tsx component to provide a native Home Assistant experience using `ha-textfield`, `ha-select`, `ha-button`, and `ha-alert` web components.
   - [ ] **Enhanced Home Security & Awareness (MV Cameras & MT Sensors):**
   - [ ] **Camera Motion Events:** Create `binary_sensor` entities for camera motion events.


### PR DESCRIPTION
Implemented a new Home Assistant Blueprint for Meraki MX appliances to alert users when their primary WAN link fails and the network switches to a backup connection. The blueprint includes inputs for primary and secondary WAN sensors and a notification device.

Fixes #2313

---
*PR created automatically by Jules for task [7267176553198812249](https://jules.google.com/task/7267176553198812249) started by @brewmarsh*