### PR TITLE
Fix data siloing by centralizing organization_id propagation

### DIFF
--- a/custom_components/meraki_ha/coordinators/main.py
+++ b/custom_components/meraki_ha/coordinators/main.py
@@ -60,25 +60,28 @@ class MerakiMainCoordinator(MerakiBaseCoordinator[dict[str, Any]]):
             self.last_successful_data, timespan=timespan
         )
 
-        # Inject organization_id into MerakiNetwork objects if missing
-        if data and "networks" in data:
-            for network in data["networks"]:
-                if hasattr(network, "organization_id") and not network.organization_id:
-                    network.organization_id = self.api.organization_id
-
         if not data:
             _LOGGER.warning("API call to get_all_data returned no data.")
             return self.last_successful_data
 
-        # Explicitly propagate organization_id to all networks
+        # Explicitly propagate organization_id to all networks and devices
+        from ..core.models.device import MerakiDevice
         from ..core.models.network import MerakiNetwork
         org_id = self.api.organization_id
+
         if "networks" in data:
             for network in data["networks"]:
                 if isinstance(network, MerakiNetwork):
                     network.organization_id = org_id
                 elif isinstance(network, dict):
                     network["organizationId"] = org_id
+
+        if "devices" in data:
+            for device in data["devices"]:
+                if isinstance(device, MerakiDevice):
+                    device.organization_id = org_id
+                elif isinstance(device, dict):
+                    device["organizationId"] = org_id
 
         # Process successful update
         (

--- a/custom_components/meraki_ha/core/models/base.py
+++ b/custom_components/meraki_ha/core/models/base.py
@@ -19,6 +19,7 @@ class MerakiBaseDevice:
     wan2_ip: str | None = None
     public_ip: str | None = None
     network_id: str | None = None
+    organization_id: str | None = None
     uplinks: list[dict[str, Any]] = field(default_factory=list)
     status: str | None = None
     firmware: str | None = None
@@ -49,6 +50,7 @@ class MerakiBaseDevice:
             "wan2Ip": self.wan2_ip,
             "publicIp": self.public_ip,
             "networkId": self.network_id,
+            "organizationId": self.organization_id,
             "status": self.status,
             "firmware": self.firmware,
             "productType": self.product_type,
@@ -76,6 +78,7 @@ class MerakiBaseDevice:
             "wan2_ip": data.get("wan2Ip"),
             "public_ip": data.get("publicIp"),
             "network_id": data.get("networkId"),
+            "organization_id": data.get("organizationId"),
             "status": data.get("status"),
             "firmware": data.get("firmware"),
             "product_type": data.get("productType"),

--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -61,6 +61,26 @@ class NetworkHandler(BaseHandler):
 
         filtered_networks = []
         for n in networks:
+            n_id = n.id if isinstance(n, MerakiNetwork) else n.get("id")
+            n_org_id = (
+                n.organization_id if isinstance(n, MerakiNetwork) else n.get("organizationId")
+            )
+
+            if n_org_id is None:
+                _LOGGER.warning(
+                    "Network %s missing organization_id, allowing discovery fallback for %s",
+                    n_id,
+                    org_id,
+                )
+                if isinstance(n, MerakiNetwork):
+                    n.organization_id = org_id
+                    filtered_networks.append(n)
+                elif isinstance(n, dict):
+                    n_model = MerakiNetwork.from_dict(n)
+                    n_model.organization_id = org_id
+                    filtered_networks.append(n_model)
+                continue
+
             if isinstance(n, MerakiNetwork) and n.organization_id == org_id:
                 filtered_networks.append(n)
             elif isinstance(n, dict) and n.get("organizationId") == org_id:

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
@@ -12,6 +13,8 @@ if TYPE_CHECKING:
     from .coordinators.base import MerakiBaseCoordinator
 
 T = TypeVar("T", bound="MerakiBaseCoordinator")
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class MerakiEntity(CoordinatorEntity[T], Generic[T]):
@@ -27,6 +30,16 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
         if data is present (even if seeded) to prevent 'unavailable' states during
         initial background synchronization of specialized coordinators.
         """
+        if self.coordinator.data:
+            _LOGGER.debug(
+                "Entity %s checking coordinator data keys: %s",
+                self.unique_id,
+                (
+                    list(self.coordinator.data.keys())
+                    if isinstance(self.coordinator.data, dict)
+                    else "Not a dict"
+                ),
+            )
         return bool(self.coordinator.data)
 
     @property


### PR DESCRIPTION
I have implemented a centralized data propagation strategy to fix the "Data Siloing" issue. 

Key changes include:
1.  **Model Update**: Added `organization_id` to the `MerakiBaseDevice` dataclass and updated its dictionary conversion methods to ensure the ID is persisted and transmitted correctly.
2.  **Coordinator Injection**: Updated `MerakiMainCoordinator` to explicitly inject the API client's `organization_id` into every `MerakiNetwork` and `MerakiDevice` object (or raw dictionary) during the update cycle. This ensures downstream components always have the correct context.
3.  **Discovery Fallback**: Modified `NetworkHandler` to log a warning if `organization_id` is missing but allow discovery to proceed for the current organization as a fallback.
4.  **Enhanced Debugging**: Added debug logs in `MerakiEntity.available` that print the entity's ID and the keys currently present in its coordinator's data, facilitating the diagnosis of potential identifier mismatches (e.g., serial vs. mac).

These changes ensure that all entities and networks are correctly discovered and remain available regardless of partial data from the Meraki API.

Fixes #2458

---
*PR created automatically by Jules for task [2064867134333580324](https://jules.google.com/task/2064867134333580324) started by @brewmarsh*