### PR TITLE
Defensive Frontend Card Registration and Versioning

### DIFF
--- a/frontend/src/meraki-content-filter-card.ts
+++ b/frontend/src/meraki-content-filter-card.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
 
 interface Config {
@@ -9,7 +9,6 @@ interface Config {
   [key: string]: any;
 }
 
-@customElement('meraki-content-filter-card')
 export class MerakiContentFilterCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -145,7 +144,6 @@ export class MerakiContentFilterCard extends LitElement {
   `;
 }
 
-@customElement('meraki-content-filter-card-editor')
 export class MerakiContentFilterCardEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -227,6 +225,18 @@ export class MerakiContentFilterCardEditor extends LitElement {
   `;
 }
 
+if (!customElements.get('meraki-content-filter-card')) {
+  customElements.define('meraki-content-filter-card', MerakiContentFilterCard);
+}
+
+if (!customElements.get('meraki-content-filter-card-editor')) {
+  customElements.define('meraki-content-filter-card-editor', MerakiContentFilterCardEditor);
+}
+
+declare global {
+  const __VERSION__: string;
+}
+
 // Register the card in the Home Assistant Lovelace UI picker
 (window as any).customCards = (window as any).customCards || [];
 if (!(window as any).customCards.some((c: any) => c.type === 'meraki-content-filter-card')) {
@@ -235,5 +245,6 @@ if (!(window as any).customCards.some((c: any) => c.type === 'meraki-content-fil
     name: "Meraki Content Filter",
     description: "Control Meraki Content Filtering profiles.",
     preview: true,
+    version: __VERSION__,
   });
 }

--- a/frontend/src/meraki-guest-access-card-editor.ts
+++ b/frontend/src/meraki-guest-access-card-editor.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
 
 interface Config {
@@ -8,7 +8,6 @@ interface Config {
   config_entry_id?: string;
 }
 
-@customElement('meraki-guest-access-card-editor')
 export class MerakiGuestAccessCardEditor extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: Config;
@@ -73,4 +72,8 @@ export class MerakiGuestAccessCardEditor extends LitElement {
       flex-direction: column;
     }
   `;
+}
+
+if (!customElements.get('meraki-guest-access-card-editor')) {
+  customElements.define('meraki-guest-access-card-editor', MerakiGuestAccessCardEditor);
 }

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
 import './meraki-content-filter-card';
 import './meraki-wifi-qr-card';
@@ -15,7 +15,6 @@ interface Config {
   config_entry_id?: string;
 }
 
-@customElement('meraki-guest-access-card')
 export class MerakiGuestAccessCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -194,4 +193,24 @@ export class MerakiGuestAccessCard extends LitElement {
     .flex { display: flex; }
     .justify-center { justify-content: center; }
   `;
+}
+
+if (!customElements.get('meraki-guest-access-card')) {
+  customElements.define('meraki-guest-access-card', MerakiGuestAccessCard);
+}
+
+declare global {
+  const __VERSION__: string;
+}
+
+// Register the card in the Home Assistant Lovelace UI picker
+(window as any).customCards = (window as any).customCards || [];
+if (!(window as any).customCards.some((c: any) => c.type === 'meraki-guest-access-card')) {
+  (window as any).customCards.push({
+    type: "meraki-guest-access-card",
+    name: "Meraki Guest Access",
+    description: "Generate temporary Wi-Fi guest access keys.",
+    preview: true,
+    version: __VERSION__,
+  });
 }

--- a/frontend/src/meraki-network-vitals-card.ts
+++ b/frontend/src/meraki-network-vitals-card.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
 
 interface Config {
@@ -11,7 +11,6 @@ interface Config {
   name?: string;
 }
 
-@customElement('meraki-network-vitals-card')
 export class MerakiNetworkVitalsCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -148,7 +147,6 @@ export class MerakiNetworkVitalsCard extends LitElement {
   `;
 }
 
-@customElement('meraki-network-vitals-card-editor')
 export class MerakiNetworkVitalsCardEditor extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: Config;
@@ -240,6 +238,18 @@ export class MerakiNetworkVitalsCardEditor extends LitElement {
   `;
 }
 
+if (!customElements.get('meraki-network-vitals-card')) {
+  customElements.define('meraki-network-vitals-card', MerakiNetworkVitalsCard);
+}
+
+if (!customElements.get('meraki-network-vitals-card-editor')) {
+  customElements.define('meraki-network-vitals-card-editor', MerakiNetworkVitalsCardEditor);
+}
+
+declare global {
+  const __VERSION__: string;
+}
+
 // Register the card in the Home Assistant Lovelace UI picker
 (window as any).customCards = (window as any).customCards || [];
 if (!(window as any).customCards.some((c: any) => c.type === 'meraki-network-vitals-card')) {
@@ -248,5 +258,6 @@ if (!(window as any).customCards.some((c: any) => c.type === 'meraki-network-vit
     name: "Meraki Network Vitals",
     description: "Compact horizontal header for Meraki network health and throughput.",
     preview: true,
+    version: __VERSION__,
   });
 }

--- a/frontend/src/meraki-wifi-qr-card.ts
+++ b/frontend/src/meraki-wifi-qr-card.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
 import { Network, SSID } from './types/meraki';
 import { WsCommand } from './types/websocket';
@@ -13,7 +13,6 @@ interface Config {
   name?: string;
 }
 
-@customElement('meraki-wifi-qr-card-editor')
 export class MerakiWifiQrCardEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -163,7 +162,6 @@ export class MerakiWifiQrCardEditor extends LitElement {
   `;
 }
 
-@customElement('meraki-wifi-qr-card')
 export class MerakiWifiQrCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -312,6 +310,18 @@ export class MerakiWifiQrCard extends LitElement {
   `;
 }
 
+if (!customElements.get('meraki-wifi-qr-card')) {
+  customElements.define('meraki-wifi-qr-card', MerakiWifiQrCard);
+}
+
+if (!customElements.get('meraki-wifi-qr-card-editor')) {
+  customElements.define('meraki-wifi-qr-card-editor', MerakiWifiQrCardEditor);
+}
+
+declare global {
+  const __VERSION__: string;
+}
+
 // Register the card in the Home Assistant Lovelace UI picker
 (window as any).customCards = (window as any).customCards || [];
 if (!(window as any).customCards.some((c: any) => c.type === 'meraki-wifi-qr-card')) {
@@ -320,5 +330,6 @@ if (!(window as any).customCards.some((c: any) => c.type === 'meraki-wifi-qr-car
     name: "Meraki Wi-Fi QR Card",
     description: "Display a scannable Wi-Fi QR code for guests.",
     preview: true,
+    version: __VERSION__,
   });
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 
 export default defineConfig({
+  define: {
+    __VERSION__: JSON.stringify(pkg.version),
+  },
   build: {
     lib: {
       entry: resolve(__dirname, 'src/meraki-guest-access-card.ts'),


### PR DESCRIPTION
This PR addresses reported 'CustomElementRegistry' crashes on Mobile Chrome by making custom card registration idempotent. It also implements build-time versioning to assist with cache-busting in the Home Assistant frontend.

Key changes:
- Removed @customElement decorators from all frontend components.
- Implemented manual registration blocks with `if (!customElements.get('element-name'))` checks.
- Updated `frontend/vite.config.ts` to inject `__VERSION__` from `package.json`.
- Updated `(window as any).customCards` registration to include the version string.
- Added registration for the `meraki-guest-access-card`.
- Verified the build and registration via Playwright.

Fixes #2445

---
*PR created automatically by Jules for task [5728419565755529727](https://jules.google.com/task/5728419565755529727) started by @brewmarsh*