### PR TITLE
Improve CI Error Capture and Playwright Reporting

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -51,11 +51,23 @@ jobs:
 
       - name: Run E2E tests
         working-directory: frontend
+        shell: bash
         env:
           HA_URL: ${{ secrets.HA_STAGING_URL }}
           HA_USERNAME: ${{ secrets.HA_STAGING_USERNAME }}
           HA_PASSWORD: ${{ secrets.HA_STAGING_PASSWORD }}
-        run: npm run test:e2e
+        run: |
+          # Use pipefail to ensure 'exit 1' if the first command in the pipe fails
+          set -o pipefail
+          if ! npm run test:e2e 2>&1 | tee playwright_output.txt; then
+            echo "FAILED_STEP_NAME=Run E2E tests" >> $GITHUB_ENV
+            {
+              echo "CI_ERROR_DETAILS<<EOF"
+              cat playwright_output.txt
+              echo "EOF"
+            } >> $GITHUB_ENV
+            exit 1
+          fi
 
       - name: Verify build artifacts
         shell: bash
@@ -193,58 +205,19 @@ jobs:
             echo "All Meraki entities are fully available."
           fi
 
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-trace
+          path: frontend/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Create Issue on Failure
         if: failure()
         uses: actions/github-script@v7
         with:
           script: |
-            const title = '🚨 Staging Smoke Test Failed';
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-            });
-
-            const existingIssue = issues.find(issue => issue.title === title);
-            if (existingIssue) {
-              console.log(`Issue already exists: ${existingIssue.html_url}`);
-              return;
-            }
-
-            const failedStep = process.env.FAILED_STEP_NAME || 'Unknown Step';
-            let errorDetails = process.env.CI_ERROR_DETAILS || 'No details captured.';
-
-            // Parse Python-style array strings into clean Markdown lists
-            if (errorDetails.startsWith('[') && errorDetails.endsWith(']')) {
-              try {
-                const items = errorDetails.slice(1, -1).split(',').map(s => s.trim().replace(/^'|'$/g, '').replace(/^"|"$/g, ''));
-                if (items.length > 0 && items[0] !== "") {
-                   errorDetails = items.map(item => `- \`${item}\``).join('\n');
-                }
-              } catch (e) {
-                errorDetails = `\`\`\`text\n${errorDetails}\n\`\`\``;
-              }
-            } else {
-              errorDetails = `\`\`\`text\n${errorDetails}\n\`\`\``;
-            }
-
-            const commitSha = context.sha.substring(0, 7);
-            const branch = context.ref.replace('refs/heads/', '');
-            const actor = context.actor;
-
-            const body = `The deployment to the staging environment failed.\n\n` +
-                         `### ❌ Failed Step: \`${failedStep}\`\n\n` +
-                         `### 📋 Error Details\n${errorDetails}\n\n` +
-                         `---\n### 🔍 Contextual Traceability\n` +
-                         `- **Commit:** [\`${commitSha}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha})\n` +
-                         `- **Branch:** \`${branch}\`\n` +
-                         `- **Triggered by:** @${actor}\n\n` +
-                         `[🔗 View full failing run details](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: title,
-              body: body,
-              labels: ['bug', 'automated-ci', 'jules']
-            });
+            const script = require('./scripts/generate_failure_issue.js');
+            await script({github, context});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.HA_URL || 'http://localhost:8123',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Collect trace on failure. See https://playwright.dev/docs/trace-viewer */
+    trace: 'retain-on-failure',
 
     /* Standard viewport */
     viewport: { width: 1280, height: 720 },

--- a/scripts/generate_failure_issue.js
+++ b/scripts/generate_failure_issue.js
@@ -1,0 +1,69 @@
+module.exports = async ({ github, context }) => {
+  const title = '🚨 Staging Smoke Test Failed';
+  const { data: issues } = await github.rest.issues.listForRepo({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    state: 'open',
+  });
+
+  const existingIssue = issues.find((issue) => issue.title === title);
+  if (existingIssue) {
+    console.log(`Issue already exists: ${existingIssue.html_url}`);
+    return;
+  }
+
+  const failedStep = process.env.FAILED_STEP_NAME || 'Unknown Step';
+  let errorDetails = process.env.CI_ERROR_DETAILS || 'No details captured.';
+
+  // Special handling for HA_USERNAME error
+  if (errorDetails.includes('HA_USERNAME and HA_PASSWORD environment variables must be set')) {
+    errorDetails =
+      '❌ **Missing Credentials:** Playwright tests failed because `HA_USERNAME` and `HA_PASSWORD` are not set in the environment.\n\n' +
+      'Please ensure these secrets are correctly configured in the repository settings and passed to the workflow.';
+  } else if (errorDetails.startsWith('[') && errorDetails.endsWith(']')) {
+    // Parse Python-style array strings into clean Markdown lists
+    try {
+      const items = errorDetails
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim().replace(/^'|'$/g, '').replace(/^"|"$/g, ''));
+      if (items.length > 0 && items[0] !== '') {
+        errorDetails = items.map((item) => `- \`${item}\``).join('\n');
+      }
+    } catch (e) {
+      errorDetails = `\`\`\`text\n${errorDetails}\n\`\`\``;
+    }
+  } else {
+    errorDetails = `\`\`\`text\n${errorDetails}\n\`\`\``;
+  }
+
+  const commitSha = context.sha.substring(0, 7);
+  const branch = context.ref.replace('refs/heads/', '');
+  const actor = context.actor;
+
+  let body =
+    `The deployment to the staging environment failed.\n\n` +
+    `### ❌ Failed Step: \`${failedStep}\`\n\n` +
+    `### 📋 Error Details\n${errorDetails}\n\n`;
+
+  if (failedStep === 'Run E2E tests') {
+    body +=
+      `### 🕵️ Playwright Trace\n` +
+      `A Playwright trace has been recorded. You can download the \`playwright-trace\` artifact from the **Artifacts** section of this workflow run and view it at [trace.playwright.dev](https://trace.playwright.dev/).\n\n`;
+  }
+
+  body +=
+    `---\n### 🔍 Contextual Traceability\n` +
+    `- **Commit:** [\`${commitSha}\`](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha})\n` +
+    `- **Branch:** \`${branch}\`\n` +
+    `- **Triggered by:** @${actor}\n\n` +
+    `[🔗 View full failing run details](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+
+  await github.rest.issues.create({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    title: title,
+    body: body,
+    labels: ['bug', 'automated-ci', 'jules'],
+  });
+};


### PR DESCRIPTION
This PR improves the automated error reporting for the staging smoke tests. It ensures that failures in the Playwright E2E tests are captured and reported in the resulting GitHub Issue with full logs and a link to the Playwright trace artifact. It also adds specific handling for the common "missing credentials" error to provide actionable feedback.

Fixes #2395

---
*PR created automatically by Jules for task [4785650129152844819](https://jules.google.com/task/4785650129152844819) started by @brewmarsh*