### PR TITLE
Refactor Switch Port Entity Naming

### DIFF
--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -242,6 +242,9 @@
       },
       "meraki_camera_rtsp_switch": {
         "name": "RTSP server"
+      },
+      "switch_port_enabled": {
+        "name": "Port {port_id} enabled"
       }
     },
     "text": {

--- a/custom_components/meraki_ha/switch/switch_port.py
+++ b/custom_components/meraki_ha/switch/switch_port.py
@@ -69,7 +69,8 @@ class _MerakiPortSwitchBase(MerakiEntity, SwitchEntity, ABC):
 
         self.entity_description = SwitchEntityDescription(
             key=f"{entity_key_prefix}_{port_id_str}",
-            name=f"Port {port_id_str} enabled",
+            translation_key="switch_port_enabled",
+            translation_placeholders={"port_id": port_id_str},
         )
         self._update_internal_state()
 

--- a/tests/switch/test_meraki_appliance_port_switch.py
+++ b/tests/switch/test_meraki_appliance_port_switch.py
@@ -73,7 +73,8 @@ async def test_appliance_port_switch_init(
     switch.hass = hass
 
     assert switch.unique_id == "Q2AA-BB33-CC44_port_switch_1"
-    assert switch.name == "Port 1 enabled"
+    assert switch.translation_key == "switch_port_enabled"
+    assert switch.entity_description.translation_placeholders == {"port_id": "1"}
     assert switch.is_on is True
 
 

--- a/tests/switch/test_meraki_switch_port_switch.py
+++ b/tests/switch/test_meraki_switch_port_switch.py
@@ -72,7 +72,8 @@ async def test_switch_port_init(
     switch.hass = hass
 
     assert switch.unique_id == "Q2AA-BB33-CC44_port_switch_1"
-    assert switch.name == "Port 1 enabled"
+    assert switch.translation_key == "switch_port_enabled"
+    assert switch.entity_description.translation_placeholders == {"port_id": "1"}
     assert switch.is_on is True
 
 


### PR DESCRIPTION
This PR refactors the naming of the Switch Port entity to utilize Home Assistant's translation mechanism instead of a hardcoded string formatting block.

### Changes
* **`switch_port.py`:** Removed `name=f"Port {port_id_str} enabled"` from `SwitchEntityDescription` initialization and replaced it with `translation_key="switch_port_enabled"` and `translation_placeholders={"port_id": port_id_str}`.
* **`strings.json`:** Added a `"switch_port_enabled"` key under `"switch"` with the string `"Port {port_id} enabled"`.
* **Tests:** Updated `test_meraki_switch_port_switch.py` and `test_meraki_appliance_port_switch.py` to assert against `translation_key` and `translation_placeholders` instead of `name`.

---
*PR created automatically by Jules for task [13121476294650682839](https://jules.google.com/task/13121476294650682839) started by @brewmarsh*