### PR TITLE
Address edge case Meraki entities availability

### DIFF
--- a/custom_components/meraki_ha/button/reboot.py
+++ b/custom_components/meraki_ha/button/reboot.py
@@ -50,9 +50,9 @@ class MerakiRebootButton(MerakiEntity, ButtonEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return super().available and self.device_data is not None
+        return super().available
 
     async def async_press(self) -> None:
         """Handle the button press."""
-        if self._device.serial:
-            await self._control_service.async_reboot(self._device.serial)
+        if serial := self._serial:
+            await self._control_service.async_reboot(serial)

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -47,15 +47,24 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
     def available(self) -> bool:
         """Return if entity is available.
 
-        An entity is available if its coordinator has data and the device is online.
+        An entity is available if its coordinator has data and the device is not offline.
         """
         if not self.coordinator.data:
             return False
 
-        # If we have a serial, check if the device is online in the O(1) data
+        # If we have a serial, check if the device is online/alerting/dormant in the O(1) data
         if self._serial:
             device = self.device_data
-            return device is not None and getattr(device, "status", "offline") == "online"
+            if device is None:
+                return False
+
+            # Handle both object and dictionary-style data
+            if isinstance(device, dict):
+                status = device.get("status", "offline")
+            else:
+                status = getattr(device, "status", "offline")
+
+            return status in ("online", "alerting", "dormant")
 
         return True
 

--- a/custom_components/meraki_ha/switch/meraki_device_led_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_device_led_switch.py
@@ -10,8 +10,8 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from ..entity import MerakiEntity
 from ..coordinators import MerakiSwitchCoordinator
 from ..core.models.device import MerakiDevice
 from ..helpers.device_info_helpers import resolve_device_info
@@ -19,7 +19,7 @@ from ..helpers.device_info_helpers import resolve_device_info
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiDeviceLEDSwitch(CoordinatorEntity, SwitchEntity):
+class MerakiDeviceLEDSwitch(MerakiEntity, SwitchEntity):
     """Switch for controlling Meraki device LEDs."""
 
     _attr_entity_category = EntityCategory.CONFIG
@@ -47,12 +47,6 @@ class MerakiDeviceLEDSwitch(CoordinatorEntity, SwitchEntity):
         )
         self._update_state()
 
-    def _get_current_device_data(self) -> MerakiDevice | None:
-        """Retrieve the latest data for this switch's device from the coordinator."""
-        if self._device_serial:
-            return self.coordinator.get_device(self._device_serial)
-        return None
-
     @callback
     def _update_state(self) -> None:
         """Update the state of the switch."""
@@ -60,9 +54,21 @@ class MerakiDeviceLEDSwitch(CoordinatorEntity, SwitchEntity):
         if self.unique_id and self.coordinator.is_pending(self.unique_id):
             return
 
-        device = self._get_current_device_data()
-        if device and device.management_interface:
-            self._attr_is_on = device.management_interface.get("ledLights", True)
+        device = self.device_data
+        # Handle both object and dictionary-style device data
+        management_interface = None
+        if device:
+            if isinstance(device, dict):
+                management_interface = device.get("management_interface")
+            else:
+                management_interface = getattr(device, "management_interface", None)
+
+        if management_interface:
+            # Handle both object and dictionary-style management_interface
+            if isinstance(management_interface, dict):
+                self._attr_is_on = management_interface.get("ledLights", True)
+            else:
+                self._attr_is_on = getattr(management_interface, "ledLights", True)
         else:
             self._attr_is_on = True  # Default to on
 
@@ -70,7 +76,7 @@ class MerakiDeviceLEDSwitch(CoordinatorEntity, SwitchEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._update_state()
-        self.async_write_ha_state()
+        super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the LEDs on."""
@@ -110,6 +116,4 @@ class MerakiDeviceLEDSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if self.coordinator.data is None:
-            return False
-        return super().available and self._get_current_device_data() is not None
+        return super().available

--- a/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_ssid_device_switch.py
@@ -119,7 +119,7 @@ class MerakiSSIDBaseSwitch(MerakiEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        if self.coordinator.data is None or not super().available:
+        if not super().available:
             return False
         ssid_data = self._get_current_ssid_data()
         return ssid_data is not None and ssid_data.get("enabled", False)
@@ -204,7 +204,8 @@ class MerakiSSIDEnabledSwitch(MerakiSSIDBaseSwitch):
     @property
     def available(self) -> bool:
         """Return True even when disabled so you can toggle it back on."""
-        if self.coordinator.data is None or not self.coordinator.last_update_success:
+        # We skip MerakiSSIDBaseSwitch.available check for "enabled" as it checks if it's already enabled
+        if not super(MerakiSSIDBaseSwitch, self).available or not self.coordinator.last_update_success:
             return False
         return self._get_current_ssid_data() is not None
 

--- a/tests/sensor/device/test_meraki_mt_sensor.py
+++ b/tests/sensor/device/test_meraki_mt_sensor.py
@@ -17,57 +17,62 @@ from custom_components.meraki_ha.types import MerakiDevice
 @pytest.fixture
 def mock_coordinator_mt_sensor(mock_coordinator: MagicMock) -> MagicMock:
     """Fixture for a mocked MerakiDataCoordinator with MT sensor data."""
+    device1 = MerakiDevice.from_dict(
+        {
+            "serial": "mt10-1",
+            "name": "MT10 Sensor",
+            "model": "MT10",
+            "productType": "sensor",
+            "status": "online",
+        }
+    )
+    device2 = MerakiDevice.from_dict(
+        {
+            "serial": "mt30-1",
+            "name": "MT30 Button",
+            "model": "MT30",
+            "productType": "sensor",
+            "status": "online",
+        }
+    )
+
     mock_coordinator.data = {
-        "devices": [
-            MerakiDevice.from_dict(
+        "devices": [device1, device2],
+        "devices_by_serial": {
+            "mt10-1": device1,
+            "mt30-1": device2,
+        },
+        "sensor_readings": {
+            "mt10-1": [
                 {
-                    "serial": "mt10-1",
-                    "name": "MT10 Sensor",
-                    "model": "MT10",
-                    "productType": "sensor",
-                    "readings": [
-                        {
-                            "metric": "temperature",
-                            "temperature": {"celsius": 25.5},
-                        },
-                        {
-                            "metric": "humidity",
-                            "humidity": {"relativePercentage": 50},
-                        },
-                        {
-                            "metric": "battery",
-                            "battery": {"percentage": 95},
-                        },
-                    ],
-                }
-            ),
-            MerakiDevice.from_dict(
+                    "metric": "temperature",
+                    "temperature": {"celsius": 25.5},
+                },
                 {
-                    "serial": "mt30-1",
-                    "name": "MT30 Button",
-                    "model": "MT30",
-                    "productType": "sensor",
-                    "readings": [
-                        {
-                            "metric": "battery",
-                            "battery": {"percentage": 88},
-                        },
-                        {
-                            "metric": "button",
-                            "button": {"pressType": "short"},
-                        },
-                    ],
-                }
-            ),
-        ]
+                    "metric": "humidity",
+                    "humidity": {"relativePercentage": 50},
+                },
+                {
+                    "metric": "battery",
+                    "battery": {"percentage": 95},
+                },
+            ],
+            "mt30-1": [
+                {
+                    "metric": "battery",
+                    "battery": {"percentage": 88},
+                },
+                {
+                    "metric": "button",
+                    "button": {"pressType": "short"},
+                },
+            ],
+        }
     }
 
     # Mock get_device to return the correct device
     def get_device(serial):
-        for d in mock_coordinator.data["devices"]:
-            if d.serial == serial:
-                return d
-        return None
+        return mock_coordinator.data["devices_by_serial"].get(serial)
 
     mock_coordinator.get_device.side_effect = get_device
     return mock_coordinator

--- a/tests/test_availability_edge_cases.py
+++ b/tests/test_availability_edge_cases.py
@@ -1,0 +1,68 @@
+"""Tests for Meraki availability edge cases."""
+
+from unittest.mock import MagicMock
+import pytest
+from custom_components.meraki_ha.entity import MerakiEntity
+
+@pytest.fixture
+def mock_coordinator_availability():
+    """Fixture for a mocked coordinator with specific device status."""
+    coordinator = MagicMock()
+    coordinator.data = {
+        "devices_by_serial": {
+            "online_serial": {"serial": "online_serial", "status": "online"},
+            "alerting_serial": {"serial": "alerting_serial", "status": "alerting"},
+            "dormant_serial": {"serial": "dormant_serial", "status": "dormant"},
+            "offline_serial": {"serial": "offline_serial", "status": "offline"},
+            "unknown_serial": {"serial": "unknown_serial", "status": "something_else"},
+            "dict_online": {"serial": "dict_online", "status": "online"},
+        }
+    }
+    return coordinator
+
+def test_meraki_entity_availability_statuses(mock_coordinator_availability):
+    """Test that MerakiEntity reports available for correct statuses."""
+
+    # Online
+    entity_online = MerakiEntity(mock_coordinator_availability)
+    entity_online._device_serial = "online_serial"
+    assert entity_online.available is True
+
+    # Alerting
+    entity_alerting = MerakiEntity(mock_coordinator_availability)
+    entity_alerting._device_serial = "alerting_serial"
+    assert entity_alerting.available is True
+
+    # Dormant
+    entity_dormant = MerakiEntity(mock_coordinator_availability)
+    entity_dormant._device_serial = "dormant_serial"
+    assert entity_dormant.available is True
+
+    # Offline
+    entity_offline = MerakiEntity(mock_coordinator_availability)
+    entity_offline._device_serial = "offline_serial"
+    assert entity_offline.available is False
+
+    # Unknown/Other
+    entity_unknown = MerakiEntity(mock_coordinator_availability)
+    entity_unknown._device_serial = "unknown_serial"
+    assert entity_unknown.available is False
+
+def test_meraki_entity_availability_no_data(mock_coordinator_availability):
+    """Test availability when coordinator has no data."""
+    mock_coordinator_availability.data = None
+    entity = MerakiEntity(mock_coordinator_availability)
+    entity._device_serial = "online_serial"
+    assert entity.available is False
+
+def test_meraki_entity_availability_missing_serial(mock_coordinator_availability):
+    """Test availability when serial is not in coordinator data."""
+    entity = MerakiEntity(mock_coordinator_availability)
+    entity._device_serial = "missing_serial"
+    assert entity.available is False
+
+def test_meraki_entity_availability_no_serial_attribute(mock_coordinator_availability):
+    """Test availability when entity has no serial attribute (e.g. network entity)."""
+    entity = MerakiEntity(mock_coordinator_availability)
+    # No _device_serial, _serial, etc.
+    assert entity.available is True


### PR DESCRIPTION
This change addresses the issue where Meraki entities were showing as unavailable when their status was 'alerting' or 'dormant'. It also refactors several button and switch entities to inherit from the base `MerakiEntity` and use the centralized availability logic and standardized `device_data` properties, ensuring robustness against different data formats (dictionaries vs. objects). Additionally, it updates the MT sensor tests to align with the modern 'God Dictionary' data structure.

Fixes #2514

---
*PR created automatically by Jules for task [6059353291064946712](https://jules.google.com/task/6059353291064946712) started by @brewmarsh*