### PR TITLE
Add idempotent Meraki webhook registration and cleanup

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -226,9 +226,9 @@ class MerakiClient:
 
     async def register_webhook(
         self, webhook_url: str, secret: str, config_entry_id: str
-    ) -> None:
+    ) -> list[str]:
         """Register a webhook with the Meraki API."""
-        await self.network.register_webhook(webhook_url, secret, config_entry_id)
+        return await self.network.register_webhook(webhook_url, secret, config_entry_id)
 
     async def unregister_webhook(self, config_entry_id: str) -> None:
         """Unregister a webhook with the Meraki API."""

--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -112,26 +112,67 @@ class NetworkEndpoints:
     @handle_meraki_errors
     async def register_webhook(
         self, webhook_url: str, secret: str, config_entry_id: str
-    ) -> None:
+    ) -> list[str]:
         """Register or update a webhook with the Meraki API."""
         networks = await self._api_client.organization.get_organization_networks()
+        webhook_name = f"Home Assistant Webhook - {config_entry_id}"
+        webhook_ids = []
+
         for network in networks:
             network_id = network["id"]
-            webhook_name = f"Home Assistant Webhook - {config_entry_id}"
-
-            existing = await self.find_webhook_by_name_and_url(
-                network_id, webhook_name, webhook_url
+            # Always fetch existing webhooks directly using the dashboard API for fresh data
+            raw_webhooks = await self._api_client.run_sync(
+                self._api_client.dashboard.networks.getNetworkWebhooksHttpServers,
+                networkId=network_id,
             )
-            if existing:
-                await self.delete_webhook(network_id, existing["id"])
+            webhooks = validate_response(raw_webhooks)
+            if not isinstance(webhooks, list):
+                webhooks = []
 
-            await self._api_client.run_sync(
+            exact_match = None
+            for webhook in webhooks:
+                name_match = webhook.get("name") == webhook_name
+                url_match = webhook.get("url") == webhook_url
+
+                # Exact match found - we'll reuse this one
+                if name_match and url_match:
+                    exact_match = webhook
+                    continue
+
+                # Orphaned or conflicting webhook found
+                # Matching name but different URL OR matching URL but different name
+                if name_match or url_match:
+                    _LOGGER.info(
+                        "Deleting orphaned or conflicting webhook '%s' (ID: %s) in network %s",
+                        webhook.get("name"),
+                        webhook.get("id"),
+                        network_id,
+                    )
+                    await self.delete_webhook(network_id, webhook["id"])
+
+            if exact_match:
+                _LOGGER.debug(
+                    "Webhook '%s' already exists in network %s, skipping creation",
+                    webhook_name,
+                    network_id,
+                )
+                webhook_ids.append(exact_match["id"])
+                continue
+
+            _LOGGER.info(
+                "Registering new webhook '%s' for network %s", webhook_name, network_id
+            )
+            response = await self._api_client.run_sync(
                 self._api_client.dashboard.networks.createNetworkWebhooksHttpServer,
                 networkId=network_id,
                 url=webhook_url,
                 sharedSecret=secret,
                 name=webhook_name,
             )
+            if response and "id" in response:
+                webhook_ids.append(response["id"])
+
+        return webhook_ids
 
     async def unregister_webhook(self, config_entry_id: str) -> None:
         """Unregister a webhook from all networks."""
@@ -139,10 +180,16 @@ class NetworkEndpoints:
         networks = await self._api_client.organization.get_organization_networks()
         for network in networks:
             network_id = network["id"]
-            webhooks = await self.get_webhooks(network_id)
-            for webhook in webhooks:
-                if webhook.get("name") == webhook_name:
-                    await self.delete_webhook(network_id, webhook["id"])
+            # Fetch webhooks directly to ensure cleanup of all instances
+            raw_webhooks = await self._api_client.run_sync(
+                self._api_client.dashboard.networks.getNetworkWebhooksHttpServers,
+                networkId=network_id,
+            )
+            webhooks = validate_response(raw_webhooks)
+            if isinstance(webhooks, list):
+                for webhook in webhooks:
+                    if webhook.get("name") == webhook_name:
+                        await self.delete_webhook(network_id, webhook["id"])
 
     async def get_vlan_data(self, network_id: str) -> list[dict[str, Any]]:
         """

--- a/custom_components/meraki_ha/core/api/protocol.py
+++ b/custom_components/meraki_ha/core/api/protocol.py
@@ -228,7 +228,7 @@ class NetworkEndpointsProtocol(Protocol):
 
     async def register_webhook(
         self, webhook_url: str, secret: str, config_entry_id: str
-    ) -> None:
+    ) -> list[str]:
         """Register or update a webhook with the Meraki API."""
         ...
 
@@ -497,7 +497,7 @@ class MerakiApiClientProtocol(Protocol):
 
     async def register_webhook(
         self, webhook_url: str, secret: str, config_entry_id: str
-    ) -> None:
+    ) -> list[str]:
         """Register a webhook with the Meraki API."""
         ...
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -49,4 +49,9 @@ This document verifies the state of the codebase against the requirements for th
   - **[IN PROGRESS]** Implementation of diagnostic tracing in critical parsers to ensure visibility into data mapping during the batch distribution phase.
   - **[IN PROGRESS]** Implementation of targeted diagnostic logging within the `available` property of entities to debug regressions in device-level availability (MT sensors, MV IPs, Reboot buttons). Logs must capture serial numbers, coordinator data keys, and specific status fields to identify mapping issues.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12) are now considered part of the standard for this integration.
+- **R13: Webhook Lifecycle Management:**
+  - **[IN PROGRESS]** Implementation of idempotent webhook registration to prevent exhausting the Meraki API limit (100 HTTP servers per network).
+  - **[IN PROGRESS]** Automated discovery and deletion of orphaned webhooks matching the Home Assistant name pattern or specific webhook URL.
+  - **[IN PROGRESS]** Reuse of existing webhooks when an exact match (name and URL) is found.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13) are now considered part of the standard for this integration.

--- a/tests/test_webhook_cleanup.py
+++ b/tests/test_webhook_cleanup.py
@@ -1,0 +1,99 @@
+"""Tests for Meraki webhook registration idempotency and cleanup."""
+
+from unittest.mock import AsyncMock, patch
+import pytest
+from custom_components.meraki_ha.core.api.endpoints.network import NetworkEndpoints
+
+@pytest.fixture
+def mock_api_client():
+    """Mock the Meraki API client protocol."""
+    client = AsyncMock()
+    client.dashboard = AsyncMock()
+    client.organization = AsyncMock()
+    # Mock run_sync to just return the result of calling the func if it's not a mock
+    async def side_effect(func, *args, **kwargs):
+        if isinstance(func, AsyncMock):
+            return await func(*args, **kwargs)
+        return func(*args, **kwargs)
+    client.run_sync.side_effect = side_effect
+    return client
+
+@pytest.fixture
+def network_endpoints(mock_api_client):
+    """Create NetworkEndpoints with a mock client."""
+    return NetworkEndpoints(mock_api_client)
+
+@pytest.mark.asyncio
+async def test_register_webhook_exact_match(network_endpoints, mock_api_client):
+    """Test that an exact match reuses the existing webhook and skips creation."""
+    network_id = "n123"
+    webhook_url = "https://example.com/webhook"
+    config_entry_id = "entry123"
+    webhook_name = f"Home Assistant Webhook - {config_entry_id}"
+
+    mock_api_client.organization.get_organization_networks.return_value = [{"id": network_id}]
+
+    # Existing webhooks include an exact match
+    existing_webhooks = [
+        {"id": "wh1", "name": webhook_name, "url": webhook_url}
+    ]
+
+    # Mock the direct API call used in the refactored code
+    mock_api_client.dashboard.networks.getNetworkWebhooksHttpServers = AsyncMock(return_value=existing_webhooks)
+
+    webhook_ids = await network_endpoints.register_webhook(webhook_url, "secret", config_entry_id)
+
+    assert webhook_ids == ["wh1"]
+    # createNetworkWebhooksHttpServer should NOT be called
+    assert mock_api_client.dashboard.networks.createNetworkWebhooksHttpServer.call_count == 0
+
+@pytest.mark.asyncio
+async def test_register_webhook_cleanup_orphans(network_endpoints, mock_api_client):
+    """Test that orphaned webhooks (same name, diff URL OR diff name, same URL) are deleted."""
+    network_id = "n123"
+    webhook_url = "https://example.com/webhook"
+    config_entry_id = "entry123"
+    webhook_name = f"Home Assistant Webhook - {config_entry_id}"
+
+    mock_api_client.organization.get_organization_networks.return_value = [{"id": network_id}]
+
+    # Existing webhooks include orphans
+    existing_webhooks = [
+        {"id": "wh_old_url", "name": webhook_name, "url": "https://old.com/webhook"},
+        {"id": "wh_other_name", "name": "Other HA", "url": webhook_url},
+        {"id": "wh_unrelated", "name": "Unrelated", "url": "https://unrelated.com"}
+    ]
+
+    mock_api_client.dashboard.networks.getNetworkWebhooksHttpServers = AsyncMock(return_value=existing_webhooks)
+    mock_api_client.dashboard.networks.createNetworkWebhooksHttpServer = AsyncMock(return_value={"id": "wh_new"})
+
+    with patch.object(network_endpoints, "delete_webhook", new_callable=AsyncMock) as mock_delete:
+        webhook_ids = await network_endpoints.register_webhook(webhook_url, "secret", config_entry_id)
+
+        # wh_old_url and wh_other_name should be deleted
+        assert mock_delete.call_count == 2
+        deleted_ids = [call.args[1] for call in mock_delete.call_args_list]
+        assert "wh_old_url" in deleted_ids
+        assert "wh_other_name" in deleted_ids
+        assert "wh_unrelated" not in deleted_ids
+
+    assert webhook_ids == ["wh_new"]
+    # Should call create once
+    mock_api_client.dashboard.networks.createNetworkWebhooksHttpServer.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_register_webhook_multiple_networks(network_endpoints, mock_api_client):
+    """Test registration across multiple networks."""
+    networks = [{"id": "n1"}, {"id": "n2"}]
+    webhook_url = "https://example.com/webhook"
+    config_entry_id = "entry123"
+
+    mock_api_client.organization.get_organization_networks.return_value = networks
+    mock_api_client.dashboard.networks.getNetworkWebhooksHttpServers = AsyncMock(return_value=[])
+    mock_api_client.dashboard.networks.createNetworkWebhooksHttpServer = AsyncMock()
+    mock_api_client.dashboard.networks.createNetworkWebhooksHttpServer.side_effect = [{"id": "wh_n1"}, {"id": "wh_n2"}]
+
+    webhook_ids = await network_endpoints.register_webhook(webhook_url, "secret", config_entry_id)
+
+    assert webhook_ids == ["wh_n1", "wh_n2"]
+    assert mock_api_client.dashboard.networks.createNetworkWebhooksHttpServer.call_count == 2


### PR DESCRIPTION
This change implements an idempotent webhook registration strategy to prevent exhausting the Meraki API limit (100 HTTP servers per network). The refactored logic in `NetworkEndpoints` now fetches fresh webhook data directly from the API, identifies and deletes orphaned or conflicting webhooks (matching the name pattern or URL but not both), and reuses exact matches. This ensures that each integration entry maintains exactly one correct webhook per network. The requirements document has been updated to include R13: Webhook Lifecycle Management.

Fixes #2485

---
*PR created automatically by Jules for task [16773554822808747682](https://jules.google.com/task/16773554822808747682) started by @brewmarsh*