### PR TITLE
Fix uncaught DOMException in Meraki dashboard cards

### DIFF
--- a/frontend/src/meraki-content-filter-card.ts
+++ b/frontend/src/meraki-content-filter-card.ts
@@ -11,7 +11,6 @@ interface Config {
   [key: string]: any;
 }
 
-@customElement('meraki-content-filter-card')
 export class MerakiContentFilterCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -140,7 +139,6 @@ export class MerakiContentFilterCard extends LitElement {
   `;
 }
 
-@customElement('meraki-content-filter-card-editor')
 export class MerakiContentFilterCardEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -200,6 +198,13 @@ export class MerakiContentFilterCardEditor extends LitElement {
 }
 
 // Global Registration
+if (!customElements.get('meraki-content-filter-card')) {
+  customElements.define('meraki-content-filter-card', MerakiContentFilterCard);
+}
+if (!customElements.get('meraki-content-filter-card-editor')) {
+  customElements.define('meraki-content-filter-card-editor', MerakiContentFilterCardEditor);
+}
+
 (window as any).customCards = (window as any).customCards || [];
 if (!(window as any).customCards.some((c: any) => c.type === 'meraki-content-filter-card')) {
   (window as any).customCards.push({

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -17,7 +17,6 @@ interface Config {
   config_entry_id?: string;
 }
 
-@customElement('meraki-guest-access-card')
 export class MerakiGuestAccessCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -216,6 +215,11 @@ declare global {
   interface HTMLElementTagNameMap {
     'meraki-guest-access-card': MerakiGuestAccessCard;
   }
+}
+
+// Register components
+if (!customElements.get('meraki-guest-access-card')) {
+  customElements.define('meraki-guest-access-card', MerakiGuestAccessCard);
 }
 
 // Register the card in the Home Assistant Lovelace UI picker

--- a/frontend/src/meraki-network-vitals-card.ts
+++ b/frontend/src/meraki-network-vitals-card.ts
@@ -13,7 +13,6 @@ interface Config {
   name?: string;
 }
 
-@customElement('meraki-network-vitals-card')
 export class MerakiNetworkVitalsCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -131,7 +130,6 @@ export class MerakiNetworkVitalsCard extends LitElement {
   `;
 }
 
-@customElement('meraki-network-vitals-card-editor')
 export class MerakiNetworkVitalsCardEditor extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: Config;
@@ -203,6 +201,13 @@ export class MerakiNetworkVitalsCardEditor extends LitElement {
 }
 
 // Global Registration
+if (!customElements.get('meraki-network-vitals-card')) {
+  customElements.define('meraki-network-vitals-card', MerakiNetworkVitalsCard);
+}
+if (!customElements.get('meraki-network-vitals-card-editor')) {
+  customElements.define('meraki-network-vitals-card-editor', MerakiNetworkVitalsCardEditor);
+}
+
 (window as any).customCards = (window as any).customCards || [];
 if (!(window as any).customCards.some((c: any) => c.type === 'meraki-network-vitals-card')) {
   (window as any).customCards.push({

--- a/frontend/src/meraki-wifi-qr-card.ts
+++ b/frontend/src/meraki-wifi-qr-card.ts
@@ -15,7 +15,6 @@ interface Config {
   name?: string;
 }
 
-@customElement('meraki-wifi-qr-card-editor')
 export class MerakiWifiQrCardEditor extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -151,7 +150,6 @@ export class MerakiWifiQrCardEditor extends LitElement {
   `;
 }
 
-@customElement('meraki-wifi-qr-card')
 export class MerakiWifiQrCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config?: Config;
@@ -247,6 +245,14 @@ export class MerakiWifiQrCard extends LitElement {
     code { background: var(--secondary-background-color); padding: 2px 4px; border-radius: 4px; font-family: monospace; }
     .version { font-size: 9px; color: var(--secondary-text-color); text-align: right; padding: 0 16px 8px; opacity: 0.4; }
   `;
+}
+
+// Register components
+if (!customElements.get('meraki-wifi-qr-card')) {
+  customElements.define('meraki-wifi-qr-card', MerakiWifiQrCard);
+}
+if (!customElements.get('meraki-wifi-qr-card-editor')) {
+  customElements.define('meraki-wifi-qr-card-editor', MerakiWifiQrCardEditor);
 }
 
 // Register the card

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     // Output directly to the integration's www folder for Home Assistant access
     outDir: resolve(__dirname, '../custom_components/meraki_ha/www'),
     emptyOutDir: false,
+    minify: true,
     rollupOptions: {
       output: {
         entryFileNames: 'meraki-card.js',


### PR DESCRIPTION
This PR resolves the 'Uncaught DOMException: the name has already been used with this registry' error that was causing the Meraki dashboard to crash. The fix involves refactoring how custom elements are registered in the frontend.

Specifically:
1.  **Audited all card files**: Identified all classes using the `@customElement` decorator.
2.  **Removed `@customElement` decorators**: Shifted away from decorators to manual registration to allow for defensive checks.
3.  **Idempotent Registration**: Added `if (!customElements.get('tag-name')) { customElements.define('tag-name', ClassName); }` at the bottom of each file. This ensures that even if the bundle is loaded multiple times or Home Assistant reloads the resources aggressively, the browser won't throw an error for duplicate registration.
4.  **Vite Optimization**: Enabled minification in `vite.config.ts` as requested.

The changes were verified by building the frontend (`npm run build`) and using a Playwright script to confirm that the components render correctly without console errors in a mock Home Assistant environment. Relevant integration tests for static paths also passed.

Fixes #2457

---
*PR created automatically by Jules for task [17002943632292552315](https://jules.google.com/task/17002943632292552315) started by @brewmarsh*