### PR TITLE
Resilient Entity Discovery Refactor

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -7,6 +7,10 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
+from homeassistant.exceptions import HomeAssistantError
+
+from ...core.errors import MerakiHAException, MerakiInformationalError
+
 from ...const_conf import (
     CONF_ENABLE_CLIENT_STATUS_SENSORS,
     CONF_ENABLE_NETWORK_SENSORS,
@@ -70,8 +74,23 @@ class NetworkHandler(BaseHandler):
 
         for network in networks:
             for generator in generators:
-                async for entity in generator(network):
-                    yield entity
+                try:
+                    async for entity in generator(network):
+                        yield entity
+                except MerakiInformationalError as e:
+                    _LOGGER.info(
+                        "Optional feature '%s' is disabled for network %s: %s",
+                        generator.__name__,
+                        network.id,
+                        e,
+                    )
+                except (MerakiHAException, HomeAssistantError) as e:
+                    _LOGGER.error(
+                        "Error in discovery generator '%s' for network %s: %s",
+                        generator.__name__,
+                        network.id,
+                        e,
+                    )
 
     async def _discover_select_entities(
         self, network: MerakiNetwork

--- a/custom_components/meraki_ha/discovery/handlers/switch.py
+++ b/custom_components/meraki_ha/discovery/handlers/switch.py
@@ -11,6 +11,10 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
+from homeassistant.exceptions import HomeAssistantError
+
+from ...core.errors import MerakiHAException, MerakiInformationalError
+
 from ...const_conf import CONF_ENABLE_DEVICE_SENSORS, CONF_ENABLE_PORT_SENSORS
 from ...sensor.device.switch_client_count import MerakiSwitchClientCountSensor
 from ..providers import SwitchPortProvider
@@ -38,29 +42,45 @@ class SwitchHandler(BaseHandler):
                 return
 
             for device in devices:
-                if not hasattr(device, "product_type"):
-                    continue
+                try:
+                    if not hasattr(device, "product_type"):
+                        continue
 
-                # Add Exclusion Logic
-                if device.product_type == "appliance" or (
-                    device.model
-                    and (device.model.startswith("MX") or device.model.startswith("Z3"))
-                ):
-                    _LOGGER.debug(
-                        "Skipping device %s in Switch Handler (Appliance Handler)",
-                        device.serial,
-                    )
-                    continue
+                    # Add Exclusion Logic
+                    if device.product_type == "appliance" or (
+                        device.model
+                        and (
+                            device.model.startswith("MX") or device.model.startswith("Z3")
+                        )
+                    ):
+                        _LOGGER.debug(
+                            "Skipping device %s in Switch Handler (Appliance Handler)",
+                            device.serial,
+                        )
+                        continue
 
-                if device.product_type == "switch":
-                    # Client Count per Switch
-                    yield MerakiSwitchClientCountSensor(
-                        self._coordinator, device, self._config_entry
-                    )
-
-                    # Switch Ports
-                    if self._config_entry.options.get(CONF_ENABLE_PORT_SENSORS, True):
-                        for entity in SwitchPortProvider.get_entities(
+                    if device.product_type == "switch":
+                        # Client Count per Switch
+                        yield MerakiSwitchClientCountSensor(
                             self._coordinator, device, self._config_entry
-                        ):
-                            yield entity
+                        )
+
+                        # Switch Ports
+                        if self._config_entry.options.get(CONF_ENABLE_PORT_SENSORS, True):
+                            for entity in SwitchPortProvider.get_entities(
+                                self._coordinator, device, self._config_entry
+                            ):
+                                yield entity
+                except MerakiInformationalError as e:
+                    _LOGGER.info(
+                        "Optional feature for switch %s is disabled: %s",
+                        getattr(device, "serial", "unknown"),
+                        e,
+                    )
+                except (MerakiHAException, HomeAssistantError) as e:
+                    _LOGGER.error(
+                        "Error discovering entities for switch %s: %s",
+                        getattr(device, "serial", "unknown"),
+                        e,
+                    )
+                    continue

--- a/custom_components/meraki_ha/discovery/handlers/universal.py
+++ b/custom_components/meraki_ha/discovery/handlers/universal.py
@@ -6,6 +6,9 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.exceptions import HomeAssistantError
+
+from ...core.errors import MerakiHAException, MerakiInformationalError
 from ...button.device.mt15_refresh_data import MerakiMt15RefreshDataButton
 from ...button.reboot import MerakiRebootButton
 from ...const_conf import (
@@ -156,8 +159,23 @@ class UniversalHandler(BaseDeviceHandler):
     async def discover_entities(self) -> AsyncIterator[Entity]:
         """Discover entities based on capabilities."""
         for cap in self.capabilities:
-            async for entity in self._discover_capability(cap):
-                yield entity
+            try:
+                async for entity in self._discover_capability(cap):
+                    yield entity
+            except MerakiInformationalError as e:
+                _LOGGER.info(
+                    "Feature '%s' is disabled or unavailable for device %s: %s",
+                    cap,
+                    self.device.serial,
+                    e,
+                )
+            except (MerakiHAException, HomeAssistantError) as e:
+                _LOGGER.error(
+                    "Failed to discover capability '%s' for device %s: %s",
+                    cap,
+                    self.device.serial,
+                    e,
+                )
 
     async def _discover_capability(self, cap: str) -> AsyncIterator[Entity]:
         """Discover entities for a specific capability."""

--- a/custom_components/meraki_ha/discovery/handlers/wireless.py
+++ b/custom_components/meraki_ha/discovery/handlers/wireless.py
@@ -11,6 +11,9 @@ import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.exceptions import HomeAssistantError
+
+from ...core.errors import MerakiHAException, MerakiInformationalError
 from ...const_conf import (
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_ENABLE_SSID_SENSORS,
@@ -52,12 +55,18 @@ class WirelessHandler(BaseHandler):
             return
 
         # Discover AP Device entities
-        async for entity in self._discover_device_entities():
-            yield entity
+        try:
+            async for entity in self._discover_device_entities():
+                yield entity
+        except (MerakiHAException, HomeAssistantError) as e:
+            _LOGGER.error("Error during wireless device entity discovery: %s", e)
 
         # Discover SSID entities
-        async for entity in self._discover_ssid_entities():
-            yield entity
+        try:
+            async for entity in self._discover_ssid_entities():
+                yield entity
+        except (MerakiHAException, HomeAssistantError) as e:
+            _LOGGER.error("Error during SSID entity discovery: %s", e)
 
     async def _discover_device_entities(self) -> AsyncIterator[Entity]:
         """Discover entities for wireless devices."""
@@ -69,18 +78,26 @@ class WirelessHandler(BaseHandler):
             return
 
         for device in devices:
-            if not hasattr(device, "product_type"):
-                continue
-            if device.product_type == "wireless":
-                # Client Count per AP
-                yield MerakiAPClientCountSensor(
-                    self._coordinator, device, self._config_entry
-                )
-                # LED Control
-                if device.management_interface:
-                    yield MerakiDeviceLEDSwitch(
+            try:
+                if not hasattr(device, "product_type"):
+                    continue
+                if device.product_type == "wireless":
+                    # Client Count per AP
+                    yield MerakiAPClientCountSensor(
                         self._coordinator, device, self._config_entry
                     )
+                    # LED Control
+                    if device.management_interface:
+                        yield MerakiDeviceLEDSwitch(
+                            self._coordinator, device, self._config_entry
+                        )
+            except (MerakiHAException, HomeAssistantError) as e:
+                _LOGGER.error(
+                    "Error discovering entities for wireless device %s: %s",
+                    getattr(device, "serial", "unknown"),
+                    e,
+                )
+                continue
 
     async def _discover_ssid_entities(self) -> AsyncIterator[Entity]:
         """Discover entities for wireless SSIDs."""
@@ -98,53 +115,69 @@ class WirelessHandler(BaseHandler):
             return
 
         for ssid in ssids:
-            if (
-                not isinstance(ssid, dict)
-                or "networkId" not in ssid
-                or "number" not in ssid
-            ):
-                continue
+            try:
+                if (
+                    not isinstance(ssid, dict)
+                    or "networkId" not in ssid
+                    or "number" not in ssid
+                ):
+                    continue
 
-            rf_profile = self._get_rf_profile(ssid)
+                rf_profile = self._get_rf_profile(ssid)
 
-            yield MerakiSSIDEnabledSwitch(
-                self._coordinator,
-                self._meraki_client,
-                self._config_entry,
-                ssid,
-                rf_profile,
-            )
-            yield MerakiSSIDBroadcastSwitch(
-                self._coordinator,
-                self._meraki_client,
-                self._config_entry,
-                ssid,
-                rf_profile,
-            )
-            yield MerakiSSIDNameText(
-                self._coordinator,
-                self._meraki_client,
-                self._config_entry,
-                ssid,
-            )
-            yield MerakiSSIDClientCountSensor(
-                self._coordinator, self._config_entry, ssid
-            )
-
-            if ssid.get("ipAssignmentMode") == "NAT mode":
-                yield MerakiAdultContentFilteringSwitch(
+                yield MerakiSSIDEnabledSwitch(
                     self._coordinator,
+                    self._meraki_client,
+                    self._config_entry,
+                    ssid,
+                    rf_profile,
+                )
+                yield MerakiSSIDBroadcastSwitch(
+                    self._coordinator,
+                    self._meraki_client,
+                    self._config_entry,
+                    ssid,
+                    rf_profile,
+                )
+                yield MerakiSSIDNameText(
+                    self._coordinator,
+                    self._meraki_client,
                     self._config_entry,
                     ssid,
                 )
+                yield MerakiSSIDClientCountSensor(
+                    self._coordinator, self._config_entry, ssid
+                )
 
-            # RF Profile Select
-            yield MerakiRFProfileSelect(
-                self._coordinator,
-                self._meraki_client,
-                self._config_entry,
-                ssid,
-            )
+                if ssid.get("ipAssignmentMode") == "NAT mode":
+                    yield MerakiAdultContentFilteringSwitch(
+                        self._coordinator,
+                        self._config_entry,
+                        ssid,
+                    )
+
+                # RF Profile Select
+                yield MerakiRFProfileSelect(
+                    self._coordinator,
+                    self._meraki_client,
+                    self._config_entry,
+                    ssid,
+                )
+            except MerakiInformationalError as e:
+                _LOGGER.info(
+                    "Optional feature for SSID %s (network %s) is disabled: %s",
+                    ssid.get("name", "unknown"),
+                    ssid.get("networkId", "unknown"),
+                    e,
+                )
+            except (MerakiHAException, HomeAssistantError) as e:
+                _LOGGER.error(
+                    "Error discovering entities for SSID %s (network %s): %s",
+                    ssid.get("name", "unknown"),
+                    ssid.get("networkId", "unknown"),
+                    e,
+                )
+                continue
 
     def _get_rf_profile(self, ssid: dict[str, Any]) -> dict[str, Any] | None:
         """Find the RF profile for this SSID's network."""

--- a/custom_components/meraki_ha/discovery/service.py
+++ b/custom_components/meraki_ha/discovery/service.py
@@ -15,6 +15,9 @@ from ..const_conf import (
     CONF_ENABLE_NETWORK_SENSORS,
 )
 from ..core.models.device import MerakiDevice
+from homeassistant.exceptions import HomeAssistantError
+
+from ..core.errors import MerakiHAException, MerakiInformationalError
 from .handlers.network import NetworkHandler
 from .handlers.switch import SwitchHandler
 from .handlers.universal import UniversalHandler
@@ -94,24 +97,36 @@ class DeviceDiscoveryService:
         all_entities: list[Entity] = []
 
         # Discover network-level entities
-        async for entity in self._discover_network_entities():
-            all_entities.append(entity)
+        try:
+            async for entity in self._discover_network_entities():
+                all_entities.append(entity)
+        except (MerakiHAException, HomeAssistantError) as e:
+            _LOGGER.error("Failed to discover network entities: %s", e)
 
         # Discover device-level entities
-        async for entity in self._discover_device_entities():
-            all_entities.append(entity)
+        try:
+            async for entity in self._discover_device_entities():
+                all_entities.append(entity)
+        except (MerakiHAException, HomeAssistantError) as e:
+            _LOGGER.error("Failed to discover device entities: %s", e)
 
         # Create Wireless handler for devices and virtual SSID devices
-        wireless_handler = WirelessHandler(
-            self._wireless_coordinator, self._config_entry, self._meraki_client
-        )
-        async for entity in wireless_handler.discover_entities():
-            all_entities.append(entity)
+        try:
+            wireless_handler = WirelessHandler(
+                self._wireless_coordinator, self._config_entry, self._meraki_client
+            )
+            async for entity in wireless_handler.discover_entities():
+                all_entities.append(entity)
+        except (MerakiHAException, HomeAssistantError) as e:
+            _LOGGER.error("Failed to discover wireless entities: %s", e)
 
         # Create Switch handler for switch devices
-        switch_handler = SwitchHandler(self._switch_coordinator, self._config_entry)
-        async for entity in switch_handler.discover_entities():
-            all_entities.append(entity)
+        try:
+            switch_handler = SwitchHandler(self._switch_coordinator, self._config_entry)
+            async for entity in switch_handler.discover_entities():
+                all_entities.append(entity)
+        except (MerakiHAException, HomeAssistantError) as e:
+            _LOGGER.error("Failed to discover switch entities: %s", e)
 
         _LOGGER.info("Entity discovery complete. Found %d entities.", len(all_entities))
         self.all_entities = all_entities
@@ -125,8 +140,11 @@ class DeviceDiscoveryService:
                 self._config_entry,
                 self._network_control_service,
             )
-            async for entity in network_handler.discover_entities():
-                yield entity
+            try:
+                async for entity in network_handler.discover_entities():
+                    yield entity
+            except (MerakiHAException, HomeAssistantError) as e:
+                _LOGGER.error("Error during network entity discovery: %s", e)
         else:
             _LOGGER.debug("Network sensors are disabled.")
 
@@ -141,21 +159,27 @@ class DeviceDiscoveryService:
                 _LOGGER.warning("Device %s has no model, skipping", device.serial)
                 continue
 
-            coordinator = self._get_coordinator_for_device(device)
+            try:
+                coordinator = self._get_coordinator_for_device(device)
 
-            handler = UniversalHandler(
-                coordinator,
-                device,
-                self._config_entry,
-                self._camera_service,
-                self._control_service,
-                self._network_control_service,
-                status_coordinator=self._device_coordinator,
-                sensor_coordinator=self._sensor_coordinator,
-            )
+                handler = UniversalHandler(
+                    coordinator,
+                    device,
+                    self._config_entry,
+                    self._camera_service,
+                    self._control_service,
+                    self._network_control_service,
+                    status_coordinator=self._device_coordinator,
+                    sensor_coordinator=self._sensor_coordinator,
+                )
 
-            async for entity in handler.discover_entities():
-                yield entity
+                async for entity in handler.discover_entities():
+                    yield entity
+            except (MerakiHAException, HomeAssistantError) as e:
+                _LOGGER.error(
+                    "Error discovering entities for device %s: %s", device.serial, e
+                )
+                continue
 
     def _get_coordinator_for_device(self, device: MerakiDevice):
         """Select coordinator based on product type."""

--- a/tests/discovery/test_resilience.py
+++ b/tests/discovery/test_resilience.py
@@ -1,0 +1,103 @@
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from custom_components.meraki_ha.discovery.service import DeviceDiscoveryService
+from custom_components.meraki_ha.core.errors import MerakiInformationalError, MerakiHAException
+from homeassistant.exceptions import HomeAssistantError
+
+@pytest.mark.asyncio
+async def test_discovery_service_resilience(hass):
+    """Test that discovery service continues even if one handler fails."""
+    # Mock all coordinators
+    mock_coordinators = {
+        name: MagicMock() for name in [
+            "main_coordinator", "device_coordinator", "switch_coordinator",
+            "camera_coordinator", "sensor_coordinator", "wireless_coordinator",
+            "appliance_coordinator", "client_coordinator"
+        ]
+    }
+
+    # Setup device_coordinator to return some devices
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    mock_device.model = "MODEL1"
+    mock_device.product_type = "wireless"
+    mock_coordinators["device_coordinator"].devices_by_serial = {"SERIAL1": mock_device}
+
+    # Mock config entry and other services
+    mock_config_entry = MagicMock()
+    mock_config_entry.options = {}
+    mock_meraki_client = MagicMock()
+    mock_camera_service = MagicMock()
+    mock_control_service = MagicMock()
+    mock_network_control_service = MagicMock()
+
+    service = DeviceDiscoveryService(
+        **mock_coordinators,
+        config_entry=mock_config_entry,
+        meraki_client=mock_meraki_client,
+        camera_service=mock_camera_service,
+        control_service=mock_control_service,
+        network_control_service=mock_network_control_service
+    )
+
+    # Patch _discover_network_entities to fail
+    with patch.object(service, "_discover_network_entities") as mock_net:
+        # Use an async generator that raises an error
+        async def async_gen_fail():
+            raise MerakiHAException("Network discovery failed")
+            yield # Keep it a generator
+
+        mock_net.side_effect = async_gen_fail
+
+        # Patch UniversalHandler to return one entity
+        with patch("custom_components.meraki_ha.discovery.service.UniversalHandler") as mock_handler_class:
+            mock_handler = MagicMock()
+            async def async_gen_entity():
+                yield MagicMock()
+            mock_handler.discover_entities.side_effect = async_gen_entity
+            mock_handler_class.return_value = mock_handler
+
+            entities = await service.discover_entities()
+
+            # Should have entities from device discovery despite network failure
+            assert len(entities) > 0
+            mock_net.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_universal_handler_resilience(hass):
+    """Test that UniversalHandler continues even if one capability fails."""
+    from custom_components.meraki_ha.discovery.handlers.universal import UniversalHandler
+
+    mock_coordinator = MagicMock()
+    mock_device = MagicMock()
+    mock_device.serial = "SERIAL1"
+    mock_device.model = "MR33"
+    mock_device.product_type = "wireless"
+
+    mock_config_entry = MagicMock()
+    mock_config_entry.options = {}
+
+    handler = UniversalHandler(
+        mock_coordinator,
+        mock_device,
+        mock_config_entry,
+        MagicMock(), MagicMock(), MagicMock()
+    )
+
+    # Set capabilities
+    handler.capabilities = ["status", "wireless"]
+
+    # Mock _discover_capability to fail for "status" but succeed for "wireless"
+    async def mock_discover_cap(cap):
+        if cap == "status":
+            raise MerakiInformationalError("Status disabled")
+        if cap == "wireless":
+            yield MagicMock()
+
+    with patch.object(handler, "_discover_capability", side_effect=mock_discover_cap):
+        entities = []
+        async for entity in handler.discover_entities():
+            entities.append(entity)
+
+        assert len(entities) == 1


### PR DESCRIPTION
The Meraki integration's discovery service was refactored to be non-blocking when encountering API errors for optional or disabled features. High-level loops in `DeviceDiscoveryService` and granular loops in specific handlers were wrapped in `try...except` blocks. Informational errors are logged at the `INFO` level, while more critical failures are logged at the `ERROR` level, ensuring discovery continues for all available entities. Unit tests were added to confirm that discovery remains robust even when individual components fail.

Fixes #2377

---
*PR created automatically by Jules for task [5031211012330804122](https://jules.google.com/task/5031211012330804122) started by @brewmarsh*