### PR TITLE
Standardize Network Entity Naming and Unique IDs

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/network.py
+++ b/custom_components/meraki_ha/binary_sensor/network.py
@@ -44,7 +44,7 @@ class MerakiNetworkStatus(BinarySensorEntity):
     """Representation of a Meraki network status sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
 
     def __init__(
         self,
@@ -57,8 +57,8 @@ class MerakiNetworkStatus(BinarySensorEntity):
 
         # Ensure network ID is available
         network_id = network.id or "unknown_network"
-        self._attr_unique_id = f"{network_id}-status"
-        self._attr_name = "Uplink status"
+        self._attr_unique_id = f"meraki-network-{network_id}-status"
+        self._attr_name = f"{network.name} Uplink Status"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -35,6 +35,10 @@ class MerakiNetworkEntity(BaseMerakiEntity):
         # CRITICAL: Keep this from 'beta' branch
         self._network = network
 
+        # Set has_entity_name to False to allow custom prefixed naming as requested
+        # for network-level entities
+        self._attr_has_entity_name = False
+
         # DEBUG: Keep this from 'fix' branch
         _LOGGER.debug(
             "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s "

--- a/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
+++ b/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
@@ -6,12 +6,14 @@ from homeassistant.components.select import SelectEntity, SelectEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from ..coordinators import MerakiMainCoordinator
 from ..core.api import MerakiApiClientProtocol
 from ..core.models.network import MerakiNetwork
 from ..core.utils.data import ensure_list_of_strings
 from ..entity import MerakiEntity
+from ..helpers.device_info_helpers import resolve_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ CONTENT_FILTERING_PROFILES: dict[str, list[str]] = {
 class MerakiContentFilteringSelect(MerakiEntity[MerakiMainCoordinator], SelectEntity):
     """Representation of a Meraki Content Filtering select entity."""
 
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
 
     def __init__(
         self,
@@ -68,12 +70,21 @@ class MerakiContentFilteringSelect(MerakiEntity[MerakiMainCoordinator], SelectEn
 
         self.entity_description = SelectEntityDescription(
             key=f"content_filtering_{self._network_id}",
-            name="Content filtering profile",
+            name=f"{network_data.name} Content Filter",
             icon="mdi:web-filter",
         )
 
+        # Unique ID must include network_id to prevent collision and generic suffixes
         self._attr_unique_id = f"meraki-network-{self._network_id}-content-filtering-profile"
         self._attr_options = list(CONTENT_FILTERING_PROFILES.keys())
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device information to link this entity to the network device."""
+        return resolve_device_info(
+            entity_data=self._network_data,
+            config_entry=self._config_entry,
+        )
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -41,6 +41,9 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
         self._ssid_number = ssid_data["number"]
         self._ssid_name = ssid_data.get("name")
 
+        # Set has_entity_name to False to allow custom prefixed naming as requested
+        self._attr_has_entity_name = False
+
         self.entity_description = SelectEntityDescription(
             key=f"{self._network_id}ssid{self._ssid_number}_rf_profile",
             name="RF profile",
@@ -49,8 +52,8 @@ class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
 
         network = coordinator.get_network(self._network_id)
         network_name = network.name if network else f"Network {self._network_id}"
-        self._attr_name = f"{network_name} SSID {self._ssid_name} RF profile"
-        self._attr_unique_id = f"{self._network_id}ssid{self._ssid_number}_rf_profile"
+        self._attr_name = f"{network_name} {self._ssid_name} RF Profile"
+        self._attr_unique_id = f"meraki-network-{self._network_id}-ssid-{self._ssid_number}-rf-profile"
         self._attr_options: list[str] = []
         self._update_internal_state()
 

--- a/custom_components/meraki_ha/meraki_select/vpn.py
+++ b/custom_components/meraki_ha/meraki_select/vpn.py
@@ -22,7 +22,7 @@ class MerakiVpnSelect(CoordinatorEntity, SelectEntity):
     """Representation of a Meraki VPN select entity."""
 
     entity_category = EntityCategory.CONFIG
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
 
     def __init__(
         self,
@@ -40,7 +40,7 @@ class MerakiVpnSelect(CoordinatorEntity, SelectEntity):
 
         self.entity_description = SelectEntityDescription(
             key=f"vpn_status_{self._network_id}",
-            name="VPN mode",
+            name=f"{network_data.name} VPN Mode",
             icon="mdi:vpn",
         )
 

--- a/custom_components/meraki_ha/sensor/network/network_clients.py
+++ b/custom_components/meraki_ha/sensor/network/network_clients.py
@@ -22,8 +22,6 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
     """Representation of a Meraki network-level client counter."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_has_entity_name = True
-    _attr_name = "Clients"
     _attr_translation_key = "network_clients"
 
     def __init__(
@@ -37,6 +35,7 @@ class MerakiNetworkClientsSensor(MerakiNetworkEntity, SensorEntity):
         super().__init__(coordinator, config_entry, network_data)
         self._network_control_service = network_control_service
         self._attr_unique_id = f"meraki_network_clients_{self._network_id}"
+        self._attr_name = f"{network_data.name} Clients"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/sensor/network/traffic_shaping.py
+++ b/custom_components/meraki_ha/sensor/network/traffic_shaping.py
@@ -33,8 +33,8 @@ class TrafficShapingSensor(MerakiNetworkEntity, SensorEntity):
             raise ValueError(f"Network {network_id} not found in coordinator data")
 
         super().__init__(coordinator, config_entry, network)
-        self._attr_unique_id = f"{network_id}-traffic-shaping"
-        self._attr_name = "Traffic Shaping"
+        self._attr_unique_id = f"meraki-network-{network_id}-traffic-shaping"
+        self._attr_name = f"{network.name} Traffic Shaping"
         self._attr_native_value = "Unknown"
 
     @callback

--- a/custom_components/meraki_ha/sensor/network/vlan.py
+++ b/custom_components/meraki_ha/sensor/network/vlan.py
@@ -43,9 +43,9 @@ class MerakiVLANStatusSensor(MerakiVLANEntity, SensorEntity):
 
         # Name: VLAN 10 (Staff) Subnet
         if vlan_name:
-            self._attr_name = f"VLAN {vlan_id} ({vlan_name}) Subnet"
+            self._attr_name = f"{self._network.name} VLAN {vlan_id} ({vlan_name}) Subnet"
         else:
-            self._attr_name = f"VLAN {vlan_id} Subnet"
+            self._attr_name = f"{self._network.name} VLAN {vlan_id} Subnet"
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -27,8 +27,8 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, config_entry, network_data)
-        self._attr_unique_id = f"{network_data.id}_vlans"
-        self._attr_name = "VLANs"
+        self._attr_unique_id = f"meraki-network-{network_data.id}-vlans-list"
+        self._attr_name = f"{network_data.name} VLANs"
         self._vlan_list: list[str] = []
         self._attr_native_value = 0
 


### PR DESCRIPTION
Standardized naming and unique ID generation for all network-level entities in the Meraki HA integration. This fix ensures that entities like content filtering, VPN mode, and uplink status have descriptive, prefixed names (e.g., 'Marshmallow Home Content Filter') and globally unique IDs that prevent collision-induced generic suffixes. Affected platforms include select, binary_sensor, and sensor.

Fixes #2465

---
*PR created automatically by Jules for task [17587798059895205845](https://jules.google.com/task/17587798059895205845) started by @brewmarsh*