### PR TITLE
Fix MT15 Refresh Button Property Conflict

### DIFF
--- a/custom_components/meraki_ha/button/device/mt15_refresh_data.py
+++ b/custom_components/meraki_ha/button/device/mt15_refresh_data.py
@@ -32,15 +32,8 @@ class MerakiMt15RefreshDataButton(MerakiEntity, ButtonEntity):
         self._device = device
         self._config_entry = config_entry
         self._meraki_client = meraki_client
-        self._serial = device.serial
-        self._attr_unique_id = f"{self._serial}-refresh"
+        self._attr_unique_id = f"{device.serial}-refresh"
         self._attr_name = "Refresh data"
-
-    @property
-    def device_data(self):
-        """Get the updated device data from the God dictionary."""
-        # This ensures the button uses the new O(1) traversal path
-        return self.coordinator.data.get("devices_by_serial", {}).get(self._serial)
 
     @property
     def unique_id(self) -> str | None:


### PR DESCRIPTION
I fixed the `AttributeError` in the `MerakiMt15RefreshDataButton` class by removing the illegal assignment to the read-only `_serial` property. I also optimized the class by removing a redundant `device_data` property that is already provided by the base `MerakiEntity` class. Tests for the MT15 refresh button and other button platform entities were run and passed successfully.

Fixes #2530

---
*PR created automatically by Jules for task [1679846391595287707](https://jules.google.com/task/1679846391595287707) started by @brewmarsh*