### PR TITLE
Fix deprecated logging in reset_integration script

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -42,4 +42,7 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** Staging workflow (`deploy-staging.yaml`) enhanced to capture rich error details in the `CI_ERROR_DETAILS` environment variable.
   - **[VERIFIED]** Automated GitHub Issues now include these error details in the body and are tagged with the `jules` label to trigger AI-driven triage.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10) are now considered part of the standard for this integration.
+- **R11: Centralized Logging (No File Dependency):**
+  - **[VERIFIED]** Reset and staging scripts must not rely on deprecated Home Assistant file-based logging endpoints (e.g., `/api/error_log`). All troubleshooting data must be sourced from GitHub Actions WebSocket captures or CI logs to ensure compatibility with HA 2025.11+.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11) are now considered part of the standard for this integration.

--- a/tests/scripts/reset_integration.py
+++ b/tests/scripts/reset_integration.py
@@ -29,21 +29,6 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-async def dump_error_log(session: aiohttp.ClientSession) -> None:
-    """Fetch and print the last few lines of the Home Assistant log."""
-    url = f"{HA_URL}/api/error_log"
-    try:
-        async with session.get(url) as resp:
-            if resp.status == 200:
-                text = await resp.text()
-                logger.error("--- Home Assistant Error Log (Last 20 lines) ---")
-                for line in text.splitlines()[-20:]:
-                    print(line)
-                logger.error("--- End of Log ---")
-    except Exception as e:
-        logger.error(f"Error fetching error log: {e}")
-
-
 async def _get_existing_entries(
     session: aiohttp.ClientSession,
 ) -> list[dict[str, Any]] | None:
@@ -201,7 +186,7 @@ async def _check_components_and_safe_mode(
             safe_mode_ok = _verify_safe_mode(data.get("safe_mode", False))
 
             if not components_ok or not safe_mode_ok:
-                await dump_error_log(session)
+                logger.error("Critical components missing or safe mode active. Check CI/WebSocket logs for details.")
                 return False
 
             return True
@@ -371,8 +356,7 @@ async def main() -> None:
         # Step 4: Add
         logger.info("--- Step 4: Add Integration ---")
         if not await add_integration(session):
-            logger.error("Failed to re-add integration.")
-            await dump_error_log(session)
+            logger.error("Failed to re-add integration. Refer to the GitHub Actions WebSocket log capture for details.")
             sys.exit(1)
 
         logger.info("✨ Meraki HA Reset Sequence Complete!")


### PR DESCRIPTION
Refactored the staging reset script to remove reliance on the deprecated `/api/error_log` Home Assistant endpoint, which was causing 404 errors. Updated the script to direct users to GitHub Actions WebSocket logs for troubleshooting. Also updated the project requirements documentation to reflect this change as a new standard (R11).

Fixes #2474

---
*PR created automatically by Jules for task [16235462128760239636](https://jules.google.com/task/16235462128760239636) started by @brewmarsh*