### PR TITLE
Standardize Blueprint Folder Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Welcome to the **Meraki Home Assistant Integration**! This project bridges the g
 - **Rich Sensor Data:** Creates a wide array of sensors for device status, client counts, data usage, firmware updates, PoE consumption, and uplink metrics (latency, jitter, packet loss).
 - **Camera Integration:** View live RTSP streams and MV Sense analytics from your Meraki cameras within Home Assistant.
 
+## Automation examples 🚀
+
+The integration includes pre-built Blueprints to simplify common automations. These are automatically discovered by Home Assistant and can be found under **Settings > Automations & Scenes > Blueprints**.
+
+Available blueprints in `automation/meraki/`:
+- **Meraki Guest Wi-Fi Creator**: Automatically creates a temporary Guest Wi-Fi key (IPSK) when a trigger entity is activated.
+- **Scheduled Meraki Content Filter**: Automatically switch Meraki Content Filtering profiles based on a schedule.
+
 ## Troubleshooting
 
 If you encounter issues with the integration, please check the following:

--- a/custom_components/meraki_ha/blueprints/automation/meraki/meraki_guest_wifi.yaml
+++ b/custom_components/meraki_ha/blueprints/automation/meraki/meraki_guest_wifi.yaml
@@ -78,7 +78,7 @@ trigger:
     to: "on"
 
 action:
-  - service: meraki_ha.create_guest_key
+  - action: meraki_ha.create_guest_key
     data:
       network_id: !input network_id
       ssid_number: !input ssid_number

--- a/custom_components/meraki_ha/blueprints/automation/meraki/scheduled_content_filter.yaml
+++ b/custom_components/meraki_ha/blueprints/automation/meraki/scheduled_content_filter.yaml
@@ -56,7 +56,7 @@ action:
           - condition: trigger
             id: trigger_start
         sequence:
-          - service: select.select_option
+          - action: select.select_option
             target:
               entity_id: !input filter_entity
             data:
@@ -65,7 +65,7 @@ action:
           - condition: trigger
             id: trigger_end
         sequence:
-          - service: select.select_option
+          - action: select.select_option
             target:
               entity_id: !input filter_entity
             data:


### PR DESCRIPTION
This change standardizes the directory structure for Home Assistant Blueprints within the Meraki integration. All automation blueprints are now located in `custom_components/meraki_ha/blueprints/automation/meraki/`. Additionally, the blueprints have been updated to use the modern `action:` key instead of the deprecated `service:` key. Documentation has been added to the `README.md` to help users discover and use these blueprints.

Fixes #2314

---
*PR created automatically by Jules for task [17821093113493117386](https://jules.google.com/task/17821093113493117386) started by @brewmarsh*