### PR TITLE
Add visual editor for Meraki Content Filter card

### DIFF
--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -3,18 +3,18 @@
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const j = globalThis, J = j.ShadowRoot && (j.ShadyCSS === void 0 || j.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Y = Symbol(), it = /* @__PURE__ */ new WeakMap();
-let mt = class {
+const G = globalThis, Q = G.ShadowRoot && (G.ShadyCSS === void 0 || G.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, X = Symbol(), ot = /* @__PURE__ */ new WeakMap();
+let $t = class {
   constructor(t, e, i) {
-    if (this._$cssResult$ = !0, i !== Y) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    if (this._$cssResult$ = !0, i !== X) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const e = this.t;
-    if (J && t === void 0) {
+    if (Q && t === void 0) {
       const i = e !== void 0 && e.length === 1;
-      i && (t = it.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), i && it.set(e, t));
+      i && (t = ot.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), i && ot.set(e, t));
     }
     return t;
   }
@@ -22,33 +22,33 @@ let mt = class {
     return this.cssText;
   }
 };
-const At = (r) => new mt(typeof r == "string" ? r : r + "", void 0, Y), Z = (r, ...t) => {
+const bt = (r) => new $t(typeof r == "string" ? r : r + "", void 0, X), F = (r, ...t) => {
   const e = r.length === 1 ? r[0] : t.reduce((i, s, o) => i + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
   })(s) + r[o + 1], r[0]);
-  return new mt(e, r, Y);
+  return new $t(e, r, X);
 }, St = (r, t) => {
-  if (J) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  if (Q) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
   else for (const e of t) {
-    const i = document.createElement("style"), s = j.litNonce;
+    const i = document.createElement("style"), s = G.litNonce;
     s !== void 0 && i.setAttribute("nonce", s), i.textContent = e.cssText, r.appendChild(i);
   }
-}, rt = J ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
+}, nt = Q ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
   let e = "";
   for (const i of t.cssRules) e += i.cssText;
-  return At(e);
+  return bt(e);
 })(r) : r;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: bt, defineProperty: Et, getOwnPropertyDescriptor: kt, getOwnPropertyNames: xt, getOwnPropertySymbols: Pt, getPrototypeOf: Ct } = Object, v = globalThis, ot = v.trustedTypes, Nt = ot ? ot.emptyScript : "", B = v.reactiveElementPolyfillSupport, N = (r, t) => r, z = { toAttribute(r, t) {
+const { is: Et, defineProperty: kt, getOwnPropertyDescriptor: xt, getOwnPropertyNames: Ct, getOwnPropertySymbols: Pt, getPrototypeOf: Nt } = Object, v = globalThis, at = v.trustedTypes, Mt = at ? at.emptyScript : "", K = v.reactiveElementPolyfillSupport, M = (r, t) => r, V = { toAttribute(r, t) {
   switch (t) {
     case Boolean:
-      r = r ? Nt : null;
+      r = r ? Mt : null;
       break;
     case Object:
     case Array:
@@ -73,7 +73,7 @@ const { is: bt, defineProperty: Et, getOwnPropertyDescriptor: kt, getOwnProperty
       }
   }
   return e;
-} }, Q = (r, t) => !bt(r, t), nt = { attribute: !0, type: String, converter: z, reflect: !1, useDefault: !1, hasChanged: Q };
+} }, tt = (r, t) => !Et(r, t), ct = { attribute: !0, type: String, converter: V, reflect: !1, useDefault: !1, hasChanged: tt };
 Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), v.litPropertyMetadata ?? (v.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
 let k = class extends HTMLElement {
   static addInitializer(t) {
@@ -82,14 +82,14 @@ let k = class extends HTMLElement {
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = nt) {
+  static createProperty(t, e = ct) {
     if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
       const i = Symbol(), s = this.getPropertyDescriptor(t, i, e);
-      s !== void 0 && Et(this.prototype, t, s);
+      s !== void 0 && kt(this.prototype, t, s);
     }
   }
   static getPropertyDescriptor(t, e, i) {
-    const { get: s, set: o } = kt(this.prototype, t) ?? { get() {
+    const { get: s, set: o } = xt(this.prototype, t) ?? { get() {
       return this[e];
     }, set(n) {
       this[e] = n;
@@ -100,17 +100,17 @@ let k = class extends HTMLElement {
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? nt;
+    return this.elementProperties.get(t) ?? ct;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(N("elementProperties"))) return;
-    const t = Ct(this);
+    if (this.hasOwnProperty(M("elementProperties"))) return;
+    const t = Nt(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(N("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(N("properties"))) {
-      const e = this.properties, i = [...xt(e), ...Pt(e)];
+    if (this.hasOwnProperty(M("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(M("properties"))) {
+      const e = this.properties, i = [...Ct(e), ...Pt(e)];
       for (const s of i) this.createProperty(s, e[s]);
     }
     const t = this[Symbol.metadata];
@@ -129,8 +129,8 @@ let k = class extends HTMLElement {
     const e = [];
     if (Array.isArray(t)) {
       const i = new Set(t.flat(1 / 0).reverse());
-      for (const s of i) e.unshift(rt(s));
-    } else t !== void 0 && e.push(rt(t));
+      for (const s of i) e.unshift(nt(s));
+    } else t !== void 0 && e.push(nt(t));
     return e;
   }
   static _$Eu(t, e) {
@@ -184,7 +184,7 @@ let k = class extends HTMLElement {
     var o;
     const i = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, i);
     if (s !== void 0 && i.reflect === !0) {
-      const n = (((o = i.converter) == null ? void 0 : o.toAttribute) !== void 0 ? i.converter : z).toAttribute(e, i.type);
+      const n = (((o = i.converter) == null ? void 0 : o.toAttribute) !== void 0 ? i.converter : V).toAttribute(e, i.type);
       this._$Em = t, n == null ? this.removeAttribute(s) : this.setAttribute(s, n), this._$Em = null;
     }
   }
@@ -192,7 +192,7 @@ let k = class extends HTMLElement {
     var o, n;
     const i = this.constructor, s = i._$Eh.get(t);
     if (s !== void 0 && this._$Em !== s) {
-      const c = i.getPropertyOptions(s), a = typeof c.converter == "function" ? { fromAttribute: c.converter } : ((o = c.converter) == null ? void 0 : o.fromAttribute) !== void 0 ? c.converter : z;
+      const c = i.getPropertyOptions(s), a = typeof c.converter == "function" ? { fromAttribute: c.converter } : ((o = c.converter) == null ? void 0 : o.fromAttribute) !== void 0 ? c.converter : V;
       this._$Em = s;
       const h = a.fromAttribute(e, c.type);
       this[s] = h ?? ((n = this._$Ej) == null ? void 0 : n.get(s)) ?? h, this._$Em = null;
@@ -202,7 +202,7 @@ let k = class extends HTMLElement {
     var n;
     if (t !== void 0) {
       const c = this.constructor;
-      if (s === !1 && (o = this[t]), i ?? (i = c.getPropertyOptions(t)), !((i.hasChanged ?? Q)(o, e) || i.useDefault && i.reflect && o === ((n = this._$Ej) == null ? void 0 : n.get(t)) && !this.hasAttribute(c._$Eu(t, i)))) return;
+      if (s === !1 && (o = this[t]), i ?? (i = c.getPropertyOptions(t)), !((i.hasChanged ?? tt)(o, e) || i.useDefault && i.reflect && o === ((n = this._$Ej) == null ? void 0 : n.get(t)) && !this.hasAttribute(c._$Eu(t, i)))) return;
       this.C(t, e, i);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
@@ -278,56 +278,56 @@ let k = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-k.elementStyles = [], k.shadowRootOptions = { mode: "open" }, k[N("elementProperties")] = /* @__PURE__ */ new Map(), k[N("finalized")] = /* @__PURE__ */ new Map(), B == null || B({ ReactiveElement: k }), (v.reactiveElementVersions ?? (v.reactiveElementVersions = [])).push("2.1.2");
+k.elementStyles = [], k.shadowRootOptions = { mode: "open" }, k[M("elementProperties")] = /* @__PURE__ */ new Map(), k[M("finalized")] = /* @__PURE__ */ new Map(), K == null || K({ ReactiveElement: k }), (v.reactiveElementVersions ?? (v.reactiveElementVersions = [])).push("2.1.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const M = globalThis, at = (r) => r, L = M.trustedTypes, ct = L ? L.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, $t = "$lit$", y = `lit$${Math.random().toFixed(9).slice(2)}$`, gt = "?" + y, Mt = `<${gt}>`, E = document, O = () => E.createComment(""), D = (r) => r === null || typeof r != "object" && typeof r != "function", X = Array.isArray, Ot = (r) => X(r) || typeof (r == null ? void 0 : r[Symbol.iterator]) == "function", F = `[
-\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, lt = /-->/g, ht = />/g, w = RegExp(`>|${F}(?:([^\\s"'>=/]+)(${F}*=${F}*(?:[^
-\f\r"'\`<>=]|("|')|))|$)`, "g"), dt = /'/g, ut = /"/g, yt = /^(?:script|style|textarea|title)$/i, Dt = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), m = Dt(1), x = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), pt = /* @__PURE__ */ new WeakMap(), A = E.createTreeWalker(E, 129);
-function vt(r, t) {
-  if (!X(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return ct !== void 0 ? ct.createHTML(t) : t;
+const O = globalThis, lt = (r) => r, B = O.trustedTypes, ht = B ? B.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, yt = "$lit$", y = `lit$${Math.random().toFixed(9).slice(2)}$`, vt = "?" + y, Ot = `<${vt}>`, E = document, D = () => E.createComment(""), T = (r) => r === null || typeof r != "object" && typeof r != "function", et = Array.isArray, Dt = (r) => et(r) || typeof (r == null ? void 0 : r[Symbol.iterator]) == "function", q = `[
+\f\r]`, N = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, dt = /-->/g, ut = />/g, A = RegExp(`>|${q}(?:([^\\s"'>=/]+)(${q}*=${q}*(?:[^
+\f\r"'\`<>=]|("|')|))|$)`, "g"), pt = /'/g, _t = /"/g, wt = /^(?:script|style|textarea|title)$/i, Tt = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), _ = Tt(1), x = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), ft = /* @__PURE__ */ new WeakMap(), b = E.createTreeWalker(E, 129);
+function At(r, t) {
+  if (!et(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return ht !== void 0 ? ht.createHTML(t) : t;
 }
-const Tt = (r, t) => {
+const Ut = (r, t) => {
   const e = r.length - 1, i = [];
-  let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = C;
+  let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = N;
   for (let c = 0; c < e; c++) {
     const a = r[c];
-    let h, _, l = -1, $ = 0;
-    for (; $ < a.length && (n.lastIndex = $, _ = n.exec(a), _ !== null); ) $ = n.lastIndex, n === C ? _[1] === "!--" ? n = lt : _[1] !== void 0 ? n = ht : _[2] !== void 0 ? (yt.test(_[2]) && (s = RegExp("</" + _[2], "g")), n = w) : _[3] !== void 0 && (n = w) : n === w ? _[0] === ">" ? (n = s ?? C, l = -1) : _[1] === void 0 ? l = -2 : (l = n.lastIndex - _[2].length, h = _[1], n = _[3] === void 0 ? w : _[3] === '"' ? ut : dt) : n === ut || n === dt ? n = w : n === lt || n === ht ? n = C : (n = w, s = void 0);
-    const g = n === w && r[c + 1].startsWith("/>") ? " " : "";
-    o += n === C ? a + Mt : l >= 0 ? (i.push(h), a.slice(0, l) + $t + a.slice(l) + y + g) : a + y + (l === -2 ? c : g);
+    let h, f, l = -1, m = 0;
+    for (; m < a.length && (n.lastIndex = m, f = n.exec(a), f !== null); ) m = n.lastIndex, n === N ? f[1] === "!--" ? n = dt : f[1] !== void 0 ? n = ut : f[2] !== void 0 ? (wt.test(f[2]) && (s = RegExp("</" + f[2], "g")), n = A) : f[3] !== void 0 && (n = A) : n === A ? f[0] === ">" ? (n = s ?? N, l = -1) : f[1] === void 0 ? l = -2 : (l = n.lastIndex - f[2].length, h = f[1], n = f[3] === void 0 ? A : f[3] === '"' ? _t : pt) : n === _t || n === pt ? n = A : n === dt || n === ut ? n = N : (n = A, s = void 0);
+    const $ = n === A && r[c + 1].startsWith("/>") ? " " : "";
+    o += n === N ? a + Ot : l >= 0 ? (i.push(h), a.slice(0, l) + yt + a.slice(l) + y + $) : a + y + (l === -2 ? c : $);
   }
-  return [vt(r, o + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), i];
+  return [At(r, o + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), i];
 };
-class T {
+class U {
   constructor({ strings: t, _$litType$: e }, i) {
     let s;
     this.parts = [];
     let o = 0, n = 0;
-    const c = t.length - 1, a = this.parts, [h, _] = Tt(t, e);
-    if (this.el = T.createElement(h, i), A.currentNode = this.el.content, e === 2 || e === 3) {
+    const c = t.length - 1, a = this.parts, [h, f] = Ut(t, e);
+    if (this.el = U.createElement(h, i), b.currentNode = this.el.content, e === 2 || e === 3) {
       const l = this.el.content.firstChild;
       l.replaceWith(...l.childNodes);
     }
-    for (; (s = A.nextNode()) !== null && a.length < c; ) {
+    for (; (s = b.nextNode()) !== null && a.length < c; ) {
       if (s.nodeType === 1) {
-        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith($t)) {
-          const $ = _[n++], g = s.getAttribute(l).split(y), R = /([.?@])?(.*)/.exec($);
-          a.push({ type: 1, index: o, name: R[2], strings: g, ctor: R[1] === "." ? It : R[1] === "?" ? Ht : R[1] === "@" ? Rt : G }), s.removeAttribute(l);
+        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith(yt)) {
+          const m = f[n++], $ = s.getAttribute(l).split(y), L = /([.?@])?(.*)/.exec(m);
+          a.push({ type: 1, index: o, name: L[2], strings: $, ctor: L[1] === "." ? Ht : L[1] === "?" ? Rt : L[1] === "@" ? jt : W }), s.removeAttribute(l);
         } else l.startsWith(y) && (a.push({ type: 6, index: o }), s.removeAttribute(l));
-        if (yt.test(s.tagName)) {
-          const l = s.textContent.split(y), $ = l.length - 1;
-          if ($ > 0) {
-            s.textContent = L ? L.emptyScript : "";
-            for (let g = 0; g < $; g++) s.append(l[g], O()), A.nextNode(), a.push({ type: 2, index: ++o });
-            s.append(l[$], O());
+        if (wt.test(s.tagName)) {
+          const l = s.textContent.split(y), m = l.length - 1;
+          if (m > 0) {
+            s.textContent = B ? B.emptyScript : "";
+            for (let $ = 0; $ < m; $++) s.append(l[$], D()), b.nextNode(), a.push({ type: 2, index: ++o });
+            s.append(l[m], D());
           }
         }
-      } else if (s.nodeType === 8) if (s.data === gt) a.push({ type: 2, index: o });
+      } else if (s.nodeType === 8) if (s.data === vt) a.push({ type: 2, index: o });
       else {
         let l = -1;
         for (; (l = s.data.indexOf(y, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += y.length - 1;
@@ -340,14 +340,14 @@ class T {
     return i.innerHTML = t, i;
   }
 }
-function P(r, t, e = r, i) {
+function C(r, t, e = r, i) {
   var n, c;
   if (t === x) return t;
   let s = i !== void 0 ? (n = e._$Co) == null ? void 0 : n[i] : e._$Cl;
-  const o = D(t) ? void 0 : t._$litDirective$;
-  return (s == null ? void 0 : s.constructor) !== o && ((c = s == null ? void 0 : s._$AO) == null || c.call(s, !1), o === void 0 ? s = void 0 : (s = new o(r), s._$AT(r, e, i)), i !== void 0 ? (e._$Co ?? (e._$Co = []))[i] = s : e._$Cl = s), s !== void 0 && (t = P(r, s._$AS(r, t.values), s, i)), t;
+  const o = T(t) ? void 0 : t._$litDirective$;
+  return (s == null ? void 0 : s.constructor) !== o && ((c = s == null ? void 0 : s._$AO) == null || c.call(s, !1), o === void 0 ? s = void 0 : (s = new o(r), s._$AT(r, e, i)), i !== void 0 ? (e._$Co ?? (e._$Co = []))[i] = s : e._$Cl = s), s !== void 0 && (t = C(r, s._$AS(r, t.values), s, i)), t;
 }
-class Ut {
+class It {
   constructor(t, e) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
   }
@@ -359,23 +359,23 @@ class Ut {
   }
   u(t) {
     const { el: { content: e }, parts: i } = this._$AD, s = ((t == null ? void 0 : t.creationScope) ?? E).importNode(e, !0);
-    A.currentNode = s;
-    let o = A.nextNode(), n = 0, c = 0, a = i[0];
+    b.currentNode = s;
+    let o = b.nextNode(), n = 0, c = 0, a = i[0];
     for (; a !== void 0; ) {
       if (n === a.index) {
         let h;
-        a.type === 2 ? h = new H(o, o.nextSibling, this, t) : a.type === 1 ? h = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (h = new jt(o, this, t)), this._$AV.push(h), a = i[++c];
+        a.type === 2 ? h = new j(o, o.nextSibling, this, t) : a.type === 1 ? h = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (h = new zt(o, this, t)), this._$AV.push(h), a = i[++c];
       }
-      n !== (a == null ? void 0 : a.index) && (o = A.nextNode(), n++);
+      n !== (a == null ? void 0 : a.index) && (o = b.nextNode(), n++);
     }
-    return A.currentNode = E, s;
+    return b.currentNode = E, s;
   }
   p(t) {
     let e = 0;
     for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(t, i, e), e += i.strings.length - 2) : i._$AI(t[e])), e++;
   }
 }
-class H {
+class j {
   get _$AU() {
     var t;
     return ((t = this._$AM) == null ? void 0 : t._$AU) ?? this._$Cv;
@@ -395,7 +395,7 @@ class H {
     return this._$AB;
   }
   _$AI(t, e = this) {
-    t = P(this, t, e), D(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== x && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Ot(t) ? this.k(t) : this._(t);
+    t = C(this, t, e), T(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== x && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Dt(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -404,33 +404,33 @@ class H {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== u && D(this._$AH) ? this._$AA.nextSibling.data = t : this.T(E.createTextNode(t)), this._$AH = t;
+    this._$AH !== u && T(this._$AH) ? this._$AA.nextSibling.data = t : this.T(E.createTextNode(t)), this._$AH = t;
   }
   $(t) {
     var o;
-    const { values: e, _$litType$: i } = t, s = typeof i == "number" ? this._$AC(t) : (i.el === void 0 && (i.el = T.createElement(vt(i.h, i.h[0]), this.options)), i);
+    const { values: e, _$litType$: i } = t, s = typeof i == "number" ? this._$AC(t) : (i.el === void 0 && (i.el = U.createElement(At(i.h, i.h[0]), this.options)), i);
     if (((o = this._$AH) == null ? void 0 : o._$AD) === s) this._$AH.p(e);
     else {
-      const n = new Ut(s, this), c = n.u(this.options);
+      const n = new It(s, this), c = n.u(this.options);
       n.p(e), this.T(c), this._$AH = n;
     }
   }
   _$AC(t) {
-    let e = pt.get(t.strings);
-    return e === void 0 && pt.set(t.strings, e = new T(t)), e;
+    let e = ft.get(t.strings);
+    return e === void 0 && ft.set(t.strings, e = new U(t)), e;
   }
   k(t) {
-    X(this._$AH) || (this._$AH = [], this._$AR());
+    et(this._$AH) || (this._$AH = [], this._$AR());
     const e = this._$AH;
     let i, s = 0;
-    for (const o of t) s === e.length ? e.push(i = new H(this.O(O()), this.O(O()), this, this.options)) : i = e[s], i._$AI(o), s++;
+    for (const o of t) s === e.length ? e.push(i = new j(this.O(D()), this.O(D()), this, this.options)) : i = e[s], i._$AI(o), s++;
     s < e.length && (this._$AR(i && i._$AB.nextSibling, s), e.length = s);
   }
   _$AR(t = this._$AA.nextSibling, e) {
     var i;
     for ((i = this._$AP) == null ? void 0 : i.call(this, !1, !0, e); t !== this._$AB; ) {
-      const s = at(t).nextSibling;
-      at(t).remove(), t = s;
+      const s = lt(t).nextSibling;
+      lt(t).remove(), t = s;
     }
   }
   setConnected(t) {
@@ -438,7 +438,7 @@ class H {
     this._$AM === void 0 && (this._$Cv = t, (e = this._$AP) == null || e.call(this, t));
   }
 }
-class G {
+class W {
   get tagName() {
     return this.element.tagName;
   }
@@ -451,11 +451,11 @@ class G {
   _$AI(t, e = this, i, s) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = P(this, t, e, 0), n = !D(t) || t !== this._$AH && t !== x, n && (this._$AH = t);
+    if (o === void 0) t = C(this, t, e, 0), n = !T(t) || t !== this._$AH && t !== x, n && (this._$AH = t);
     else {
       const c = t;
       let a, h;
-      for (t = o[0], a = 0; a < o.length - 1; a++) h = P(this, c[i + a], e, a), h === x && (h = this._$AH[a]), n || (n = !D(h) || h !== this._$AH[a]), h === u ? t = u : t !== u && (t += (h ?? "") + o[a + 1]), this._$AH[a] = h;
+      for (t = o[0], a = 0; a < o.length - 1; a++) h = C(this, c[i + a], e, a), h === x && (h = this._$AH[a]), n || (n = !T(h) || h !== this._$AH[a]), h === u ? t = u : t !== u && (t += (h ?? "") + o[a + 1]), this._$AH[a] = h;
     }
     n && !s && this.j(t);
   }
@@ -463,7 +463,7 @@ class G {
     t === u ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class It extends G {
+class Ht extends W {
   constructor() {
     super(...arguments), this.type = 3;
   }
@@ -471,7 +471,7 @@ class It extends G {
     this.element[this.name] = t === u ? void 0 : t;
   }
 }
-class Ht extends G {
+class Rt extends W {
   constructor() {
     super(...arguments), this.type = 4;
   }
@@ -479,12 +479,12 @@ class Ht extends G {
     this.element.toggleAttribute(this.name, !!t && t !== u);
   }
 }
-class Rt extends G {
+class jt extends W {
   constructor(t, e, i, s, o) {
     super(t, e, i, s, o), this.type = 5;
   }
   _$AI(t, e = this) {
-    if ((t = P(this, t, e, 0) ?? u) === x) return;
+    if ((t = C(this, t, e, 0) ?? u) === x) return;
     const i = this._$AH, s = t === u && i !== u || t.capture !== i.capture || t.once !== i.once || t.passive !== i.passive, o = t !== u && (i === u || s);
     s && this.element.removeEventListener(this.name, this, i), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
@@ -493,7 +493,7 @@ class Rt extends G {
     typeof this._$AH == "function" ? this._$AH.call(((e = this.options) == null ? void 0 : e.host) ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class jt {
+class zt {
   constructor(t, e, i) {
     this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = i;
   }
@@ -501,17 +501,17 @@ class jt {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    P(this, t);
+    C(this, t);
   }
 }
-const W = M.litHtmlPolyfillSupport;
-W == null || W(T, H), (M.litHtmlVersions ?? (M.litHtmlVersions = [])).push("3.3.2");
-const zt = (r, t, e) => {
+const J = O.litHtmlPolyfillSupport;
+J == null || J(U, j), (O.litHtmlVersions ?? (O.litHtmlVersions = [])).push("3.3.2");
+const Lt = (r, t, e) => {
   const i = (e == null ? void 0 : e.renderBefore) ?? t;
   let s = i._$litPart$;
   if (s === void 0) {
     const o = (e == null ? void 0 : e.renderBefore) ?? null;
-    i._$litPart$ = s = new H(t.insertBefore(O(), o), o, void 0, e ?? {});
+    i._$litPart$ = s = new j(t.insertBefore(D(), o), o, void 0, e ?? {});
   }
   return s._$AI(r), s;
 };
@@ -521,7 +521,7 @@ const zt = (r, t, e) => {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const S = globalThis;
-class b extends k {
+class w extends k {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -532,7 +532,7 @@ class b extends k {
   }
   update(t) {
     const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = zt(e, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Lt(e, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     var t;
@@ -546,17 +546,17 @@ class b extends k {
     return x;
   }
 }
-var ft;
-b._$litElement$ = !0, b.finalized = !0, (ft = S.litElementHydrateSupport) == null || ft.call(S, { LitElement: b });
-const K = S.litElementPolyfillSupport;
-K == null || K({ LitElement: b });
+var mt;
+w._$litElement$ = !0, w.finalized = !0, (mt = S.litElementHydrateSupport) == null || mt.call(S, { LitElement: w });
+const Y = S.litElementPolyfillSupport;
+Y == null || Y({ LitElement: w });
 (S.litElementVersions ?? (S.litElementVersions = [])).push("4.2.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const wt = (r) => (t, e) => {
+const st = (r) => (t, e) => {
   e !== void 0 ? e.addInitializer(() => {
     customElements.define(r, t);
   }) : customElements.define(r, t);
@@ -566,7 +566,7 @@ const wt = (r) => (t, e) => {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const Lt = { attribute: !0, type: String, converter: z, reflect: !1, hasChanged: Q }, Gt = (r = Lt, t, e) => {
+const Gt = { attribute: !0, type: String, converter: V, reflect: !1, hasChanged: tt }, Vt = (r = Gt, t, e) => {
   const { kind: i, metadata: s } = e;
   let o = globalThis.litPropertyMetadata.get(s);
   if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), i === "setter" && ((r = Object.create(r)).wrapped = !0), o.set(e.name, r), i === "accessor") {
@@ -587,8 +587,8 @@ const Lt = { attribute: !0, type: String, converter: z, reflect: !1, hasChanged:
   }
   throw Error("Unsupported decorator location: " + i);
 };
-function V(r) {
-  return (t, e) => typeof e == "object" ? Gt(r, t, e) : ((i, s, o) => {
+function z(r) {
+  return (t, e) => typeof e == "object" ? Vt(r, t, e) : ((i, s, o) => {
     const n = s.hasOwnProperty(o);
     return s.constructor.createProperty(o, i), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
   })(r, t, e);
@@ -599,14 +599,17 @@ function V(r) {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 function p(r) {
-  return V({ ...r, state: !0, attribute: !1 });
+  return z({ ...r, state: !0, attribute: !1 });
 }
-var Vt = Object.defineProperty, Bt = Object.getOwnPropertyDescriptor, tt = (r, t, e, i) => {
-  for (var s = i > 1 ? void 0 : i ? Bt(t, e) : t, o = r.length - 1, n; o >= 0; o--)
+var Bt = Object.defineProperty, Ft = Object.getOwnPropertyDescriptor, P = (r, t, e, i) => {
+  for (var s = i > 1 ? void 0 : i ? Ft(t, e) : t, o = r.length - 1, n; o >= 0; o--)
     (n = r[o]) && (s = (i ? n(t, e, s) : n(s)) || s);
-  return i && s && Vt(t, e, s), s;
+  return i && s && Bt(t, e, s), s;
 };
-let U = class extends b {
+let I = class extends w {
+  static async getConfigElement() {
+    return document.createElement("meraki-content-filter-card-editor");
+  }
   setConfig(r) {
     if (!r || !r.entity)
       throw new Error("Please define a Meraki content filter entity");
@@ -620,10 +623,10 @@ let U = class extends b {
   }
   render() {
     if (!this._config || !this.hass)
-      return m``;
+      return _``;
     const r = this._config.entity, t = this.hass.states[r];
     if (!t)
-      return m`
+      return _`
         <ha-card>
           <div class="card-content">
             <ha-alert alert-type="error">Entity not found: ${r}</ha-alert>
@@ -631,7 +634,7 @@ let U = class extends b {
         </ha-card>
       `;
     const e = t.state, i = t.attributes.options || ["None", "Security", "Family", "Strict"], s = this._config.name || t.attributes.friendly_name || "Content Filter";
-    return m`
+    return _`
       <ha-card>
         <div class="card-header">${s}</div>
         <div class="card-content">
@@ -639,7 +642,7 @@ let U = class extends b {
             Current Profile: <strong>${e}</strong>
           </div>
           <div class="profile-buttons">
-            ${i.map((o) => m`
+            ${i.map((o) => _`
               <div
                 class="profile-button ${e === o ? "active" : ""}"
                 @click="${() => this._handleProfileSelect(o)}"
@@ -664,7 +667,7 @@ let U = class extends b {
       }
   }
 };
-U.styles = Z`
+I.styles = F`
     :host {
       display: block;
     }
@@ -724,28 +727,88 @@ U.styles = Z`
       display: block;
     }
   `;
-tt([
-  V({ attribute: !1 })
-], U.prototype, "hass", 2);
-tt([
+P([
+  z({ attribute: !1 })
+], I.prototype, "hass", 2);
+P([
   p()
-], U.prototype, "_config", 2);
-U = tt([
-  wt("meraki-content-filter-card")
-], U);
+], I.prototype, "_config", 2);
+I = P([
+  st("meraki-content-filter-card")
+], I);
+let H = class extends w {
+  setConfig(r) {
+    this._config = r;
+  }
+  render() {
+    return !this.hass || !this._config ? _`` : _`
+      <div class="card-config">
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${this._config.entity}
+          .configValue=${"entity"}
+          .includeDomains=${["select"]}
+          @value-changed=${this._valueChanged}
+          allow-custom-entity
+          label="Entity (Required)"
+        ></ha-entity-picker>
+        <ha-textfield
+          label="Name (Optional)"
+          .value=${this._config.name || ""}
+          .configValue=${"name"}
+          @input=${this._valueChanged}
+        ></ha-textfield>
+      </div>
+    `;
+  }
+  _valueChanged(r) {
+    if (!this._config || !this.hass)
+      return;
+    const t = r.target, e = t.configValue;
+    if (!e)
+      return;
+    let i = t.value;
+    if (this._config[e] === i)
+      return;
+    const s = { ...this._config };
+    i === "" || i === void 0 ? delete s[e] : s[e] = i, this._config = s;
+    const o = new CustomEvent("config-changed", {
+      detail: { config: this._config },
+      bubbles: !0,
+      composed: !0
+    });
+    this.dispatchEvent(o);
+  }
+};
+H.styles = F`
+    .card-config ha-entity-picker,
+    .card-config ha-textfield {
+      display: block;
+      margin-bottom: 16px;
+    }
+  `;
+P([
+  z({ attribute: !1 })
+], H.prototype, "hass", 2);
+P([
+  p()
+], H.prototype, "_config", 2);
+H = P([
+  st("meraki-content-filter-card-editor")
+], H);
 window.customCards = window.customCards || [];
-window.customCards.push({
+window.customCards.some((r) => r.type === "meraki-content-filter-card") || window.customCards.push({
   type: "meraki-content-filter-card",
   name: "Meraki Content Filter",
   description: "Control Meraki Content Filtering profiles.",
   preview: !0
 });
-var Ft = Object.defineProperty, Wt = Object.getOwnPropertyDescriptor, et = (r, t, e, i) => {
-  for (var s = i > 1 ? void 0 : i ? Wt(t, e) : t, o = r.length - 1, n; o >= 0; o--)
+var Wt = Object.defineProperty, Kt = Object.getOwnPropertyDescriptor, it = (r, t, e, i) => {
+  for (var s = i > 1 ? void 0 : i ? Kt(t, e) : t, o = r.length - 1, n; o >= 0; o--)
     (n = r[o]) && (s = (i ? n(t, e, s) : n(s)) || s);
-  return i && s && Ft(t, e, s), s;
+  return i && s && Wt(t, e, s), s;
 };
-let I = class extends b {
+let R = class extends w {
   setConfig(r) {
     if (!r)
       throw new Error("Invalid configuration");
@@ -762,7 +825,7 @@ let I = class extends b {
   }
   _renderStatusDot(r, t) {
     if (!r || !this.hass.states[r])
-      return m`
+      return _`
         <div class="status-item">
           <svg height="12" width="12">
             <circle cx="6" cy="6" r="6" fill="var(--disabled-text-color)" />
@@ -772,7 +835,7 @@ let I = class extends b {
       `;
     const e = this.hass.states[r], i = e ? e.state.toLowerCase() : "unknown";
     let s = "var(--disabled-text-color)";
-    return i === "ok" || i === "online" || i === "connected" ? s = "var(--success-color)" : i === "warning" ? s = "var(--warning-color)" : (i === "error" || i === "offline" || i === "failed") && (s = "var(--error-color)"), m`
+    return i === "ok" || i === "online" || i === "connected" ? s = "var(--success-color)" : i === "warning" ? s = "var(--warning-color)" : (i === "error" || i === "offline" || i === "failed") && (s = "var(--error-color)"), _`
       <div class="status-item">
         <svg height="12" width="12">
           <circle cx="6" cy="6" r="6" fill="${s}" />
@@ -783,9 +846,9 @@ let I = class extends b {
   }
   render() {
     if (!this._config || !this.hass)
-      return m``;
+      return _``;
     const r = this._config.throughput_entity, t = r && this.hass.states[r] ? this.hass.states[r].state + " " + (this.hass.states[r].attributes.unit_of_measurement || "") : "N/A";
-    return m`
+    return _`
       <ha-card>
         <div class="card-content">
           <div class="vitals-container">
@@ -804,7 +867,7 @@ let I = class extends b {
     `;
   }
 };
-I.styles = Z`
+R.styles = F`
     :host {
       display: block;
     }
@@ -850,15 +913,15 @@ I.styles = Z`
       --mdc-icon-size: 18px;
     }
   `;
-et([
-  V({ attribute: !1 })
-], I.prototype, "hass", 2);
-et([
+it([
+  z({ attribute: !1 })
+], R.prototype, "hass", 2);
+it([
   p()
-], I.prototype, "_config", 2);
-I = et([
-  wt("meraki-network-vitals-card")
-], I);
+], R.prototype, "_config", 2);
+R = it([
+  st("meraki-network-vitals-card")
+], R);
 window.customCards = window.customCards || [];
 window.customCards.some((r) => r.type === "meraki-network-vitals-card") || window.customCards.push({
   type: "meraki-network-vitals-card",
@@ -866,8 +929,8 @@ window.customCards.some((r) => r.type === "meraki-network-vitals-card") || windo
   description: "Compact horizontal header for Meraki network health and throughput.",
   preview: !0
 });
-var q = /* @__PURE__ */ ((r) => (r.GET_CONFIG = "meraki_ha/get_config", r.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", r.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", r.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", r.GET_VERSION = "meraki_ha/get_version", r.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", r.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", r.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", r.GET_GUEST_KEYS = "meraki_ha/ipsk/get", r.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", r.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", r))(q || {});
-const _t = async (r, t) => {
+var Z = /* @__PURE__ */ ((r) => (r.GET_CONFIG = "meraki_ha/get_config", r.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", r.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", r.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", r.GET_VERSION = "meraki_ha/get_version", r.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", r.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", r.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", r.GET_GUEST_KEYS = "meraki_ha/ipsk/get", r.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", r.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", r))(Z || {});
+const gt = async (r, t) => {
   if (!r)
     throw new Error("Home Assistant object is not available.");
   try {
@@ -880,12 +943,12 @@ const _t = async (r, t) => {
     throw console.error(`Meraki HA: WebSocket error [${t.type}]:`, e), e;
   }
 };
-var Kt = Object.defineProperty, f = (r, t, e, i) => {
+var qt = Object.defineProperty, g = (r, t, e, i) => {
   for (var s = void 0, o = r.length - 1, n; o >= 0; o--)
     (n = r[o]) && (s = n(t, e, s) || s);
-  return s && Kt(t, e, s), s;
+  return s && qt(t, e, s), s;
 };
-const st = class st extends b {
+const rt = class rt extends w {
   constructor() {
     super(...arguments), this._selectedNetwork = "", this._selectedSSID = "", this._selectedPolicy = "", this._selectedDuration = "60", this._customName = "", this._customPassphrase = "", this._creating = !1, this._error = null, this._success = null, this._networks = [], this._ssids = [], this._policies = [], this._loading = !0, this._initDone = !1;
   }
@@ -919,8 +982,8 @@ const st = class st extends b {
           this._error = "Meraki integration not found. Please configure it first.", this._loading = !1;
           return;
         }
-        const s = await _t(this.hass, {
-          type: q.GET_CONFIG,
+        const s = await gt(this.hass, {
+          type: Z.GET_CONFIG,
           config_entry_id: i
         });
         this._networks = (Array.isArray(s.networks) ? s.networks : []).filter((o) => {
@@ -933,6 +996,8 @@ const st = class st extends b {
         this._loading = !1;
       }
     }
+  }
+  async _fetchSSIDs() {
   }
   async _fetchPolicies(t, e) {
     var i;
@@ -947,8 +1012,8 @@ const st = class st extends b {
           s = n.length > 0 ? n[0].entry_id : void 0;
         }
         if (!s) return;
-        const o = await _t(this.hass, {
-          type: q.TIMED_ACCESS_GET_POLICIES,
+        const o = await gt(this.hass, {
+          type: Z.TIMED_ACCESS_GET_POLICIES,
           config_entry_id: s,
           network_id: t
         });
@@ -960,7 +1025,7 @@ const st = class st extends b {
   render() {
     var e, i;
     if (this._loading && !this._networks.length)
-      return m`
+      return _`
         <ha-card .header="${((e = this._config) == null ? void 0 : e.name) || "Meraki Guest Access"}">
           <div class="card-content flex justify-center p-8">
             <ha-circular-progress active></ha-circular-progress>
@@ -968,15 +1033,15 @@ const st = class st extends b {
         </ha-card>
       `;
     const t = (this._ssids || []).filter((s) => s.networkId === this._selectedNetwork);
-    return m`
+    return _`
       <ha-card .header="${((i = this._config) == null ? void 0 : i.name) || "Meraki Guest Access"}">
         <div class="card-content">
-          ${this._error ? m`
+          ${this._error ? _`
                 <ha-alert alert-type="error" dismissable @alert-dismissed-clicked="${() => this._error = null}">
                   ${this._error}
                 </ha-alert>
               ` : ""}
-          ${this._success ? m`
+          ${this._success ? _`
                 <ha-alert alert-type="success" dismissable @alert-dismissed-clicked="${() => this._success = null}">
                   ${this._success}
                 </ha-alert>
@@ -991,7 +1056,11 @@ const st = class st extends b {
               naturalMenuWidth
             >
               ${(this._networks || []).map(
-      (s) => m`<mwc-list-item value="${String(s.id)}">${s.name}</mwc-list-item>`
+      (s) => _`
+                  <mwc-list-item value="${s.id}">
+                    ${s.name}
+                  </mwc-list-item>
+                `
     )}
             </ha-select>
 
@@ -1004,7 +1073,11 @@ const st = class st extends b {
               naturalMenuWidth
             >
               ${(t || []).map(
-      (s) => m`<mwc-list-item value="${String(s.number)}">${s.name} (SSID ${s.number})</mwc-list-item>`
+      (s) => _`
+                  <mwc-list-item value="${String(s.number)}">
+                    ${s.name} (SSID ${s.number})
+                  </mwc-list-item>
+                `
     )}
             </ha-select>
 
@@ -1018,7 +1091,11 @@ const st = class st extends b {
             >
               <mwc-list-item value="">None (Default)</mwc-list-item>
               ${(this._policies || []).map(
-      (s) => m`<mwc-list-item value="${String(s.groupPolicyId)}">${s.name}</mwc-list-item>`
+      (s) => _`
+                  <mwc-list-item value="${String(s.groupPolicyId)}">
+                    ${s.name}
+                  </mwc-list-item>
+                `
     )}
             </ha-select>
 
@@ -1065,7 +1142,7 @@ const st = class st extends b {
   _handleNetworkChange(t) {
     t.stopPropagation();
     const i = t.target.value;
-    !i || i === this._selectedNetwork || (this._selectedNetwork = i, this._selectedSSID = "", this._selectedPolicy = "", this._fetchPolicies(i));
+    !i || i === this._selectedNetwork || (this._selectedNetwork = i, this._selectedSSID = "", this._selectedPolicy = "", this._fetchSSIDs(), this._fetchPolicies(i));
   }
   _handleSSIDChange(t) {
     t.stopPropagation();
@@ -1102,7 +1179,7 @@ const st = class st extends b {
     }
   }
 };
-st.styles = Z`
+rt.styles = F`
     :host {
       display: block;
     }
@@ -1131,53 +1208,53 @@ st.styles = Z`
       padding: 32px;
     }
   `;
-let d = st;
-f([
-  V({ attribute: !1 })
+let d = rt;
+g([
+  z({ attribute: !1 })
 ], d.prototype, "hass");
-f([
+g([
   p()
 ], d.prototype, "_config");
-f([
+g([
   p()
 ], d.prototype, "_selectedNetwork");
-f([
+g([
   p()
 ], d.prototype, "_selectedSSID");
-f([
+g([
   p()
 ], d.prototype, "_selectedPolicy");
-f([
+g([
   p()
 ], d.prototype, "_selectedDuration");
-f([
+g([
   p()
 ], d.prototype, "_customName");
-f([
+g([
   p()
 ], d.prototype, "_customPassphrase");
-f([
+g([
   p()
 ], d.prototype, "_creating");
-f([
+g([
   p()
 ], d.prototype, "_error");
-f([
+g([
   p()
 ], d.prototype, "_success");
-f([
+g([
   p()
 ], d.prototype, "_networks");
-f([
+g([
   p()
 ], d.prototype, "_ssids");
-f([
+g([
   p()
 ], d.prototype, "_policies");
-f([
+g([
   p()
 ], d.prototype, "_loading");
-f([
+g([
   p()
 ], d.prototype, "_initDone");
 customElements.get("meraki-guest-access-card") || customElements.define("meraki-guest-access-card", d);

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -28,4 +28,7 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** ACL score for `resolve_device_info` reduced below 10 by removing nested conditionals and delegating logic.
   - **[VERIFIED]** All helper functions are strictly typed and under 50 lines of code.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6) are now considered part of the standard for this integration.
+- **R7: Visual Card Editors:**
+  - **[IN PROGRESS]** Implementation of visual configuration editors for Meraki custom cards to replace YAML-only editing and improve user experience with native Home Assistant entity pickers.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7) are now considered part of the standard for this integration.

--- a/frontend/src/meraki-content-filter-card.ts
+++ b/frontend/src/meraki-content-filter-card.ts
@@ -6,12 +6,17 @@ interface Config {
   type: string;
   entity: string;
   name?: string;
+  [key: string]: any;
 }
 
 @customElement('meraki-content-filter-card')
 export class MerakiContentFilterCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
+
+  public static async getConfigElement() {
+    return document.createElement("meraki-content-filter-card-editor");
+  }
 
   public setConfig(config: Config): void {
     if (!config || !config.entity) {
@@ -146,11 +151,90 @@ export class MerakiContentFilterCard extends LitElement {
   `;
 }
 
+@customElement('meraki-content-filter-card-editor')
+export class MerakiContentFilterCardEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() private _config?: Config;
+
+  public setConfig(config: Config): void {
+    this._config = config;
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return html``;
+    }
+
+    return html`
+      <div class="card-config">
+        <ha-entity-picker
+          .hass=${this.hass}
+          .value=${this._config.entity}
+          .configValue=${"entity"}
+          .includeDomains=${["select"]}
+          @value-changed=${this._valueChanged}
+          allow-custom-entity
+          label="Entity (Required)"
+        ></ha-entity-picker>
+        <ha-textfield
+          label="Name (Optional)"
+          .value=${this._config.name || ""}
+          .configValue=${"name"}
+          @input=${this._valueChanged}
+        ></ha-textfield>
+      </div>
+    `;
+  }
+
+  private _valueChanged(ev: any): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target;
+    const configValue = target.configValue;
+
+    if (!configValue) {
+      return;
+    }
+
+    let newValue = target.value;
+    if (this._config[configValue] === newValue) {
+      return;
+    }
+
+    const newConfig = { ...this._config };
+    if (newValue === "" || newValue === undefined) {
+      delete newConfig[configValue];
+    } else {
+      newConfig[configValue] = newValue;
+    }
+
+    this._config = newConfig;
+
+    const event = new CustomEvent("config-changed", {
+      detail: { config: this._config },
+      bubbles: true,
+      composed: true,
+    });
+    this.dispatchEvent(event);
+  }
+
+  static styles = css`
+    .card-config ha-entity-picker,
+    .card-config ha-textfield {
+      display: block;
+      margin-bottom: 16px;
+    }
+  `;
+}
+
 // Register the card in the Home Assistant Lovelace UI picker
 (window as any).customCards = (window as any).customCards || [];
-(window as any).customCards.push({
-  type: "meraki-content-filter-card",
-  name: "Meraki Content Filter",
-  description: "Control Meraki Content Filtering profiles.",
-  preview: true,
-});
+if (!(window as any).customCards.some((c: any) => c.type === 'meraki-content-filter-card')) {
+  (window as any).customCards.push({
+    type: "meraki-content-filter-card",
+    name: "Meraki Content Filter",
+    description: "Control Meraki Content Filtering profiles.",
+    preview: true,
+  });
+}


### PR DESCRIPTION
Implemented a visual configuration editor for the Meraki Content Filter card. This allows users to select the content filter entity using a native Home Assistant entity picker restricted to the 'select' domain, and optionally set a custom card name. This replaces the previous YAML-only configuration which often led to errors when the default entity was missing.

Verification:
- Updated frontend/src/meraki-content-filter-card.ts.
- Verified build with npm run build in frontend/ directory.
- Confirmed custom_components/meraki_ha/www/meraki-card.js was updated.
- Verified backend integration tests passed (ignoring pre-existing known issues).
- Updated requirements documentation in docs/requirements/requirements.md.

Fixes #2328

---
*PR created automatically by Jules for task [1833462126193397182](https://jules.google.com/task/1833462126193397182) started by @brewmarsh*