### PR TITLE
Add BAML Natural Language Intent Router for Assist

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -36,6 +36,7 @@ from .core.repositories.camera_repository import CameraRepository
 from .core.repository import MerakiRepository
 from .discovery.service import DeviceDiscoveryService
 from .helpers.migrations import async_cleanup_ghost_devices, async_migrate_entities
+from .intent import async_setup_intents
 from .services import async_setup_services
 from .services.camera_service import CameraService
 from .services.device_control_service import DeviceControlService
@@ -77,6 +78,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     # Set up services
     await async_setup_services(hass)
+
+    # Set up intents
+    await async_setup_intents(hass)
 
     return True
 

--- a/custom_components/meraki_ha/intent.py
+++ b/custom_components/meraki_ha/intent.py
@@ -1,0 +1,219 @@
+"""Intents for the Meraki HA integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from baml_client import b
+from baml_client.types import MerakiIntent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from .const.integration import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+INTENT_MERAKI_SMART_COMMAND = "MerakiSmartCommand"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the Meraki intents."""
+    intent.async_register(hass, MerakiSmartCommandHandler())
+
+
+class MerakiSmartCommandHandler(intent.IntentHandler):
+    """Handle Meraki smart commands."""
+
+    intent_type = INTENT_MERAKI_SMART_COMMAND
+    slot_schema = {intent.vol.Required("command"): intent.cv.string}
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Handle the intent."""
+        slots = self.async_validate_slots(intent_obj.slots)
+        user_text = slots.get("command", {}).get("value")
+
+        if not user_text:
+            response = intent_obj.create_response()
+            response.async_set_speech("I didn't receive a command to process.")
+            return response
+
+        _LOGGER.debug("Received Meraki smart command: %s", user_text)
+
+        # Pass to BAML
+        try:
+            baml_response = await b.RouteMerakiIntent(user_command=user_text)
+        except Exception as err:
+            _LOGGER.error("BAML routing failed: %s", err)
+            response = intent_obj.create_response()
+            response.async_set_speech(
+                "I'm sorry, I had trouble processing that network command."
+            )
+            return response
+
+        _LOGGER.debug("BAML response: %s", baml_response)
+
+        response = intent_obj.create_response()
+
+        if baml_response.intent == MerakiIntent.Unknown:
+            response.async_set_speech(
+                "I'm not sure how to help with that Meraki command."
+            )
+            return response
+
+        # Execute the command
+        speech = await self._async_execute_intent(intent_obj.hass, baml_response)
+        response.async_set_speech(speech)
+        return response
+
+    async def _async_execute_intent(
+        self, hass: HomeAssistant, baml_response: Any
+    ) -> str:
+        """Execute the parsed intent."""
+        if baml_response.intent == MerakiIntent.RebootDevice:
+            return await self._async_handle_reboot(hass, baml_response)
+        if baml_response.intent == MerakiIntent.GenerateGuestAccess:
+            return await self._async_handle_guest_access(hass, baml_response)
+        if baml_response.intent == MerakiIntent.GetNetworkStatus:
+            return await self._async_handle_network_status(hass, baml_response)
+        if baml_response.intent == MerakiIntent.CycleSwitchPort:
+            return "Power cycling switch ports via voice is not yet implemented."
+
+        return "Command recognized but execution is not yet supported."
+
+    async def _async_handle_reboot(self, hass: HomeAssistant, baml_response: Any) -> str:
+        """Handle reboot device intent."""
+        target = baml_response.target_device
+        if not target:
+            return "I need to know which device you want to reboot."
+
+        # Find device
+        device_data = self._find_device_by_name(hass, target)
+        if not device_data:
+            return f"I couldn't find a Meraki device named {target}."
+
+        entry_id, serial = device_data
+        device_control_service = hass.data[DOMAIN][entry_id]["device_control_service"]
+
+        try:
+            await device_control_service.async_reboot(serial)
+            return f"Restarting {target} now."
+        except Exception as err:
+            _LOGGER.error("Failed to reboot %s: %s", target, err)
+            return f"I encountered an error while trying to reboot {target}."
+
+    async def _async_handle_guest_access(
+        self, hass: HomeAssistant, baml_response: Any
+    ) -> str:
+        """Handle generate guest access intent."""
+        network_name = baml_response.network_name
+        guest_name = baml_response.guest_name or "Guest"
+        duration = baml_response.duration_minutes or 60
+
+        # Find network
+        network_data = self._find_network_by_name(hass, network_name)
+        if not network_data:
+            if network_name:
+                return f"I couldn't find a Meraki network named {network_name}."
+            return "I need to know which network to create guest access for."
+
+        entry_id, network_id = network_data
+        ipsk_manager = hass.data[DOMAIN].get("ipsk_manager")
+
+        if not ipsk_manager:
+            return "Guest access management is not available right now."
+
+        # We need an SSID to use. For now, let's assume SSID 1 or try to find a suitable one.
+        # Ideally BAML or the intent should specify.
+        # Defaulting to SSID 1 for now as a placeholder.
+        ssid_number = "1"
+
+        try:
+            key = await ipsk_manager.create_guest_key(
+                config_entry_id=entry_id,
+                network_id=network_id,
+                ssid_number=ssid_number,
+                duration_minutes=duration,
+                name=guest_name,
+            )
+            return (
+                f"Generated guest access for {guest_name}. "
+                f"The password is {key['passphrase']}."
+            )
+        except Exception as err:
+            _LOGGER.error("Failed to generate guest access: %s", err)
+            return "I couldn't create the guest password at this time."
+
+    async def _async_handle_network_status(
+        self, hass: HomeAssistant, baml_response: Any
+    ) -> str:
+        """Handle network status intent."""
+        network_name = baml_response.network_name
+        network_data = self._find_network_by_name(hass, network_name)
+
+        if not network_data:
+            if network_name:
+                return f"I couldn't find a Meraki network named {network_name}."
+            return "I'm not sure which network you're asking about."
+
+        entry_id, network_id = network_data
+        network_control_service = hass.data[DOMAIN][entry_id]["network_control_service"]
+        main_coordinator = hass.data[DOMAIN][entry_id]["main_coordinator"]
+
+        # Get actual network name from coordinator for friendly response
+        actual_name = main_coordinator.networks_by_id.get(network_id, {}).get(
+            "name", network_name
+        )
+        client_count = network_control_service.get_network_client_count(network_id)
+
+        return f"The {actual_name} network currently has {client_count} active clients."
+
+    def _find_device_by_name(
+        self, hass: HomeAssistant, name: str
+    ) -> tuple[str, str] | None:
+        """Find device by name in all config entries."""
+        search_name = name.lower()
+        for entry_id, entry_data in hass.data[DOMAIN].items():
+            if not isinstance(entry_data, dict):
+                continue
+            main_coordinator = entry_data.get("main_coordinator")
+            if not main_coordinator or not main_coordinator.devices_by_serial:
+                continue
+
+            for serial, device in main_coordinator.devices_by_serial.items():
+                if device.get("name", "").lower() == search_name:
+                    return entry_id, serial
+        return None
+
+    def _find_network_by_name(
+        self, hass: HomeAssistant, name: str | None
+    ) -> tuple[str, str] | None:
+        """Find network by name in all config entries."""
+        if not name:
+            # If no name provided, and only one entry/network exists, return it
+            all_networks = []
+            for entry_id, entry_data in hass.data[DOMAIN].items():
+                if not isinstance(entry_data, dict):
+                    continue
+                main_coordinator = entry_data.get("main_coordinator")
+                if not main_coordinator or not main_coordinator.networks_by_id:
+                    continue
+                for net_id in main_coordinator.networks_by_id:
+                    all_networks.append((entry_id, net_id))
+
+            if len(all_networks) == 1:
+                return all_networks[0]
+            return None
+
+        search_name = name.lower()
+        for entry_id, entry_data in hass.data[DOMAIN].items():
+            if not isinstance(entry_data, dict):
+                continue
+            main_coordinator = entry_data.get("main_coordinator")
+            if not main_coordinator or not main_coordinator.networks_by_id:
+                continue
+
+            for net_id, network in main_coordinator.networks_by_id.items():
+                if network.get("name", "").lower() == search_name:
+                    return entry_id, net_id
+        return None

--- a/custom_components/meraki_ha/intents.yaml
+++ b/custom_components/meraki_ha/intents.yaml
@@ -1,0 +1,5 @@
+MerakiSmartCommand:
+  data:
+    sentences:
+      - "[can you] [please] {command}"
+      - "{command}"

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -59,4 +59,9 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** `baml-py` added to dependencies.
   - **[VERIFIED]** `baml_src` configuration and generation logic established.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14) are now considered part of the standard for this integration.
+- R15: Native Assist Integration:
+  - **[IN PROGRESS]** Implementation of a custom Intent Handler to expose BAML-powered Natural Language Intent Routing to Home Assistant's native Assist conversation pipeline.
+  - **[IN PROGRESS]** Registration of `MerakiSmartCommand` intent.
+  - **[IN PROGRESS]** Mapping of BAML-parsed intents (Reboot, Guest Access, Status) to internal services.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15) are now considered part of the standard for this integration.

--- a/tests/test_meraki_intent.py
+++ b/tests/test_meraki_intent.py
@@ -1,0 +1,140 @@
+"""Test the Meraki intent handler."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from baml_client.types import MerakiIntent, MerakiIntentResponse
+from custom_components.meraki_ha.const.integration import DOMAIN
+from custom_components.meraki_ha.intent import MerakiSmartCommandHandler
+from homeassistant.helpers import intent
+
+
+@pytest.fixture
+def intent_handler():
+    """Fixture for the intent handler."""
+    return MerakiSmartCommandHandler()
+
+
+async def test_handle_reboot_success(hass, intent_handler):
+    """Test successful reboot intent handling."""
+    # Mock BAML response
+    baml_response = MerakiIntentResponse(
+        intent=MerakiIntent.RebootDevice,
+        target_device="Garage Switch",
+        guest_name=None,
+        duration_minutes=None,
+        network_name=None,
+    )
+
+    # Setup mock data in hass
+    serial = "ABCD-1234-EFGH"
+    entry_id = "test_entry"
+    device_control_service = AsyncMock()
+
+    device = {"name": "Garage Switch"}
+
+    main_coordinator = MagicMock()
+    main_coordinator.devices_by_serial = {serial: device}
+
+    hass.data[DOMAIN] = {
+        entry_id: {
+            "main_coordinator": main_coordinator,
+            "device_control_service": device_control_service,
+        }
+    }
+
+    # Prepare intent object
+    intent_obj = intent.Intent(
+        hass,
+        "MerakiSmartCommand",
+        "reboot Garage Switch",
+        None,
+        None,
+        None,
+        None,
+    )
+    intent_obj.slots = {"command": {"value": "reboot Garage Switch"}}
+
+    with patch("baml_client.b.RouteMerakiIntent", return_value=baml_response):
+        response = await intent_handler.async_handle(intent_obj)
+
+    assert response.speech["plain"]["speech"] == "Restarting Garage Switch now."
+    device_control_service.async_reboot.assert_called_once_with(serial)
+
+
+async def test_handle_guest_access_success(hass, intent_handler):
+    """Test successful guest access intent handling."""
+    # Mock BAML response
+    baml_response = MerakiIntentResponse(
+        intent=MerakiIntent.GenerateGuestAccess,
+        target_device=None,
+        guest_name="GuestUser",
+        duration_minutes=30,
+        network_name="Main Network",
+    )
+
+    # Setup mock data in hass
+    network_id = "N_123"
+    entry_id = "test_entry"
+    ipsk_manager = AsyncMock()
+    ipsk_manager.create_guest_key.return_value = {"passphrase": "secretpassword"}
+
+    network = {"name": "Main Network"}
+
+    main_coordinator = MagicMock()
+    main_coordinator.networks_by_id = {network_id: network}
+
+    hass.data[DOMAIN] = {
+        entry_id: {
+            "main_coordinator": main_coordinator,
+        },
+        "ipsk_manager": ipsk_manager
+    }
+
+    # Prepare intent object
+    intent_obj = intent.Intent(
+        hass,
+        "MerakiSmartCommand",
+        "create guest wifi for GuestUser for 30 minutes on Main Network",
+        None,
+        None,
+        None,
+        None,
+    )
+    intent_obj.slots = {"command": {"value": "create guest wifi for GuestUser for 30 minutes on Main Network"}}
+
+    with patch("baml_client.b.RouteMerakiIntent", return_value=baml_response):
+        response = await intent_handler.async_handle(intent_obj)
+
+    assert "Generated guest access for GuestUser" in response.speech["plain"]["speech"]
+    assert "secretpassword" in response.speech["plain"]["speech"]
+    ipsk_manager.create_guest_key.assert_called_once()
+
+
+async def test_handle_unknown_intent(hass, intent_handler):
+    """Test unknown intent handling."""
+    # Mock BAML response
+    baml_response = MerakiIntentResponse(
+        intent=MerakiIntent.Unknown,
+        target_device=None,
+        guest_name=None,
+        duration_minutes=None,
+        network_name=None,
+    )
+
+    # Prepare intent object
+    intent_obj = intent.Intent(
+        hass,
+        "MerakiSmartCommand",
+        "what is for lunch",
+        None,
+        None,
+        None,
+        None,
+    )
+    intent_obj.slots = {"command": {"value": "what is for lunch"}}
+
+    with patch("baml_client.b.RouteMerakiIntent", return_value=baml_response):
+        response = await intent_handler.async_handle(intent_obj)
+
+    assert response.speech["plain"]["speech"] == "I'm not sure how to help with that Meraki command."


### PR DESCRIPTION
This change exposes the BAML-powered Natural Language Intent Router to Home Assistant's native Assist conversation pipeline. It adds a custom intent handler that processes raw user text, uses the BAML client to extract intents and parameters, and executes the corresponding Meraki service calls. Supported actions include rebooting devices, generating temporary guest wifi access, and checking network status.

Fixes #2498

---
*PR created automatically by Jules for task [10616812499815066491](https://jules.google.com/task/10616812499815066491) started by @brewmarsh*