### PR TITLE
Implement Safety Parser for Data Normalization

### DIFF
--- a/custom_components/meraki_ha/core/utils/data.py
+++ b/custom_components/meraki_ha/core/utils/data.py
@@ -1,0 +1,25 @@
+"""Data utilities for Meraki integration."""
+
+from typing import Any
+
+
+def ensure_list_of_strings(data: list[Any] | None, key_to_extract: str = "name") -> list[str]:
+    """Ensure that the input data is a list of strings.
+
+    If an element is a dictionary, extract the value of key_to_extract.
+    If the element is already a string, keep it.
+    If the element is None or of another type, ignore it to maintain a clean string list.
+    """
+    if not data or not isinstance(data, list):
+        return []
+
+    result: list[str] = []
+    for item in data:
+        if isinstance(item, str):
+            result.append(item)
+        elif isinstance(item, dict):
+            value = item.get(key_to_extract)
+            if value is not None:
+                result.append(str(value))
+
+    return result

--- a/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
+++ b/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import HomeAssistantError
 from ..coordinators import MerakiMainCoordinator
 from ..core.api import MerakiApiClientProtocol
 from ..core.models.network import MerakiNetwork
+from ..core.utils.data import ensure_list_of_strings
 from ..entity import MerakiEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -83,13 +84,15 @@ class MerakiContentFilteringSelect(MerakiEntity[MerakiMainCoordinator], SelectEn
         content_filtering = self.coordinator.data["content_filtering"].get(
             self._network_id
         )
-        if not content_filtering:
+        # Safety check: ensure content_filtering is a dictionary and not None
+        if not content_filtering or not isinstance(content_filtering, dict):
             return None
 
-        blocked_categories = {
-            cat["id"] if isinstance(cat, dict) else cat
-            for cat in content_filtering.get("blockedUrlCategories", [])
-        }
+        blocked_categories = set(
+            ensure_list_of_strings(
+                content_filtering.get("blockedUrlCategories", []), key_to_extract="id"
+            )
+        )
 
         # Reverse map to find the best matching profile
         # We look for an exact match first


### PR DESCRIPTION
Implemented a centralized data normalization utility `ensure_list_of_strings` in `custom_components/meraki_ha/core/utils/data.py` to address `TypeError: unhashable type: 'dict'` crashes. This utility extracts a specified key (defaulting to 'name', but using 'id' for content filtering) from dictionaries within a list, ensuring a consistent list of strings.

Refactored `custom_components/meraki_ha/meraki_select/meraki_content_filtering.py` to utilize this utility when processing `blockedUrlCategories`. Additionally, improved robustness by adding checks for non-dictionary or `None` values in the coordinator data for content filtering.

Verified the fix using the existing reproduction test which simulates the dictionary response from the Meraki API.

Fixes #2448

---
*PR created automatically by Jules for task [17955697231049860847](https://jules.google.com/task/17955697231049860847) started by @brewmarsh*