### PR TITLE
Fix unhandled exception in webhook registration

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -236,7 +236,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         secret = entry.data["webhook_secret"]
 
-    await async_register_webhook(hass, webhook_id, secret, api_client, entry=entry)
+    try:
+        await async_register_webhook(hass, webhook_id, secret, api_client, entry=entry)
+    except Exception as e:
+        _LOGGER.error(
+            "Failed to register webhook. Fast updates disabled, falling back to polling. Error: %s",
+            e,
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/meraki_ha/webhook.py
+++ b/custom_components/meraki_ha/webhook.py
@@ -152,9 +152,8 @@ async def async_register_webhook(
         entry: The config entry.
 
     """
-    webhook.async_register(hass, DOMAIN, "Meraki", webhook_id, async_handle_webhook)
-
     try:
+        webhook.async_register(hass, DOMAIN, "Meraki", webhook_id, async_handle_webhook)
         webhook_url, resolved_id = _resolve_registration_params(
             hass, webhook_id, entry, config_entry_id
         )

--- a/tests/test_webhook_fault_tolerance.py
+++ b/tests/test_webhook_fault_tolerance.py
@@ -1,0 +1,29 @@
+"""Tests for Meraki webhook registration fault tolerance."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.meraki_ha.webhook import async_register_webhook
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def mock_api_client():
+    """Mock the Meraki API client."""
+    client = AsyncMock()
+    client.register_webhook = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_async_register_webhook_fault_tolerance(hass: HomeAssistant, mock_api_client):
+    """Test that async_register_webhook does not raise exceptions."""
+    mock_api_client.register_webhook.side_effect = Exception("API Error")
+
+    with patch("homeassistant.components.webhook.async_register") as mock_ha_register:
+        # This should not raise despite the side_effect
+        await async_register_webhook(hass, "test_webhook_id", "test_secret", mock_api_client)
+
+    assert mock_ha_register.called
+    # It should have caught the exception and logged it (we can't easily check logs here without more setup)


### PR DESCRIPTION
This change makes the Meraki integration setup process resilient to webhook registration failures. Previously, if `async_register_webhook` raised an exception (e.g., due to a connection error or invalid public URL), the entire `async_setup_entry` would abort, preventing any entities from loading. 

The fix involves wrapping the registration call in a `try...except` block in `__init__.py` and consolidating the registration logic inside a `try...except` block in `webhook.py`. If registration fails, the integration now logs a descriptive error and continues loading, falling back to standard polling mode.

Verified with existing and new tests.

Fixes #2508

---
*PR created automatically by Jules for task [9367523714205257012](https://jules.google.com/task/9367523714205257012) started by @brewmarsh*