### PR TITLE
Fix Missing Network Entities via Org ID Propagation

### DIFF
--- a/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
+++ b/custom_components/meraki_ha/core/coordinator_helpers/data_fetcher.py
@@ -142,10 +142,16 @@ class DataFetchManager:
         from ..models.network import MerakiNetwork
 
         networks_raw = batch_data.get("networks") or []
-        data["networks"] = [
-            MerakiNetwork.from_dict(n) if isinstance(n, dict) else n
-            for n in networks_raw
-        ]
+        networks = []
+        for n in networks_raw:
+            if isinstance(n, dict):
+                # Ensure organization_id is propagated if missing from API
+                if not n.get("organizationId"):
+                    n["organizationId"] = self.client.organization_id
+                networks.append(MerakiNetwork.from_dict(n))
+            else:
+                networks.append(n)
+        data["networks"] = networks
 
     def _distribute_devices(
         self, data: dict[str, Any], batch_data: dict[str, Any]

--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -16,6 +16,7 @@ from custom_components.meraki_ha.const.config import (
 )
 from ...sensor.network.network_clients import MerakiNetworkClientsSensor
 from ...sensor.network.traffic_shaping import TrafficShapingSensor
+from ...types import MerakiNetwork
 from .base import BaseHandler
 
 if TYPE_CHECKING:
@@ -48,7 +49,19 @@ class NetworkHandler(BaseHandler):
         if not self._config_entry.options.get(CONF_ENABLE_NETWORK_SENSORS, True):
             _LOGGER.debug("Network sensors are disabled.")
             return []
-        return self._coordinator.data.get("networks", [])
+
+        networks = self._coordinator.data.get("networks", [])
+        if not networks:
+            return []
+
+        # Filter networks by organization ID to ensure we only discover
+        # entities for the current organization.
+        org_id = self._coordinator.api.organization_id
+        return [
+            n
+            for n in networks
+            if isinstance(n, MerakiNetwork) and n.organization_id == org_id
+        ]
 
     async def discover_entities(self) -> AsyncIterator[Entity]:
         """Discover network-level entities."""

--- a/tests/discovery/handlers/test_network.py
+++ b/tests/discovery/handlers/test_network.py
@@ -18,7 +18,7 @@ from custom_components.meraki_ha.sensor.network.network_clients import (
 from custom_components.meraki_ha.sensor.network.vlan import MerakiVLANStatusSensor
 from custom_components.meraki_ha.types import MerakiNetwork
 
-from ..const import MOCK_CONFIG_ENTRY
+from ...const import MOCK_CONFIG_ENTRY
 
 MOCK_NETWORK_1 = MerakiNetwork(
     id="N_1234", name="Network 1", organization_id="org1", product_types=["wireless"]
@@ -32,6 +32,7 @@ MOCK_NETWORK_2 = MerakiNetwork(
 def mock_coordinator():
     """Fixture for a mock MerakiMainCoordinator."""
     coordinator = MagicMock()
+    coordinator.api.organization_id = "org1"
     coordinator.data = {
         "networks": [MOCK_NETWORK_1, MOCK_NETWORK_2],
         "vlans": {

--- a/tests/discovery/test_service.py
+++ b/tests/discovery/test_service.py
@@ -154,4 +154,6 @@ async def test_discover_entities_delegates_to_handler(
             mock_camera_service,
             mock_control_service,
             mock_network_control_service,
+            status_coordinator=mock_coordinator_with_devices,
+            sensor_coordinator=mock_coordinator_with_devices,
         )


### PR DESCRIPTION
This change fixes the issue where network-level entities (Buttons, Selects, SSIDs) were not being discovered because MerakiNetwork models were missing their 'organization_id', causing them to be filtered out during discovery.

Key changes:
1.  **data_fetcher.py**: Injected the client's `organization_id` into the raw network data if it's not provided by the API during batch distribution.
2.  **network.py**: Updated `_get_networks` to strictly filter networks by the coordinator's `organization_id`.
3.  **tests**: Updated `test_network.py` and `test_service.py` to correctly mock `organization_id` and match the updated handler signatures, ensuring discovery logic is properly verified.

Fixes #2425

---
*PR created automatically by Jules for task [12719621313995764815](https://jules.google.com/task/12719621313995764815) started by @brewmarsh*