### PR TITLE
Integrate Braintrust for Meraki HA Observability

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from functools import partial
 from typing import Any, cast
 
+import braintrust
 import meraki
+from dotenv import load_dotenv
 from homeassistant.core import HomeAssistant
 
 from ...core.errors import (
@@ -34,6 +37,11 @@ from .protocol import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Initialize Braintrust for observability
+load_dotenv()
+if os.getenv("BRAINTRUST_API_KEY"):
+    braintrust.init(project="Meraki HA", api_key=os.getenv("BRAINTRUST_API_KEY"))
 
 
 class MerakiClient:
@@ -108,6 +116,7 @@ class MerakiClient:
                 )
             )
 
+    @braintrust.traced
     async def run_sync(
         self,
         func: Callable[..., Any],
@@ -127,6 +136,20 @@ class MerakiClient:
             The result of the function.
 
         """
+        # Extract metadata for Braintrust
+        org_id = kwargs.get("organizationId") or self.organization_id
+        serial = kwargs.get("serial") or kwargs.get("deviceSerial")
+        if not serial and args and isinstance(args[0], str):
+            # Many Meraki calls have serial as the first positional argument
+            serial = args[0]
+
+        braintrust.current_span().log(
+            metadata={
+                "organization_id": org_id,
+                "device_serial": serial,
+            }
+        )
+
         async with self._semaphore:
             try:
                 loop = asyncio.get_event_loop()
@@ -134,6 +157,19 @@ class MerakiClient:
                     None, partial(func, *args, **kwargs)
                 )
             except meraki.APIError as e:
+                # Log error details to Braintrust
+                braintrust.current_span().log(
+                    metadata={
+                        "error_message": str(e),
+                        "status_code": getattr(e, "status", None),
+                        "meraki_request_id": (
+                            e.response.headers.get("X-Cisco-Meraki-API-Request-Id")
+                            if e.response is not None and hasattr(e.response, "headers")
+                            else None
+                        ),
+                    }
+                )
+
                 error_msg = str(e)
                 if (
                     "Traffic Analysis with Hostname Visibility" in error_msg

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -39,10 +39,12 @@
     "aiodns>=4.0.0",
     "aiofiles>=24.1.0",
     "aiohttp>=3.11.11",
+    "braintrust",
     "diskcache==5.6.3",
     "meraki==1.54.0",
     "orjson>=3.9.0",
     "pycares>=4.11.0",
+    "python-dotenv",
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],

--- a/custom_components/meraki_ha/requirements.txt
+++ b/custom_components/meraki_ha/requirements.txt
@@ -1,10 +1,12 @@
 aiodns>=4.0.0
 aiofiles>=24.1.0
 aiohttp==3.11.11
+braintrust
 diskcache==5.6.3
 meraki==1.54.0
 orjson>=3.9.0
 pycares>=4.11.0
+python-dotenv
 urllib3>=1.26.5
 webrtc-models==0.3.0
 pytest==8.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiodns>=4.0.0
 aiofiles>=24.1.0
 aiohttp>=3.11.11
 bandit==1.7.9
+braintrust
 codecov
 diskcache==5.6.3
 filelock==3.20.3
@@ -18,6 +19,7 @@ pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
 pycares>=4.11.0
+python-dotenv
 pytest-asyncio
 pytest-cov
 pytest-mock


### PR DESCRIPTION
This PR integrates Braintrust (BoundaryML) into the Meraki HA core API client to improve observability and debugging. It instruments the `run_sync` method with Braintrust tracing, captures organization and device metadata, and logs detailed error context (including Meraki Request IDs) during API failures.

Fixes #2412

---
*PR created automatically by Jules for task [4376806436587859628](https://jules.google.com/task/4376806436587859628) started by @brewmarsh*