### PR TITLE
Audit for Python 3.14 anti-patterns and document compatibility

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -141,6 +141,12 @@
 | :----------------------------------------------------- | :------- |
 | The Integration uses Voluptuous for schema validation. | Included |
 
+### Python 3.14 Compatibility
+
+| Requirement                                                                                                                                                 | Status   |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| The integration must be free of syntax anti-patterns that trigger `SyntaxWarning` in Python 3.14+, such as `return`, `break`, or `continue` inside `finally` blocks. | Included |
+
 ### Testing & Hardening
 
 | Requirement                                                                                                                                                                                          | Status   |

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -47,4 +47,8 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** `MerakiEntity` and `BaseMerakiEntity` implement centralized data extraction using these identifiers in `_handle_coordinator_update` and the `available` property.
   - **[VERIFIED]** All specialized coordinators are awaited during `async_setup_entry` via `asyncio.gather` to prevent race conditions during platform setup.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10) are now considered part of the standard for this integration.
+- **R12: Python 3.14 Syntax Compatibility:**
+  - **[VERIFIED]** Audited `custom_components/meraki_ha/` for `return`, `break`, or `continue` statements inside `finally` blocks.
+  - **[VERIFIED]** `core/api/client.py` and other complex sync/async wrappers verified to be free of these anti-patterns.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12) are now considered part of the standard for this integration.


### PR DESCRIPTION
Performed a comprehensive audit of the `meraki_ha` integration for Python 3.14 syntax anti-patterns, specifically focusing on `return`, `break`, or `continue` statements inside `finally` blocks. 

Using a custom AST-based auditing tool, I scanned all Python files within the `custom_components/meraki_ha/` directory. No instances of these anti-patterns were found in the internal codebase. 

Updated the project documentation to formalize Python 3.14 compatibility as a core requirement (R12) and marked it as verified. Verified the changes by running representative tests from the suite.

Fixes #2374

---
*PR created automatically by Jules for task [12300979655930949440](https://jules.google.com/task/12300979655930949440) started by @brewmarsh*