### PR TITLE
Fix Unavailable Entities and Coordinator Race Conditions

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import secrets
 import string
@@ -128,45 +129,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     appliance_coordinator = MerakiApplianceCoordinator(hass, entry, api_client)
     client_coordinator = MerakiClientCoordinator(hass, entry, api_client)
 
-    # 1. Block setup until the basic device skeleton is loaded (Tier 1)
-    # This is strictly required to populate the Device Registry promptly.
-    await device_coordinator.async_config_entry_first_refresh()
-
-    # Seed the specialized coordinators with the basic device data so discovery
-    # can proceed without waiting for the heavy full organizational/sensor refresh.
-    # We explicitly do NOT use async_set_updated_data() here because that would mark
-    # the coordinators as having had a successful first update, making entities
-    # prematurely "available" with incomplete data.
-    for coord in [
-        main_coordinator,
-        switch_coordinator,
-        camera_coordinator,
-        sensor_coordinator,
-        wireless_coordinator,
-        appliance_coordinator,
-        client_coordinator,
-    ]:
-        coord.data = device_coordinator.data
-        coord.devices_by_serial = device_coordinator.devices_by_serial
-        coord.networks_by_id = device_coordinator.networks_by_id
-        coord.ssids_by_network_and_number = (
-            device_coordinator.ssids_by_network_and_number
-        )
-
-    # 2. Start heavy fetching for other coordinators in the background.
-    # This prevents blocking the Home Assistant UI and avoids setup timeouts.
-    for coord, name in [
-        (main_coordinator, "meraki_main_init"),
-        (switch_coordinator, "meraki_switch_init"),
-        (camera_coordinator, "meraki_camera_init"),
-        (sensor_coordinator, "meraki_sensor_init"),
-        (wireless_coordinator, "meraki_wireless_init"),
-        (appliance_coordinator, "meraki_appliance_init"),
-        (client_coordinator, "meraki_client_init"),
-    ]:
-        entry.async_create_background_task(
-            hass, coord.async_request_refresh(), name=name
-        )
+    # 1. Block setup until all coordinators have performed their first refresh.
+    # This ensures a consistent data contract and prevents race conditions
+    # where entities are created before their data is available.
+    await asyncio.gather(
+        device_coordinator.async_config_entry_first_refresh(),
+        main_coordinator.async_config_entry_first_refresh(),
+        switch_coordinator.async_config_entry_first_refresh(),
+        camera_coordinator.async_config_entry_first_refresh(),
+        sensor_coordinator.async_config_entry_first_refresh(),
+        wireless_coordinator.async_config_entry_first_refresh(),
+        appliance_coordinator.async_config_entry_first_refresh(),
+        client_coordinator.async_config_entry_first_refresh(),
+    )
 
     repo = MerakiRepository(api_client)
     device_control_service = DeviceControlService(repo)

--- a/custom_components/meraki_ha/coordinators/appliance.py
+++ b/custom_components/meraki_ha/coordinators/appliance.py
@@ -36,9 +36,12 @@ class MerakiApplianceCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                     _,
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
-            return data
+
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
-            data, _ = self.update_processor.process_failure(
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(
                 err, self.last_successful_data
             )
-            return data
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/coordinators/camera.py
+++ b/custom_components/meraki_ha/coordinators/camera.py
@@ -36,9 +36,12 @@ class MerakiCameraCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                     _,
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
-            return data
+
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
-            data, _ = self.update_processor.process_failure(
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(
                 err, self.last_successful_data
             )
-            return data
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/coordinators/client.py
+++ b/custom_components/meraki_ha/coordinators/client.py
@@ -36,9 +36,12 @@ class MerakiClientCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                     _,
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
-            return data
+
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
-            data, _ = self.update_processor.process_failure(
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(
                 err, self.last_successful_data
             )
-            return data
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/coordinators/device.py
+++ b/custom_components/meraki_ha/coordinators/device.py
@@ -42,7 +42,8 @@ class MerakiDeviceCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
             updated = self.polling_manager.record_success()
             self.apply_polling_update(updated)
 
-            return data
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
             _LOGGER.error("Error fetching Meraki device data: %s", err)
 
@@ -53,5 +54,6 @@ class MerakiDeviceCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
             if "429" in str(err):
                 raise UpdateFailed(f"Meraki API rate limit: {err}") from err
 
-            data, _ = self.update_processor.process_failure(err, self.last_successful_data)
-            return data
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(err, self.last_successful_data)
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/coordinators/main.py
+++ b/custom_components/meraki_ha/coordinators/main.py
@@ -31,13 +31,14 @@ class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from API endpoint, apply filters, and handle exceptions."""
         try:
-            data = await self._execute_update_cycle()
+            await self._execute_update_cycle()
 
             # Record success and potentially reset interval
             updated = self.polling_manager.record_success()
             self.apply_polling_update(updated)
 
-            return data
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
             _LOGGER.error("Error fetching Meraki main data: %s", err)
 
@@ -48,10 +49,11 @@ class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
             if "429" in str(err):
                 raise UpdateFailed(f"Meraki API rate limit: {err}") from err
 
-            data, _ = self.update_processor.process_failure(err, self.last_successful_data)
-            return data
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(err, self.last_successful_data)
+            return {**self.devices_by_serial, **self.networks_by_id}
 
-    async def _execute_update_cycle(self) -> dict[str, Any]:
+    async def _execute_update_cycle(self) -> None:
         """Execute the update cycle and process data."""
         timespan = (
             int(self.update_interval.total_seconds()) if self.update_interval else 300
@@ -62,7 +64,7 @@ class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
 
         if not data:
             _LOGGER.warning("API call to get_all_data returned no data.")
-            return self.last_successful_data
+            return
 
         # Process successful update
         (
@@ -77,4 +79,3 @@ class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
 
         self.last_successful_update = datetime.now()
         self.last_successful_data = data
-        return data

--- a/custom_components/meraki_ha/coordinators/sensor.py
+++ b/custom_components/meraki_ha/coordinators/sensor.py
@@ -42,9 +42,11 @@ class MerakiSensorCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
             updated = self.polling_manager.record_success()
             self.apply_polling_update(updated)
 
-            return data
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
-            data, _ = self.update_processor.process_failure(
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(
                 err, self.last_successful_data
             )
-            return data
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/coordinators/switch.py
+++ b/custom_components/meraki_ha/coordinators/switch.py
@@ -36,9 +36,12 @@ class MerakiSwitchCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                     _,
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
-            return data
+
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
-            data, _ = self.update_processor.process_failure(
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(
                 err, self.last_successful_data
             )
-            return data
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/coordinators/wireless.py
+++ b/custom_components/meraki_ha/coordinators/wireless.py
@@ -36,9 +36,12 @@ class MerakiWirelessCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
                     _,
                 ) = await self.update_processor.process_success(data, self.data)
                 self.last_successful_data = data
-            return data
+
+            # Return a merged dictionary keyed by serial/ID for efficient extraction
+            return {**self.devices_by_serial, **self.networks_by_id}
         except Exception as err:
-            data, _ = self.update_processor.process_failure(
+            # Fallback to last successful data if update fails
+            self.update_processor.process_failure(
                 err, self.last_successful_data
             )
-            return data
+            return {**self.devices_by_serial, **self.networks_by_id}

--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABC
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -85,17 +86,30 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
     def available(self) -> bool:
         """Return True if entity is available."""
         # First check if coordinator has data
-        if self.coordinator.data is None or not self.coordinator.last_update_success:
+        if self.coordinator.data is None:
             return False
 
-        # For device-based entities, check device status
-        if self._serial:
-            device = self.coordinator.get_device(self._serial)
-            return bool(device and device.status == "online")
+        # Check for specific identifier in centralized data
+        identifier = self._serial or self._network_id
+        if identifier:
+            return identifier in self.coordinator.data
 
-        # For network-based entities, check network status
-        if self._network_id:
-            network = self.coordinator.get_network(self._network_id)
-            return bool(network)
+        return self.coordinator.last_update_success
 
-        return True
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the centralized coordinator."""
+        if not self.coordinator.data:
+            self._attr_available = False
+        else:
+            identifier = self._serial or self._network_id
+            if identifier and (data := self.coordinator.data.get(identifier)):
+                self._attr_available = True
+                if hasattr(self, "_update_state_from_data"):
+                    self._update_state_from_data(data)
+                elif hasattr(self, "_update_sensor_data"):
+                    self._update_sensor_data()
+            else:
+                self._attr_available = identifier in self.coordinator.data if identifier else True
+
+        self.async_write_ha_state()

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+import logging
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
@@ -23,11 +25,58 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
     def available(self) -> bool:
         """Return if entity is available.
 
-        An entity is available if its coordinator has data. We allow availability
-        if data is present (even if seeded) to prevent 'unavailable' states during
-        initial background synchronization of specialized coordinators.
+        An entity is available if its coordinator has data and the specific
+        device or network data exists in the centralized payload.
         """
-        return bool(self.coordinator.data)
+        if not self.coordinator.data:
+            return False
+
+        # Extract identifier
+        identifier = getattr(self, "_serial", None) or getattr(
+            self, "_device_serial", None
+        )
+        if not identifier and hasattr(self, "_device"):
+            identifier = getattr(self._device, "serial", None)
+
+        if not identifier:
+            identifier = getattr(self, "_network_id", None)
+
+        if not identifier:
+            return True
+
+        return identifier in self.coordinator.data
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the centralized coordinator."""
+        if not self.coordinator.data:
+            self._attr_available = False
+        else:
+            # Extract only this specific device's data from the master dict
+            identifier = getattr(self, "_serial", None) or getattr(
+                self, "_device_serial", None
+            )
+            if not identifier and hasattr(self, "_device"):
+                identifier = getattr(self._device, "serial", None)
+
+            if not identifier:
+                identifier = getattr(self, "_network_id", None)
+
+            if identifier and (data := self.coordinator.data.get(identifier)):
+                self._attr_available = True
+                if hasattr(self, "_update_state_from_data"):
+                    self._update_state_from_data(data)
+                elif hasattr(self, "_update_sensor_data"):
+                    self._update_sensor_data()
+                elif hasattr(self, "_update_native_value"):
+                    # For MerakiMtSensor
+                    if hasattr(self, "_device") and hasattr(data, "serial"):
+                        self._device = data
+                    self._update_native_value()
+            else:
+                self._attr_available = identifier in self.coordinator.data if identifier else True
+
+        self.async_write_ha_state()
 
     @property
     def unique_id(self) -> str | None:
@@ -36,6 +85,10 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
         This logic attempts to find a serial number or network/SSID identifier
         across various internal naming schemes used in the integration.
         """
+        # Prioritize manually assigned _attr_unique_id
+        if manual_id := getattr(self, "_attr_unique_id", None):
+            return manual_id
+
         serial = None
 
         # 1. Attempt to find a physical device serial
@@ -66,8 +119,7 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
             # (e.g., 'serial_merakirtspstreamcamera')
             return f"{serial}_{self.__class__.__name__.lower()}"
 
-        # Final fallback to manually assigned _attr_unique_id
-        return getattr(self, "_attr_unique_id", None)
+        return None
 
 
 class MerakiSensor(MerakiEntity[T], SensorEntity, Generic[T]):

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -100,7 +100,9 @@ class MerakiDeviceStatusSensor(MerakiSensor):
 
     def _get_current_device_data(self) -> MerakiDevice | None:
         """Retrieve the latest data for this sensor's device from the coordinator."""
-        return self.coordinator.get_device(self._device_serial)
+        if self.coordinator.data:
+            return self.coordinator.data.get(self._device_serial)
+        return None
 
     def _update_sensor_data(self) -> None:
         """Update sensor state and attributes from coordinator data."""
@@ -185,19 +187,5 @@ class MerakiDeviceStatusSensor(MerakiSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._update_sensor_data()
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        # Check basic coordinator availability
-        if self.coordinator.data is None or not super().available:
-            return False
-        # Check if the specific device data is available
-        if self.coordinator.data.get("devices"):
-            return any(
-                dev.serial == self._device_serial
-                for dev in self.coordinator.data["devices"]
-            )
-        return False
+        # MerakiEntity handles data extraction and calls _update_sensor_data
+        super()._handle_coordinator_update()

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -9,11 +9,11 @@ from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.const import UnitOfPower
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...const import DOMAIN
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -22,8 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiPoeUsageSensor(
-    CoordinatorEntity,
-    SensorEntity,
+    MerakiSensor,
 ):
     """
     Representation of a Meraki switch PoE usage sensor.
@@ -54,6 +53,7 @@ class MerakiPoeUsageSensor(
         """
         super().__init__(coordinator)
         self._device = device
+        self._serial = device.serial
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
@@ -74,11 +74,14 @@ class MerakiPoeUsageSensor(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self._device.serial:
-            device = self.coordinator.get_device(self._device.serial)
+        super()._handle_coordinator_update()
+
+    def _update_sensor_data(self) -> None:
+        """Update sensor data."""
+        if self._device.serial and self.coordinator.data:
+            device = self.coordinator.data.get(self._device.serial)
             if device:
                 self._device = device
-                self.async_write_ha_state()
 
     @property
     def native_value(self) -> float | None:

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -42,4 +42,9 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** Staging workflow (`deploy-staging.yaml`) enhanced to capture rich error details in the `CI_ERROR_DETAILS` environment variable.
   - **[VERIFIED]** Automated GitHub Issues now include these error details in the body and are tagged with the `jules` label to trigger AI-driven triage.
 
+- **R11: Centralized Data Contract:**
+  - **[VERIFIED]** Coordinators now return a merged dictionary keyed by device `serial` or network `id` in `_async_update_data`.
+  - **[VERIFIED]** `MerakiEntity` and `BaseMerakiEntity` implement centralized data extraction using these identifiers in `_handle_coordinator_update` and the `available` property.
+  - **[VERIFIED]** All specialized coordinators are awaited during `async_setup_entry` via `asyncio.gather` to prevent race conditions during platform setup.
+
 This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10) are now considered part of the standard for this integration.

--- a/tests/sensor/device/test_device_status.py
+++ b/tests/sensor/device/test_device_status.py
@@ -50,7 +50,11 @@ def mock_device_coordinator() -> MagicMock:
         ],
     )
 
-    coordinator.data: dict[str, list[MerakiDevice]] = {"devices": [device1, device2]}
+    coordinator.data: dict[str, Any] = {
+        device1.serial: device1,
+        device2.serial: device2,
+        "devices": [device1, device2],
+    }
 
     # Setup get_device return values
     def get_device(serial: str) -> MerakiDevice | None:


### PR DESCRIPTION
This submission fixes the 'unavailable/unknown' entity issue that occurred after the centralized coordinator refactor. It addresses two primary root causes: race conditions during integration startup and an inefficient data contract between coordinators and entities.

Key improvements:
1. **Race Condition Prevention**: The integration setup now explicitly waits for all coordinators to perform their first refresh before discovering entities and forwarding platforms.
2. **Keyed Data Contract (Requirement R11)**: Coordinators now return data in a dictionary format keyed by device serial or network ID. This allows entities to extract their specific state in O(1) time without iterating through lists.
3. **Robust Base Entities**: `MerakiEntity` and `BaseMerakiEntity` now handle coordinator updates centrally, marking themselves unavailable if their specific identifier is missing from the payload.
4. **Consistency**: Child entities like `MerakiPoeUsageSensor` have been refactored to inherit from `MerakiSensor` for standardized availability and update logic.
5. **Verified Stability**: Unit tests have been updated and verified to ensure the new data structure is correctly handled.

Fixes #2368

---
*PR created automatically by Jules for task [5456359871496896077](https://jules.google.com/task/5456359871496896077) started by @brewmarsh*