### PR TITLE
Fix hollow MerakiClient initialization

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -25,6 +25,14 @@ from ...core.errors import (
     MerakiTrafficAnalysisError,
     MerakiVlansDisabledError,
 )
+from .endpoints.appliance import ApplianceEndpoints
+from .endpoints.camera import CameraEndpoints
+from .endpoints.devices import DevicesEndpoints
+from .endpoints.network import NetworkEndpoints
+from .endpoints.organization import OrganizationEndpoints
+from .endpoints.sensor import SensorEndpoints
+from .endpoints.switch import SwitchEndpoints
+from .endpoints.wireless import WirelessEndpoints
 from .protocol import (
     ApplianceEndpointsProtocol,
     CameraEndpointsProtocol,
@@ -93,6 +101,16 @@ class MerakiClient:
         # Set of disabled features to prevent repetitive API calls
         self._disabled_features: set[str] = set()
         self._enable_vpn_management = False
+
+        # Initialize endpoint handlers
+        self.organization = OrganizationEndpoints(self)
+        self.appliance = ApplianceEndpoints(self, self._hass)
+        self.camera = CameraEndpoints(self)
+        self.devices = DevicesEndpoints(self)
+        self.network = NetworkEndpoints(self)
+        self.sensor = SensorEndpoints(self)
+        self.switch = SwitchEndpoints(self)
+        self.wireless = WirelessEndpoints(self)
 
     @property
     def has_dashboard(self) -> bool:

--- a/tests/test_meraki_client_init.py
+++ b/tests/test_meraki_client_init.py
@@ -1,0 +1,27 @@
+"""Test the MerakiClient initialization."""
+
+import pytest
+from unittest.mock import MagicMock
+from custom_components.meraki_ha.core.api.client import MerakiClient
+from homeassistant.core import HomeAssistant
+
+def test_meraki_client_init(hass: HomeAssistant) -> None:
+    """Test that MerakiClient initializes its endpoint handlers."""
+    api_key = "test-api-key"
+    org_id = "test-org-id"
+
+    client = MerakiClient(hass, api_key, org_id)
+
+    # Check if all endpoint handlers are initialized
+    assert client.organization is not None
+    assert client.appliance is not None
+    assert client.camera is not None
+    assert client.devices is not None
+    assert client.network is not None
+    assert client.sensor is not None
+    assert client.switch is not None
+    assert client.wireless is not None
+
+    # Verify a specific endpoint call doesn't raise AttributeError on access
+    # (though we won't call the actual API)
+    assert hasattr(client.organization, "get_organizations")


### PR DESCRIPTION
The `MerakiClient` was missing initialization of its endpoint sub-modules, leading to `AttributeError` during the configuration flow (e.g., when calling `client.organization.get_organizations()`). This PR ensures all endpoint handlers are properly instantiated using client composition within the `MerakiClient` constructor.

Fixes #2434

---
*PR created automatically by Jules for task [7967433186817622375](https://jules.google.com/task/7967433186817622375) started by @brewmarsh*