### PR TITLE
Remove extra debug logging

### DIFF
--- a/custom_components/meraki_ha/core/parsers/sensors.py
+++ b/custom_components/meraki_ha/core/parsers/sensors.py
@@ -123,8 +123,6 @@ def _merge_battery_readings(
 def _process_reading(device: MerakiDevice, reading: dict[str, Any]) -> None:
     """Process a single reading for a device."""
     metric = reading.get("metric")
-    if metric == "power":
-        _LOGGER.debug("MT40 Power Reading Payload: %s", reading)
 
     if metric and metric in METRIC_HANDLERS:
         METRIC_HANDLERS[metric](device, reading)

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -197,13 +197,4 @@ class MerakiDeviceStatusSensor(MerakiSensor):
 
         # Check if the specific device data is available
         device = self.coordinator.get_device(self._device_serial)
-        is_avail = device is not None
-
-        if not is_avail:
-            _LOGGER.debug(
-                "Device Status Sensor %s unavailable: device %s not found in coordinator lookup",
-                self.unique_id,
-                self._device_serial,
-            )
-
-        return is_avail
+        return device is not None


### PR DESCRIPTION
I have removed several high-frequency diagnostic logs that were contributing to log noise in production, specifically in the sensor parsers and device status entities. While the specific strings mentioned in the prompt appear to have been already removed (consistent with Requirement R12), I have cleaned up remaining noisy debug statements.

Fixes #2487

---
*PR created automatically by Jules for task [10111956292422041571](https://jules.google.com/task/10111956292422041571) started by @brewmarsh*