### PR TITLE
Fix Playwright environment variable visibility and reporting

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+playwright-report/
+test-results/
+.env

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.HA_URL || 'http://localhost:8123',
 
+    /* Standard timeout for individual actions to account for potentially slow staging server responses */
+    actionTimeout: 10000,
+
     /* Collect trace on failure. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
 

--- a/frontend/tests/dashboard.spec.ts
+++ b/frontend/tests/dashboard.spec.ts
@@ -1,11 +1,17 @@
 import { test, expect } from '@playwright/test';
 
 test('Dashboard cards render without errors', async ({ page }) => {
+  // Debug log to confirm which variables are reaching the process
+  console.log('Environment HA_ keys:', Object.keys(process.env).filter(k => k.startsWith('HA_')));
+
   const username = process.env.HA_USERNAME;
   const password = process.env.HA_PASSWORD;
 
-  if (!username || !password) {
-    throw new Error('HA_USERNAME and HA_PASSWORD environment variables must be set');
+  if (!username) {
+    throw new Error('HA_USERNAME environment variable must be set');
+  }
+  if (!password) {
+    throw new Error('HA_PASSWORD environment variable must be set');
   }
 
   // Go to Home Assistant login page


### PR DESCRIPTION
This PR addresses the issue where Playwright E2E tests on the staging server were failing due to missing environment variables. 

Key improvements:
1. **Diagnostics**: Added a sanitized debug log in `frontend/tests/dashboard.spec.ts` that prints the keys of available `HA_` environment variables. This allows us to verify variable propagation in CI logs without exposing secrets.
2. **Error Handling**: Updated the test validation to throw specific errors when `HA_USERNAME` or `HA_PASSWORD` is missing, making it immediately clear which variable is failing to load.
3. **Reliability**: Set an `actionTimeout` of 10,000ms in `frontend/playwright.config.ts` to better handle potential latency on the staging environment.
4. **Hygiene**: Created a `frontend/.gitignore` to ensure transient artifacts like `playwright-report/` and `test-results/` are not tracked in the repository.

Fixes #2402

---
*PR created automatically by Jules for task [17787843780310742930](https://jules.google.com/task/17787843780310742930) started by @brewmarsh*