### PR TITLE
Implement Proactive Webhook Garbage Collection

### DIFF
--- a/custom_components/meraki_ha/core/api/endpoints/network.py
+++ b/custom_components/meraki_ha/core/api/endpoints/network.py
@@ -114,6 +114,8 @@ class NetworkEndpoints:
         self, webhook_url: str, secret: str, config_entry_id: str
     ) -> list[str]:
         """Register or update a webhook with the Meraki API."""
+        import asyncio
+
         networks = await self._api_client.organization.get_organization_networks()
         webhook_name = f"Home Assistant Webhook - {config_entry_id}"
         webhook_ids = []
@@ -130,26 +132,35 @@ class NetworkEndpoints:
                 webhooks = []
 
             exact_match = None
+            to_delete = []
+
+            # 1. Identify perfect match and garbage
             for webhook in webhooks:
                 name_match = webhook.get("name") == webhook_name
                 url_match = webhook.get("url") == webhook_url
 
-                # Exact match found - we'll reuse this one
+                # Perfect match found - we'll reuse this one
                 if name_match and url_match:
                     exact_match = webhook
-                    continue
+                # Proactive garbage collection: anything that looks like us but isn't a perfect match
+                elif "Home Assistant Webhook" in webhook.get(
+                    "name", ""
+                ) or webhook.get("url") == webhook_url:
+                    to_delete.append(webhook)
 
-                # Orphaned or conflicting webhook found
-                # Matching name but different URL OR matching URL but different name
-                if name_match or url_match:
-                    _LOGGER.info(
-                        "Deleting orphaned or conflicting webhook '%s' (ID: %s) in network %s",
-                        webhook.get("name"),
-                        webhook.get("id"),
-                        network_id,
-                    )
-                    await self.delete_webhook(network_id, webhook["id"])
+            # 2. Clean up garbage webhooks (Legacy/Orphaned/Conflicting)
+            for webhook in to_delete:
+                _LOGGER.info(
+                    "Deleting orphaned or conflicting webhook '%s' (ID: %s) in network %s",
+                    webhook.get("name"),
+                    webhook.get("id"),
+                    network_id,
+                )
+                await self.delete_webhook(network_id, webhook["id"])
+                # Sleep briefly to avoid 429 rate limits during cleanup
+                await asyncio.sleep(1)
 
+            # 3. Finalize registration
             if exact_match:
                 _LOGGER.debug(
                     "Webhook '%s' already exists in network %s, skipping creation",

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -50,9 +50,10 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** Established O(1) dictionary traversal as the project standard for entity data retrieval from the centralized coordinator. Temporary diagnostic logging in `available` properties and parsers has been removed following the stabilization of the 'God Module' data structure (nested under `devices_by_serial`, `networks_by_id`, and `sensor_readings`).
 
 - **R13: Webhook Lifecycle Management:**
-  - **[IN PROGRESS]** Implementation of idempotent webhook registration to prevent exhausting the Meraki API limit (100 HTTP servers per network).
-  - **[IN PROGRESS]** Automated discovery and deletion of orphaned webhooks matching the Home Assistant name pattern or specific webhook URL.
-  - **[IN PROGRESS]** Reuse of existing webhooks when an exact match (name and URL) is found.
+  - **[VERIFIED]** Implementation of idempotent webhook registration to prevent exhausting the Meraki API limit (100 HTTP servers per network).
+  - **[VERIFIED]** Automated discovery and deletion of orphaned webhooks matching the Home Assistant name pattern or specific webhook URL.
+  - **[VERIFIED]** Proactive self-healing routine for garbage collection of legacy webhooks.
+  - **[VERIFIED]** Reuse of existing webhooks when an exact match (name and URL) is found.
 
 - R14: Structured LLM Outputs (BAML):
   - **[VERIFIED]** BAML (BoundaryML) initialized as the project standard for structured LLM interactions.


### PR DESCRIPTION
Implemented a proactive garbage collection routine for Meraki webhooks. The integration now identifies and deletes legacy or orphaned webhooks that match the "Home Assistant Webhook" naming convention or the target URL, while still reusing exact matches for idempotency. This prevents hitting the Meraki API limit of 100 HTTP servers per network, especially useful in CI/CD environments. A 1-second delay was added between deletions to respect API rate limits. Relevant requirements documentation was updated to reflect these changes.

Fixes #2509

---
*PR created automatically by Jules for task [4071082708929807527](https://jules.google.com/task/4071082708929807527) started by @brewmarsh*