### PR TITLE
Fix test failures for BaseMerakiEntity and meraki_select entities

### DIFF
--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,2 @@
+from custom_components.meraki_ha.core.entities import BaseMerakiEntity
+print(BaseMerakiEntity)

--- a/tests/core/test_entities.py
+++ b/tests/core/test_entities.py
@@ -40,7 +40,12 @@ def mock_coordinator():
         time_zone="America/Los_Angeles",
     )
 
-    coordinator.data = {"devices": [device], "networks": [network]}
+    coordinator.data = {
+        "devices": [device],
+        "networks": [network],
+        "devices_by_serial": {device.serial: device},
+        "networks_by_id": {network.id: network},
+    }
 
     coordinator.get_device.return_value = device
     coordinator.get_network.return_value = network

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -92,7 +92,7 @@ async def test_content_filtering_select_entity(
 
     with (
         patch(
-            "custom_components.meraki_ha.coordinators.base.ApiClient",
+            "custom_components.meraki_ha.core.api.factory.create_api_client",
             return_value=mock_meraki_client,
         ),
         patch(

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -78,7 +78,7 @@ async def test_vpn_select_entity(
 
     with (
         patch(
-            "custom_components.meraki_ha.coordinators.base.ApiClient",
+            "custom_components.meraki_ha.core.api.factory.create_api_client",
             return_value=mock_meraki_client,
         ),
         patch(


### PR DESCRIPTION
This change fixes unit test failures introduced by recent god dictionary refactoring. The `BaseMerakiEntity` availability tests are fixed by adding `devices_by_serial` and `networks_by_id` dictionaries to the `mock_coordinator`. The meraki_select unit tests are fixed by patching the central `create_api_client` factory instead of `ApiClient`.

---
*PR created automatically by Jules for task [7446948853487163322](https://jules.google.com/task/7446948853487163322) started by @brewmarsh*