### PR TITLE
Fix empty API response handling and RTSP stream auto-enable configuration

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from custom_components.meraki_ha.const.config import CONF_ENABLE_CAMERA_ENTITIES
+from custom_components.meraki_ha.const.config import (
+    CONF_ENABLE_CAMERA_ENTITIES,
+    CONF_RTSP_STREAM_ENABLED,
+)
 from custom_components.meraki_ha.const.integration import DOMAIN
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -114,7 +117,7 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         await super().async_added_to_hass()
 
         if (
-            self.coordinator.config_entry.options.get(CONF_ENABLE_CAMERA_ENTITIES, True)
+            self.coordinator.config_entry.options.get(CONF_RTSP_STREAM_ENABLED, False)
             and not self.device_data.rtsp_url
         ):
             # Move the blocking API call to a background task to prevent Setup timeout

--- a/custom_components/meraki_ha/core/utils/api/formatters.py
+++ b/custom_components/meraki_ha/core/utils/api/formatters.py
@@ -39,11 +39,12 @@ def validate_response(response: Any) -> Any:
 
     Raises
     ------
-        MerakiConnectionError: If response is invalid or empty
+        MerakiConnectionError: If response is invalid
 
     """
     if response is None:
-        raise MerakiConnectionError("Empty response from API")
+        _LOGGER.warning("Empty response from API")
+        return {}
 
     if isinstance(response, dict):
         if not response:

--- a/tests/camera/test_camera_auto_stream.py
+++ b/tests/camera/test_camera_auto_stream.py
@@ -6,7 +6,10 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.meraki_ha.camera import MerakiRTSPStreamCamera
-from custom_components.meraki_ha.const.config import CONF_ENABLE_CAMERA_ENTITIES
+from custom_components.meraki_ha.const.config import (
+    CONF_ENABLE_CAMERA_ENTITIES,
+    CONF_RTSP_STREAM_ENABLED,
+)
 from tests.const import MOCK_CAMERA_DEVICE
 
 
@@ -53,7 +56,10 @@ async def test_camera_auto_enables_stream(
         mock_device_data.return_value = device_no_rtsp
 
         # Enable camera entities option
-        mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: True}
+        mock_config_entry.options = {
+            CONF_ENABLE_CAMERA_ENTITIES: True,
+            CONF_RTSP_STREAM_ENABLED: True,
+        }
 
         # Act
         # In HA 2024.12+, async_create_background_task is the preferred way.
@@ -91,7 +97,10 @@ async def test_camera_does_not_auto_enable_if_already_streaming(
     # Arrange
     mock_camera.hass = hass
     # device_data already has rtsp_url from MOCK_CAMERA_DEVICE
-    mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: True}
+    mock_config_entry.options = {
+        CONF_ENABLE_CAMERA_ENTITIES: True,
+        CONF_RTSP_STREAM_ENABLED: True,
+    }
 
     # Act
     await mock_camera.async_added_to_hass()
@@ -122,8 +131,11 @@ async def test_camera_does_not_auto_enable_if_option_disabled(
         device_no_rtsp = dataclasses.replace(MOCK_CAMERA_DEVICE, rtsp_url=None)
         mock_device_data.return_value = device_no_rtsp
 
-        # Disable camera entities option
-        mock_config_entry.options = {CONF_ENABLE_CAMERA_ENTITIES: False}
+        # Disable RTSP stream option
+        mock_config_entry.options = {
+            CONF_ENABLE_CAMERA_ENTITIES: True,
+            CONF_RTSP_STREAM_ENABLED: False,
+        }
 
         # Act
         # Even if we don't expect a task, we should mock it to be safe

--- a/tests/core/utils/test_api_utils.py
+++ b/tests/core/utils/test_api_utils.py
@@ -125,8 +125,8 @@ async def test_handle_meraki_errors_empty_response():
 
 def test_validate_response():
     """Test the validate_response function."""
-    with pytest.raises(MerakiConnectionError):
-        validate_response(None)
+    # None is now allowed, returns an empty dict
+    assert validate_response(None) == {}
 
     # Empty dicts are now allowed, but will log a warning
     assert validate_response({}) == {}


### PR DESCRIPTION
This PR addresses two critical bugs identified in the `ha-camera-refactor2` requirements:
1. **R4 (API Robustness):** Fixed an issue where `validate_response` would raise a connection error if an empty (`None`) response was received from the Meraki API. This commonly happens on empty but successful payload responses, such as 204 No Content. `validate_response` will now return an empty dictionary `{}` instead, preventing crashes.
2. **R3 (Configuration Honored):** The integration previously auto-enabled RTSP streams for cameras in the background merely if the camera entities option was enabled (`CONF_ENABLE_CAMERA_ENTITIES`). This has been changed to specifically check the `CONF_RTSP_STREAM_ENABLED` user configuration.

Unit tests have been updated and are passing successfully.

---
*PR created automatically by Jules for task [5493012590955983453](https://jules.google.com/task/5493012590955983453) started by @brewmarsh*