### PR TITLE
Eliminate deprecated POWER_VOLT_AMPERE constant

### DIFF
--- a/custom_components/meraki_ha/descriptions.py
+++ b/custom_components/meraki_ha/descriptions.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
-    POWER_VOLT_AMPERE,
+    UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -52,7 +52,7 @@ MT_APPARENT_POWER_DESCRIPTION = SensorEntityDescription(
     name="Apparent Power",
     device_class=SensorDeviceClass.APPARENT_POWER,
     state_class=SensorStateClass.MEASUREMENT,
-    native_unit_of_measurement=POWER_VOLT_AMPERE,
+    native_unit_of_measurement=UnitOfApparentPower.VOLT_AMPERE,
 )
 
 


### PR DESCRIPTION
The integration was crashing during setup due to an `ImportError` when attempting to import `POWER_VOLT_AMPERE` from `homeassistant.const`. This constant has been deprecated and removed in recent Home Assistant versions in favor of the `UnitOfApparentPower` Enum.

I have:
1.  Identified the usage of `POWER_VOLT_AMPERE` in `custom_components/meraki_ha/descriptions.py`.
2.  Updated the import statement to include `UnitOfApparentPower` and removed the reference to `POWER_VOLT_AMPERE`.
3.  Updated `MT_APPARENT_POWER_DESCRIPTION` to use `UnitOfApparentPower.VOLT_AMPERE` as the `native_unit_of_measurement`.
4.  Verified that other power and energy units in the same file were already correctly using their respective Enums (`UnitOfPower`, `UnitOfEnergy`, etc.).
5.  Verified the changes by reading the file and running relevant tests. Existing test failures in the suite were confirmed to be unrelated to these changes.

Fixes #2527

---
*PR created automatically by Jules for task [12260875017977426891](https://jules.google.com/task/12260875017977426891) started by @brewmarsh*