### PR TITLE
Unblock config flow with lazy SDK imports

### DIFF
--- a/custom_components/meraki_ha/authentication.py
+++ b/custom_components/meraki_ha/authentication.py
@@ -8,18 +8,21 @@ against the Meraki Dashboard API using the Meraki SDK.
 from __future__ import annotations
 
 import logging
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from meraki.exceptions import APIError as MerakiSDKAPIError
 
-from .core.api import MerakiApiClientProtocol, create_api_client
 from .core.errors import (
     InvalidOrgID,  # Ensure this is imported for validation logic
     MerakiAuthenticationError,
     MerakiConnectionError,
 )
+
+if TYPE_CHECKING:
+    from meraki.exceptions import APIError as MerakiSDKAPIError
+    from .core.api import MerakiApiClientProtocol
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +52,8 @@ class MerakiAuthentication:
 
     async def _async_get_authenticated_client(self) -> MerakiApiClientProtocol:
         """Initialize and setup the Meraki API client."""
+        from .core.api import create_api_client
+
         client = create_api_client(
             hass=self.hass,
             api_key=self.api_key,
@@ -105,6 +110,8 @@ class MerakiAuthentication:
             MerakiConnectionError: If there is a connection error.
 
         """
+        from meraki.exceptions import APIError as MerakiSDKAPIError
+
         client = await self._async_get_authenticated_client()
 
         try:

--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -16,8 +16,6 @@ from .const.config import (
     CONF_MERAKI_ORG_ID,
 )
 from .const.integration import DOMAIN
-from .core.api import create_api_client
-from .schemas import STEP_USER_DATA_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +27,9 @@ class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
+        from .core.api import create_api_client
+        from .schemas import STEP_USER_DATA_SCHEMA
+
         errors: dict[str, str] = {}
         if user_input is not None:
             try:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -29,10 +29,12 @@ async def test_validate_meraki_credentials(hass: HomeAssistant) -> None:
 
     """
     with patch(
-        "custom_components.meraki_ha.authentication.create_api_client",
-    ) as mock_client:
-        mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.organization.get_organization = AsyncMock(
+        "custom_components.meraki_ha.core.api.create_api_client",
+    ) as mock_create_client:
+        mock_client = AsyncMock()
+        mock_create_client.return_value = mock_client
+        mock_client.async_setup = AsyncMock()
+        mock_client.organization.get_organization = AsyncMock(
             return_value={"id": "test-org-id", "name": "Test Org"},
         )
         result = await validate_meraki_credentials(hass, "test-api-key", "test-org-id")
@@ -51,12 +53,14 @@ async def test_validate_meraki_credentials_invalid_org(hass: HomeAssistant) -> N
     """
     with (
         patch(
-            "custom_components.meraki_ha.authentication.create_api_client",
-        ) as mock_client,
+            "custom_components.meraki_ha.core.api.create_api_client",
+        ) as mock_create_client,
         pytest.raises(InvalidOrgID),
     ):
-        mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.organization.get_organization = AsyncMock(
+        mock_client = AsyncMock()
+        mock_create_client.return_value = mock_client
+        mock_client.async_setup = AsyncMock()
+        mock_client.organization.get_organization = AsyncMock(
             return_value={},
         )
         await validate_meraki_credentials(hass, "test-api-key", "test-org-id")
@@ -74,12 +78,15 @@ async def test_validate_meraki_credentials_auth_failed(hass: HomeAssistant) -> N
     """
     with (
         patch(
-            "custom_components.meraki_ha.authentication.create_api_client",
-        ) as mock_client,
+            "custom_components.meraki_ha.core.api.create_api_client",
+        ) as mock_create_client,
         pytest.raises(ConfigEntryAuthFailed),
     ):
-        mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.organization.get_organization = AsyncMock(
+        mock_client = AsyncMock()
+        mock_create_client.return_value = mock_client
+        mock_client.async_setup = AsyncMock()
+        # Direct call to the organization endpoint which would be called by authentication
+        mock_client.organization.get_organization = AsyncMock(
             side_effect=MerakiAuthenticationError("test"),
         )
         await validate_meraki_credentials(hass, "test-api-key", "test-org-id")
@@ -97,10 +104,12 @@ async def test_validate_meraki_credentials_no_dashboard(hass: HomeAssistant) -> 
     """
     with (
         patch(
-            "custom_components.meraki_ha.authentication.create_api_client",
-        ) as mock_client,
+            "custom_components.meraki_ha.core.api.create_api_client",
+        ) as mock_create_client,
         pytest.raises(MerakiConnectionError),
     ):
-        mock_client.return_value.async_setup = AsyncMock()
-        mock_client.return_value.dashboard = None
+        mock_client = AsyncMock()
+        mock_create_client.return_value = mock_client
+        mock_client.async_setup = AsyncMock()
+        mock_client.dashboard = None
         await validate_meraki_credentials(hass, "test-api-key", "test-org-id")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,7 +27,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "custom_components.meraki_ha.config_flow.create_api_client",
+            "custom_components.meraki_ha.core.api.create_api_client",
         ) as mock_create_client,
         patch(
             "custom_components.meraki_ha.async_setup_entry",
@@ -68,7 +68,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "custom_components.meraki_ha.config_flow.create_api_client",
+        "custom_components.meraki_ha.core.api.create_api_client",
         side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(


### PR DESCRIPTION
Unblocked the Meraki integration's config flow by implementing a lazy-import strategy for heavy third-party dependencies (specifically the Meraki SDK). This ensures that these modules are only loaded when needed at runtime, preventing performance warnings in the Home Assistant event loop during module import. The changes include refactoring `config_flow.py` and `authentication.py` to use local imports and `TYPE_CHECKING` blocks, as well as updating the test suite to maintain coverage and correctness with the new structure.

Fixes #2526

---
*PR created automatically by Jules for task [8371168834262246100](https://jules.google.com/task/8371168834262246100) started by @brewmarsh*