### PR TITLE
Fix Config Flow: Implement MerakiClient Composition

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -16,7 +16,7 @@ from .const.config import (
     CONF_MERAKI_ORG_ID,
 )
 from .const.integration import DOMAIN
-from .core.api.client import MerakiClient
+from .core.api import create_api_client
 from .schemas import STEP_USER_DATA_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 # Validation logic using the updated Client name
-                client = MerakiClient(
+                client = create_api_client(
                     self.hass,
                     user_input[CONF_MERAKI_API_KEY],
                     user_input.get(CONF_MERAKI_ORG_ID),

--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -25,6 +25,14 @@ from ...core.errors import (
     MerakiTrafficAnalysisError,
     MerakiVlansDisabledError,
 )
+from .endpoints.appliance import ApplianceEndpoints
+from .endpoints.camera import CameraEndpoints
+from .endpoints.devices import DevicesEndpoints
+from .endpoints.network import NetworkEndpoints
+from .endpoints.organization import OrganizationEndpoints
+from .endpoints.sensor import SensorEndpoints
+from .endpoints.switch import SwitchEndpoints
+from .endpoints.wireless import WirelessEndpoints
 from .protocol import (
     ApplianceEndpointsProtocol,
     CameraEndpointsProtocol,
@@ -93,6 +101,16 @@ class MerakiClient:
         # Set of disabled features to prevent repetitive API calls
         self._disabled_features: set[str] = set()
         self._enable_vpn_management = False
+
+        # Initialize endpoint handlers
+        self.appliance = ApplianceEndpoints(self, hass)
+        self.camera = CameraEndpoints(self)
+        self.devices = DevicesEndpoints(self)
+        self.network = NetworkEndpoints(self)
+        self.organization = OrganizationEndpoints(self)
+        self.switch = SwitchEndpoints(self)
+        self.wireless = WirelessEndpoints(self)
+        self.sensor = SensorEndpoints(self)
 
     @property
     def has_dashboard(self) -> bool:

--- a/custom_components/meraki_ha/core/api/factory.py
+++ b/custom_components/meraki_ha/core/api/factory.py
@@ -5,21 +5,13 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant
 
 from .client import MerakiClient
-from .endpoints.appliance import ApplianceEndpoints
-from .endpoints.camera import CameraEndpoints
-from .endpoints.devices import DevicesEndpoints
-from .endpoints.network import NetworkEndpoints
-from .endpoints.organization import OrganizationEndpoints
-from .endpoints.sensor import SensorEndpoints
-from .endpoints.switch import SwitchEndpoints
-from .endpoints.wireless import WirelessEndpoints
 from .protocol import MerakiApiClientProtocol as MerakiApiClientProtocolType
 
 
 def create_api_client(
     hass: HomeAssistant,
     api_key: str,
-    org_id: str,
+    org_id: str | None = None,
     base_url: str = "https://api.meraki.com/api/v1",
 ) -> MerakiApiClientProtocolType:
     """
@@ -36,16 +28,4 @@ def create_api_client(
         The configured Meraki API client.
 
     """
-    client = MerakiClient(hass, api_key, org_id, base_url)
-
-    # Initialize endpoint handlers
-    client.appliance = ApplianceEndpoints(client, hass)
-    client.camera = CameraEndpoints(client)
-    client.devices = DevicesEndpoints(client)
-    client.network = NetworkEndpoints(client)
-    client.organization = OrganizationEndpoints(client)
-    client.switch = SwitchEndpoints(client)
-    client.wireless = WirelessEndpoints(client)
-    client.sensor = SensorEndpoints(client)
-
-    return client
+    return MerakiClient(hass, api_key, org_id, base_url)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,14 +27,15 @@ async def test_form(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "custom_components.meraki_ha.config_flow.MerakiClient",
-        ) as mock_client_class,
+            "custom_components.meraki_ha.config_flow.create_api_client",
+        ) as mock_create_client,
         patch(
             "custom_components.meraki_ha.async_setup_entry",
             return_value=True,
         ) as mock_setup_entry,
     ):
-        mock_client = mock_client_class.return_value
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
         async def mock_async_setup():
             pass
         mock_client.async_setup = mock_async_setup
@@ -67,7 +68,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "custom_components.meraki_ha.config_flow.MerakiClient",
+        "custom_components.meraki_ha.config_flow.create_api_client",
         side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
Fixed the `AttributeError: 'MerakiClient' object has no attribute 'organization'` by implementing Client Composition directly within the `MerakiClient` class. This ensures that all endpoint handlers (appliance, camera, devices, network, organization, sensor, switch, wireless) are properly initialized regardless of how the client is instantiated. Additionally, updated the configuration flow to use the `create_api_client` factory and adjusted tests to match this pattern.

Fixes #2433

---
*PR created automatically by Jules for task [13112119195273273154](https://jules.google.com/task/13112119195273273154) started by @brewmarsh*