### PR TITLE
Enhance staging smoke test with entity state auditing

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -142,3 +142,17 @@ jobs:
           
           echo "Logs appear clean."
           echo "HAS_ERRORS=false" >> $GITHUB_ENV
+
+      - name: Audit Entity States
+        shell: bash
+        run: |
+          echo "Checking for unavailable or unknown entities..."
+          PAYLOAD='{"template": "{{ integration_entities(\"meraki_ha\") | select(\"is_state\", [\"unavailable\", \"unknown\"]) | list }}"}'
+          RESPONSE=$(curl -sS -X POST -H "Authorization: Bearer ${{ secrets.HA_STAGING_TOKEN }}" -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.HA_STAGING_URL }}/api/template")
+
+          if [ "$RESPONSE" != "[]" ] && [ "$RESPONSE" != "" ]; then
+            echo "::error::CRITICAL: The following Meraki entities are unavailable or unknown: $RESPONSE"
+            exit 1
+          else
+            echo "All Meraki entities are fully available."
+          fi

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -147,6 +147,7 @@
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
 | The integration uses a non-blocking setup sequence where only Tier 1 data (basic device skeleton) is awaited during `async_setup_entry`. Heavy sensor data is fetched in the background.             | Included |
 | Automated smoke tests must include a 90-second wait after integration initialization to allow the Meraki background coordinators to complete their initial data fetch before auditing logs or state. | Included |
+| Staging smoke tests must audit entity states via the Home Assistant Template API to ensure no Meraki entities are in an 'unavailable' or 'unknown' state before passing.                             | Included |
 
 \*\*Frontend Development (DEPRECATED - Removed in v2.3.0)
 


### PR DESCRIPTION
This PR enhances the staging smoke test by adding a new audit step that checks for "Unavailable" or "Unknown" entities after the integration has initialized. This ensures that silent failures, where entities successfully register but fail to fetch data, are caught before the build passes. The Home Assistant Template API is used with a Jinja2 template to efficiently identify problematic entities. Technical requirements documentation has also been updated to include this new CI/CD capability.

Fixes #2315

---
*PR created automatically by Jules for task [14850606895028495543](https://jules.google.com/task/14850606895028495543) started by @brewmarsh*