### PR TITLE
Fix payload keys and configuration schema consistency

### DIFF
--- a/custom_components/meraki_ha/const/config.py
+++ b/custom_components/meraki_ha/const/config.py
@@ -9,7 +9,7 @@ CONF_INTEGRATION_TITLE: Final = "Meraki"
 """Title for the integration."""
 
 
-CONF_MERAKI_ORG_ID: Final = "meraki_org_id"
+CONF_MERAKI_ORG_ID: Final = "organization_id"
 """Configuration key for the Meraki organization ID."""
 
 CONF_SCAN_INTERVAL: Final = "scan_interval"

--- a/custom_components/meraki_ha/strings.json
+++ b/custom_components/meraki_ha/strings.json
@@ -5,16 +5,16 @@
         "title": "Meraki credentials",
         "description": "Enter your Meraki API key and organization ID.",
         "data": {
-          "meraki_api_key": "Meraki API key",
-          "meraki_org_id": "Meraki organization ID"
+          "api_key": "Meraki API key",
+          "organization_id": "Meraki organization ID"
         }
       },
       "reauth": {
         "title": "Re-authenticate Meraki",
         "description": "The API key for organization {org_id} is no longer valid. Please enter a new Meraki API key.",
         "data": {
-          "meraki_api_key": "Meraki API key",
-          "meraki_org_id": "Meraki organization ID"
+          "api_key": "Meraki API key",
+          "organization_id": "Meraki organization ID"
         }
       },
       "reconfigure": {

--- a/custom_components/meraki_ha/translations/en.json
+++ b/custom_components/meraki_ha/translations/en.json
@@ -5,16 +5,16 @@
         "title": "Meraki credentials",
         "description": "Enter your Meraki API key and organization ID.",
         "data": {
-          "meraki_api_key": "Meraki API key",
-          "meraki_org_id": "Meraki organization ID"
+          "api_key": "Meraki API key",
+          "organization_id": "Meraki organization ID"
         }
       },
       "reauth": {
         "title": "Re-authenticate Meraki",
         "description": "The API key for organization {org_id} is no longer valid. Please enter a new Meraki API key.",
         "data": {
-          "meraki_api_key": "Meraki API key",
-          "meraki_org_id": "Meraki organization ID"
+          "api_key": "Meraki API key",
+          "organization_id": "Meraki organization ID"
         }
       },
       "reconfigure": {

--- a/custom_components/meraki_ha/translations/es.json
+++ b/custom_components/meraki_ha/translations/es.json
@@ -5,16 +5,16 @@
         "title": "Credenciales de Meraki",
         "description": "Introduzca su clave de API de Meraki y su ID de organización.",
         "data": {
-          "meraki_api_key": "Clave de API de Meraki",
-          "meraki_org_id": "ID de organización de Meraki"
+          "api_key": "Clave de API de Meraki",
+          "organization_id": "ID de organización de Meraki"
         }
       },
       "reauth": {
         "title": "Reautenticar Meraki",
         "description": "La clave de API para la organización {org_id} ya no es válida. Por favor, introduzca una nueva clave de API de Meraki.",
         "data": {
-          "meraki_api_key": "Clave de API de Meraki",
-          "meraki_org_id": "ID de organización de Meraki"
+          "api_key": "Clave de API de Meraki",
+          "organization_id": "ID de organización de Meraki"
         }
       },
       "reconfigure": {

--- a/custom_components/meraki_ha/translations/fr.json
+++ b/custom_components/meraki_ha/translations/fr.json
@@ -5,16 +5,16 @@
         "title": "Informations d'identification Meraki",
         "description": "Entrez votre clé API Meraki et votre ID d'organisation.",
         "data": {
-          "meraki_api_key": "Clé API Meraki",
-          "meraki_org_id": "ID d'organisation Meraki"
+          "api_key": "Clé API Meraki",
+          "organization_id": "ID d'organisation Meraki"
         }
       },
       "reauth": {
         "title": "Réauthentifier Meraki",
         "description": "La clé API pour l'organisation {org_id} n'est plus valide. Veuillez entrer une nouvelle clé API Meraki.",
         "data": {
-          "meraki_api_key": "Clé API Meraki",
-          "meraki_org_id": "ID d'organisation Meraki"
+          "api_key": "Clé API Meraki",
+          "organization_id": "ID d'organisation Meraki"
         }
       },
       "reconfigure": {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,8 +28,8 @@ async def async_get_config_entry(
     """Create a mock config entry for testing."""
     if data is None:
         data = {
-            "meraki_api_key": MERAKI_TEST_API_KEY,
-            "meraki_org_id": MERAKI_TEST_ORG_ID,
+            "api_key": MERAKI_TEST_API_KEY,
+            "organization_id": MERAKI_TEST_ORG_ID,
         }
 
     config_entry = MockConfigEntry(

--- a/tests/core/utils/test_validation_utils.py
+++ b/tests/core/utils/test_validation_utils.py
@@ -30,12 +30,12 @@ def test_config_schema():
     with pytest.raises(vol.Invalid):
         CONFIG_SCHEMA({})
     with pytest.raises(vol.Invalid):
-        CONFIG_SCHEMA({"api_key": "invalid", "meraki_org_id": "123456"})
+        CONFIG_SCHEMA({"api_key": "invalid", "organization_id": "123456"})
     with pytest.raises(vol.Invalid):
-        CONFIG_SCHEMA({"api_key": "0" * 40, "meraki_org_id": "invalid"})
-    assert CONFIG_SCHEMA({"api_key": "0" * 40, "meraki_org_id": "123456"}) == {
+        CONFIG_SCHEMA({"api_key": "0" * 40, "organization_id": "invalid"})
+    assert CONFIG_SCHEMA({"api_key": "0" * 40, "organization_id": "123456"}) == {
         "api_key": "0" * 40,
-        "meraki_org_id": "123456",
+        "organization_id": "123456",
         "scan_interval": 300,
     }
 

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -16,7 +16,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        data={"api_key": "fake_key", "organization_id": "fake_org"},
         options={},
         entry_id="test_entry",
     )

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -16,7 +16,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        data={"api_key": "fake_key", "organization_id": "fake_org"},
         options={},
         entry_id="test_entry",
     )

--- a/tests/meraki_select/test_rf_profile_select.py
+++ b/tests/meraki_select/test_rf_profile_select.py
@@ -18,7 +18,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        data={"api_key": "fake_key", "organization_id": "fake_org"},
         options={CONF_ENABLE_SSID_SENSORS: True},
         entry_id="test_entry",
     )

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -19,7 +19,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        data={"api_key": "fake_key", "organization_id": "fake_org"},
         options={CONF_ENABLE_VPN_MANAGEMENT: True},
         entry_id="test_entry",
     )

--- a/tests/scripts/reset_integration.py
+++ b/tests/scripts/reset_integration.py
@@ -230,8 +230,8 @@ def _build_form_payload(step_id: str, current_step: dict[str, Any]) -> dict[str,
     payload: dict[str, Any] = {}
     if step_id == "user":
         payload = {
-            "meraki_api_key": MERAKI_API_KEY, # <-- Add 'meraki_' prefix
-            "meraki_org_id": MERAKI_ORG_ID,   # <-- Add 'meraki_' prefix
+            "api_key": MERAKI_API_KEY,
+            "organization_id": MERAKI_ORG_ID,
         }
     else:
         # Generic handler for other steps - just take defaults

--- a/tests/test_static_path.py
+++ b/tests/test_static_path.py
@@ -13,7 +13,7 @@ async def test_static_path_registration(hass: HomeAssistant) -> None:
     """Test that static path registration uses the new async method."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"meraki_api_key": "fake_key", "meraki_org_id": "fake_org"},
+        data={"api_key": "fake_key", "organization_id": "fake_org"},
         entry_id="test_entry",
     )
     entry.add_to_hass(hass)


### PR DESCRIPTION
The Meraki HA integration schema was updated to use 'api_key' and 'organization_id', but the automated integration reset script and several other parts of the codebase were still using legacy keys ('meraki_api_key' and 'meraki_org_id'). This PR updates the reset script, configuration constants, translation files, and test suites to ensure full consistency and prevent CI deployment failures.

Fixes #2438

---
*PR created automatically by Jules for task [15860273282134663172](https://jules.google.com/task/15860273282134663172) started by @brewmarsh*