### PR TITLE
Fix Discovery Coordinator Crash and Logging Bug

### DIFF
--- a/custom_components/meraki_ha/core/entities/__init__.py
+++ b/custom_components/meraki_ha/core/entities/__init__.py
@@ -70,14 +70,20 @@ class BaseMerakiEntity(CoordinatorEntity, Entity, ABC):
         """Get the updated device data from the God dictionary."""
         if not self.coordinator.data or not self._serial:
             return None
-        return self.coordinator.data.get("devices_by_serial", {}).get(self._serial)
+        devices_map = self.coordinator.data.get("devices_by_serial")
+        if not isinstance(devices_map, dict):
+            return None
+        return devices_map.get(self._serial)
 
     @property
     def network_data(self) -> Any | None:
         """Get the updated network data from the God dictionary."""
         if not self.coordinator.data or not self._network_id:
             return None
-        return self.coordinator.data.get("networks_by_id", {}).get(self._network_id)
+        networks_map = self.coordinator.data.get("networks_by_id")
+        if not isinstance(networks_map, dict):
+            return None
+        return networks_map.get(self._network_id)
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/custom_components/meraki_ha/discovery/handlers/universal.py
+++ b/custom_components/meraki_ha/discovery/handlers/universal.py
@@ -199,7 +199,7 @@ class UniversalHandler(BaseDeviceHandler):
             yield self._instantiate_single_entity(cap, provider)
         except Exception as e:
             _LOGGER.error(
-                "Failed to instantiate entity for capability %s on %s: %s",
+                "Failed to instantiate entity for capability %s on %s (%s): %s",
                 cap,
                 self.device.serial,
                 self.device.model,

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -38,7 +38,10 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
         """Get the updated device data from the God dictionary."""
         if not self.coordinator.data or not self._serial:
             return None
-        return self.coordinator.data.get("devices_by_serial", {}).get(self._serial)
+        devices_map = self.coordinator.data.get("devices_by_serial")
+        if not isinstance(devices_map, dict):
+            return None
+        return devices_map.get(self._serial)
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/sensor/client_tracker.py
+++ b/custom_components/meraki_ha/sensor/client_tracker.py
@@ -52,9 +52,10 @@ class ClientTrackerDeviceSensor(CoordinatorEntity, SensorEntity):
 
     def _update_state(self) -> None:
         """Update the state of the sensor."""
-        clients = (
-            self.coordinator.data.get("clients") if self.coordinator.data else None
-        )
+        if not self.coordinator.data:
+            self._attr_native_value = 0
+            return
+        clients = self.coordinator.data.get("clients")
         if isinstance(clients, list):
             self._attr_native_value = len(clients)
         else:
@@ -98,9 +99,12 @@ class MerakiClientSensor(CoordinatorEntity, SensorEntity):
         """Update the state of the sensor."""
         is_online = False
         client_info = {}
-        clients = (
-            self.coordinator.data.get("clients") if self.coordinator.data else None
-        )
+        if not self.coordinator.data:
+            self._attr_native_value = "offline"
+            self._attr_extra_state_attributes = {}
+            self._attr_icon = "mdi:lan-disconnect"
+            return
+        clients = self.coordinator.data.get("clients")
         if isinstance(clients, list):
             for client in clients:
                 if not isinstance(client, dict):

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -136,7 +136,10 @@ class MerakiMtSensor(MerakiSensor, RestoreSensor):
         """Return the device readings as a list if valid."""
         if not self.coordinator.data or not self._serial:
             return None
-        return self.coordinator.data.get("sensor_readings", {}).get(self._serial)
+        readings_map = self.coordinator.data.get("sensor_readings")
+        if not isinstance(readings_map, dict):
+            return None
+        return readings_map.get(self._serial)
 
     def _get_value_from_readings_list(
         self, key: str, readings: list[dict[str, Any]]

--- a/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
@@ -40,13 +40,15 @@ class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity)
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        org_name = "Organization"
+        if self.coordinator.data:
+            org_data = self.coordinator.data.get("organization")
+            if isinstance(org_data, dict):
+                org_name = org_data.get("name", "Organization")
+
         return DeviceInfo(
             identifiers={(DOMAIN, self._org_id)},
-            name=standardize_device_name(
-                self.coordinator.data.get("organization", {}).get(
-                    "name", "Organization"
-                )
-            ),
+            name=standardize_device_name(org_name),
             manufacturer="Cisco Meraki",
         )
 
@@ -58,11 +60,15 @@ class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity)
     @property
     def native_value(self) -> int:
         """Return the state of the sensor."""
-        if not self.coordinator.data or not self.coordinator.data.get("clients"):
+        if not self.coordinator.data:
+            return 0
+
+        clients = self.coordinator.data.get("clients")
+        if not isinstance(clients, list):
             return 0
 
         count = 0
-        for client in self.coordinator.data["clients"]:
+        for client in clients:
             if not isinstance(client, dict):
                 continue
             if client.get("deviceType") == self._device_type:

--- a/tests/sensor/test_setup_mt_sensors.py
+++ b/tests/sensor/test_setup_mt_sensors.py
@@ -102,9 +102,15 @@ def mock_coordinator_with_mt_devices(mock_coordinator: MagicMock) -> MagicMock:
         device = MerakiDevice.from_dict(d)
         for reading in d.get("readings", []):
             _populate_device_reading(device, reading)
+        # Ensure status is online for availability tests
+        device.status = "online"
         devices_objects.append(device)
 
-    mock_coordinator.data = {"devices": devices_objects}
+    mock_coordinator.data = {
+        "devices": devices_objects,
+        "devices_by_serial": {d.serial: d for d in devices_objects},
+        "sensor_readings": {}, # Initialize empty sensor_readings for defensive checks
+    }
     mock_coordinator.devices_by_serial = {d.serial: d for d in devices_objects}
 
     def get_device(serial: str) -> MerakiDevice | None:


### PR DESCRIPTION
The recent coordinator refactor exposed an issue where entity discovery fails if `coordinator.data` is `None` during initialization. This was causing an `AttributeError` in `meraki_mt_base.py`. Additionally, a malformed logging string in `universal.py` was causing a `TypeError`.

This PR fixes these issues by:
1. Adding checks for `self.coordinator.data is None` in all critical data access properties.
2. Ensuring nested lookups (like `sensor_readings` or `devices_by_serial`) check that the parent key exists and is a dictionary.
3. Correcting the `_LOGGER.error` format string in `universal.py` to match the four arguments provided.
4. Updating the MT sensor test fixture to ensure it provides a compatible `coordinator.data` structure, including an initialized `sensor_readings` map and `devices_by_serial` lookup table.

Verified through unit tests and code review.

Fixes #2505

---
*PR created automatically by Jules for task [3478760528699821355](https://jules.google.com/task/3478760528699821355) started by @brewmarsh*