### PR TITLE
Fix Entity Discovery Service returning 0 devices

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -185,6 +185,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "discovery_service": discovery_service,
     }
 
+    # Verify that the device coordinator has data before starting discovery.
+    # If devices_by_serial is empty, discovery will find 0 entities.
+    if not device_coordinator.devices_by_serial:
+        _LOGGER.warning(
+            "Device coordinator has no device data after first refresh. "
+            "Entity discovery may be incomplete. "
+            "Check Meraki API connectivity and organization ID: %s",
+            entry.data[CONF_MERAKI_ORG_ID],
+        )
+    else:
+        _LOGGER.info(
+            "Device coordinator populated with %d devices. Starting discovery.",
+            len(device_coordinator.devices_by_serial),
+        )
+
     await discovery_service.discover_entities()
 
     # Set up services

--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -78,11 +78,9 @@ class DeviceDiscoveryService:
         self._control_service = control_service
         self._network_control_service = network_control_service
 
-        devices_data = self._device_coordinator.data.get("devices", [])
-        self._devices: list[MerakiDevice] = [
-            d if isinstance(d, MerakiDevice) else MerakiDevice.from_dict(d)
-            for d in devices_data
-        ]
+        self._devices: list[MerakiDevice] = list(
+            self._device_coordinator.devices_by_serial.values()
+        )
         self.all_entities: list[Entity] = []
 
     async def discover_entities(self) -> list[Entity]:
@@ -134,6 +132,8 @@ class DeviceDiscoveryService:
 
     async def _discover_device_entities(self):
         """Discover entities for all devices."""
+        # Refresh devices list from coordinator to ensure it's populated
+        self._devices = list(self._device_coordinator.devices_by_serial.values())
         _LOGGER.debug("Starting entity discovery for %d devices", len(self._devices))
 
         for device in self._devices:

--- a/tests/discovery/test_service.py
+++ b/tests/discovery/test_service.py
@@ -28,11 +28,13 @@ def mock_coordinator_with_devices(
     unsupported_device = replace(
         MOCK_DEVICE, serial="unsupported_serial", model="unsupported"
     )
+    devices = [wireless_device, camera_device, unsupported_device]
     mock_coordinator.data = {
-        "devices": [wireless_device, camera_device, unsupported_device],
+        "devices": devices,
         "networks": [],
         "ssids": [],
     }
+    mock_coordinator.devices_by_serial = {d.serial: d for d in devices}
     return mock_coordinator
 
 
@@ -147,11 +149,15 @@ async def test_discover_entities_delegates_to_handler(
 
         # Assert UniversalHandler called for each device
         assert MockUniversalHandler.call_count == 3
+        # Use the first device from the list we created in the fixture
+        first_device = list(mock_coordinator_with_devices.devices_by_serial.values())[0]
         MockUniversalHandler.assert_any_call(
             mock_coordinator_with_devices,
-            mock_coordinator_with_devices.data["devices"][0],
+            first_device,
             mock_config_entry,
             mock_camera_service,
             mock_control_service,
             mock_network_control_service,
+            status_coordinator=mock_coordinator_with_devices,
+            sensor_coordinator=mock_coordinator_with_devices,
         )


### PR DESCRIPTION
This change fixes a bug where entity discovery would find 0 devices despite coordinators having data. The issue was caused by `DeviceDiscoveryService` attempting to access a non-existent "devices" key in the `device_coordinator.data` dictionary. The service now correctly uses the `devices_by_serial` property which follows the Requirement R11 flat dictionary contract. Additionally, a validation check was added to `__init__.py` to log the count of discovered devices and issue a warning if none are found after the initial coordinator refresh. tests were also updated to match the current implementation.

Fixes #2375

---
*PR created automatically by Jules for task [10283691214291768739](https://jules.google.com/task/10283691214291768739) started by @brewmarsh*