### PR TITLE
Restore organization_id and fix CI log reporting

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -135,7 +135,9 @@ jobs:
           echo "Extracting logs from Home Assistant API..."
           curl -sS -H "Authorization: Bearer $HA_TOKEN" \
                -H "Content-Type: application/json" \
-               "$HA_URL/api/error_log" > full_ha_log.txt || { echo "Failed to fetch logs from API"; exit 1; }
+               "$HA_URL/api/error_log" > "${{ env.HA_CONFIG_DIR }}/home-assistant.log" || { echo "Failed to fetch logs from API"; exit 1; }
+          sudo chmod 666 "${{ env.HA_CONFIG_DIR }}/home-assistant.log"
+          cp "${{ env.HA_CONFIG_DIR }}/home-assistant.log" full_ha_log.txt
 
           # Stage 1 & 2: Search for Tracebacks or specific Python errors mentioning meraki
           if grep -i -E "traceback|attributeerror|nameerror|typeerror" full_ha_log.txt | grep -i "meraki" > /dev/null; then

--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_API_KEY
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
@@ -13,17 +12,14 @@ from .const.config import (
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_ENABLE_DEVICE_STATUS,
     CONF_ENABLE_PORT_SENSORS,
+    CONF_MERAKI_API_KEY,
+    CONF_MERAKI_ORG_ID,
 )
 from .const.integration import DOMAIN
 from .core.api.client import MerakiClient
+from .schemas import STEP_USER_DATA_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
-
-DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_API_KEY): selector.TextSelector(
-        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-    )
-})
 
 class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Meraki."""
@@ -37,7 +33,11 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 # Validation logic using the updated Client name
-                client = MerakiClient(self.hass, user_input[CONF_API_KEY])
+                client = MerakiClient(
+                    self.hass,
+                    user_input[CONF_MERAKI_API_KEY],
+                    user_input.get(CONF_MERAKI_ORG_ID),
+                )
                 await client.async_setup()
                 await client.get_organizations()
             except Exception:  # pylint: disable=broad-except
@@ -47,7 +47,7 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title="Meraki", data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
     @staticmethod

--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -142,10 +142,21 @@ class DataFetchManager:
         from ..models.network import MerakiNetwork
 
         networks_raw = batch_data.get("networks") or []
-        data["networks"] = [
-            MerakiNetwork.from_dict(n) if isinstance(n, dict) else n
-            for n in networks_raw
-        ]
+        org_id = None
+        if org_dict := batch_data.get("organization"):
+            if isinstance(org_dict, dict):
+                org_id = org_dict.get("id")
+
+        processed_networks = []
+        for n in networks_raw:
+            if isinstance(n, dict):
+                if org_id and not n.get("organizationId"):
+                    n["organizationId"] = org_id
+                processed_networks.append(MerakiNetwork.from_dict(n))
+            else:
+                processed_networks.append(n)
+
+        data["networks"] = processed_networks
 
     def _distribute_devices(
         self, data: dict[str, Any], batch_data: dict[str, Any]

--- a/custom_components/meraki_ha/schemas.py
+++ b/custom_components/meraki_ha/schemas.py
@@ -52,6 +52,15 @@ CONFIG_SCHEMA = vol.Schema(
     }
 )
 
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MERAKI_API_KEY): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
+        vol.Required(CONF_MERAKI_ORG_ID): selector.TextSelector(),
+    }
+)
+
 OPTIONS_SCHEMA_GENERAL = vol.Schema(
     {
         vol.Required(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ from custom_components.meraki_ha.const.config import (
     CONF_ENABLE_CAMERA_ENTITIES,
     CONF_ENABLE_DEVICE_STATUS,
     CONF_MERAKI_API_KEY,
+    CONF_MERAKI_ORG_ID,
 )
 from homeassistant import config_entries, setup
 from homeassistant.core import HomeAssistant
@@ -44,7 +45,8 @@ async def test_form(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "api_key": "test-api-key",
+                CONF_MERAKI_API_KEY: "test-api-key",
+                CONF_MERAKI_ORG_ID: "test-org-id",
             },
         )
         await hass.async_block_till_done()
@@ -52,7 +54,8 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "Meraki"
     assert result2["data"] == {
-        "api_key": "test-api-key",
+        CONF_MERAKI_API_KEY: "test-api-key",
+        CONF_MERAKI_ORG_ID: "test-org-id",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -70,7 +73,8 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "api_key": "test-api-key",
+                CONF_MERAKI_API_KEY: "test-api-key",
+                CONF_MERAKI_ORG_ID: "test-org-id",
             },
         )
 


### PR DESCRIPTION
This PR addresses critical regressions in the Meraki integration:
1.  **Schema Restoration**: Re-added `organization_id` to `STEP_USER_DATA_SCHEMA` in `schemas.py` and updated `config_flow.py` to collect it.
2.  **Discovery Fix**: Enhanced `DataFetchManager` in `data_fetcher.py` to ensure every `MerakiNetwork` instance receives an `organization_id`, which is required for network-level entity creation.
3.  **CI Reliability**: Updated `deploy-staging.yaml` with a "Dual-Source Log Strategy", ensuring logs are correctly fetched from the HA API and stored in the expected location for the audit steps.
4.  **Verification**: Updated `tests/test_config_flow.py` to cover the new schema requirements and fixed a missing import in `config_flow.py`.

Fixes #2427

---
*PR created automatically by Jules for task [11712060571413466575](https://jules.google.com/task/11712060571413466575) started by @brewmarsh*