### PR TITLE
Fix Playwright testing URL and add card assertions

### DIFF
--- a/frontend/tests/dashboard.spec.ts
+++ b/frontend/tests/dashboard.spec.ts
@@ -6,6 +6,7 @@ test('Dashboard cards render without errors', async ({ page }) => {
 
   const username = process.env.HA_USERNAME;
   const password = process.env.HA_PASSWORD;
+  const baseUrl = process.env.HA_URL || 'http://localhost:8123';
 
   if (!username) {
     throw new Error('HA_USERNAME environment variable must be set');
@@ -15,7 +16,7 @@ test('Dashboard cards render without errors', async ({ page }) => {
   }
 
   // Go to Home Assistant login page
-  await page.goto('/');
+  await page.goto(baseUrl);
 
   // Check if we are already logged in or if we need to log in
   if (page.url().includes('/auth/login')) {
@@ -25,20 +26,34 @@ test('Dashboard cards render without errors', async ({ page }) => {
     await page.click('button[type="submit"]');
   }
 
-  // Navigate to the dashboard
-  await page.goto('/lovelace/0');
+  // Navigate to the specific staging dashboard view
+  const targetUrl = `${baseUrl.replace(/\/$/, '')}/card-testing/meraki`;
+  await page.goto(targetUrl);
 
-  // Wait for the dashboard to settle
+  // Wait for the dashboard to settle and the specific card to render
   await page.waitForLoadState('networkidle');
 
-  // Assert no error cards are present
+  // Requirement: Ensure the test waits for the Lit element to finish rendering
+  const cardSelector = 'custom-meraki-network-vitals-card';
+  await page.waitForSelector(cardSelector, { state: 'visible', timeout: 15000 });
+
+  // Assertions
+
+  // 1. Verify that the 'Meraki Network Vitals' card is visible
+  const vitalsCard = page.locator(cardSelector);
+  await expect(vitalsCard).toBeVisible();
+
+  // 2. Also verify via text-based selector as a fallback/secondary check
+  await expect(page.getByText('Network Status', { exact: false })).toBeVisible();
+
+  // 3. Assert no error cards are present
   // Home Assistant uses <hui-error-card> for cards that fail to load
   const errorCards = page.locator('hui-error-card');
   await expect(errorCards).toHaveCount(0, { message: 'Found an error card on the dashboard!' });
 
-  // Also check for the text "Entity not found" which is common when entities are missing
+  // 4. Also check for the text "Entity not found" which is common when entities are missing
   await expect(page.getByText('Entity not found')).toHaveCount(0, { message: 'Found "Entity not found" text on the dashboard!' });
 
-  // Optional: check for "Custom element doesn't exist" which happens if the card isn't registered
+  // 5. Optional: check for "Custom element doesn't exist" which happens if the card isn't registered
   await expect(page.getByText("Custom element doesn't exist")).toHaveCount(0, { message: 'A custom card element was not found/registered!' });
 });


### PR DESCRIPTION
Updated the Playwright dashboard test to align with the new staging dashboard structure. The test now navigates to the specific `/card-testing/meraki` slug and verifies the visibility of the 'Meraki Network Vitals' card using both its custom element selector and text-based content. Added robust waiting logic to ensure the web component is fully rendered before assertions are performed.

Fixes #2406

---
*PR created automatically by Jules for task [7483797593983751746](https://jules.google.com/task/7483797593983751746) started by @brewmarsh*