### PR TITLE
Implement Network Health Sensors

### DIFF
--- a/custom_components/meraki_ha/discovery/handlers/network.py
+++ b/custom_components/meraki_ha/discovery/handlers/network.py
@@ -16,6 +16,7 @@ from custom_components.meraki_ha.const.config import (
 )
 from ...sensor.network.network_clients import MerakiNetworkClientsSensor
 from ...sensor.network.traffic_shaping import TrafficShapingSensor
+from ...sensor.network_health import MerakiNetworkHealthSensor
 from ...types import MerakiNetwork
 from .base import BaseHandler
 
@@ -104,6 +105,7 @@ class NetworkHandler(BaseHandler):
             self._discover_client_status_sensors,
             self._discover_traffic_shaping,
             self._discover_vlans,
+            self._discover_network_health_sensors,
         )
 
         for network in networks:
@@ -213,3 +215,17 @@ class NetworkHandler(BaseHandler):
                 network.id,
                 vlan,
             )
+
+    async def _discover_network_health_sensors(
+        self, network: MerakiNetwork
+    ) -> AsyncIterator[Entity]:
+        """Discover network health sensors."""
+        yield MerakiNetworkHealthSensor(
+            self._coordinator, self._config_entry, network, "MX", "Gateways"
+        )
+        yield MerakiNetworkHealthSensor(
+            self._coordinator, self._config_entry, network, "MS", "Switches"
+        )
+        yield MerakiNetworkHealthSensor(
+            self._coordinator, self._config_entry, network, "MR", "Access Points"
+        )

--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -1,0 +1,127 @@
+"""Network-level aggregated health sensors for Meraki."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+
+from ..coordinators import MerakiMainCoordinator
+from ..core.entities.meraki_network_entity import MerakiNetworkEntity
+from ..core.models.network import MerakiNetwork
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
+    """Sensor to aggregate health of a specific Meraki device family (MX, MS, MR)."""
+
+    def __init__(
+        self,
+        coordinator: MerakiMainCoordinator,
+        config_entry: ConfigEntry,
+        network: MerakiNetwork,
+        family_prefix: str,
+        family_name: str,
+    ) -> None:
+        """Initialize the aggregated health sensor."""
+        super().__init__(coordinator, config_entry, network)
+        self._network_id = network.id
+        self._family_prefix = family_prefix
+        self._family_name = family_name
+
+        self._attr_name = f"{network.name} {family_name} Health"
+        self._attr_unique_id = f"{network.id}_{family_prefix.lower()}_health"
+
+        if family_prefix == "MR":
+            self._attr_icon = "mdi:wifi"
+        elif family_prefix == "MS":
+            self._attr_icon = "mdi:lan"
+        elif family_prefix == "MX":
+            self._attr_icon = "mdi:router-network"
+        else:
+            self._attr_icon = "mdi:server-network"
+
+        self._family_devices_cache: list[Any] = []
+        self._compute_device_cache()
+
+    def _compute_device_cache(self) -> None:
+        """Compute the device cache to avoid O(M) scans on every property access."""
+        if not self.coordinator.data:
+            self._family_devices_cache = []
+            return
+
+        data = self.coordinator.data
+        devices = []
+
+        if isinstance(data, dict) and "devices_by_serial" in data:
+            devices = list(data["devices_by_serial"].values())
+        elif isinstance(data, dict) and "devices" in data:
+            devices = data["devices"]
+        elif isinstance(data, list):
+            devices = data
+
+        self._family_devices_cache = [
+            d
+            for d in devices
+            if getattr(d, "network_id", None) == self._network_id
+            and (getattr(d, "model", "") or "").startswith(self._family_prefix)
+        ]
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._compute_device_cache()
+        self.async_write_ha_state()
+
+    @property
+    def _family_devices(self) -> list[Any]:
+        """Return the cached family devices."""
+        return self._family_devices_cache
+
+    @property
+    def native_value(self) -> str:
+        """Calculate the aggregated state of the device family."""
+        devices = self._family_devices
+        if not devices:
+            return "N/A"
+
+        offline_count = sum(
+            1
+            for d in devices
+            if str(getattr(d, "status", "offline")).lower()
+            not in ("online", "alerting", "dormant")
+        )
+
+        if offline_count == 0:
+            return "Online"
+        if offline_count < len(devices):
+            return "Degraded"
+        return "Offline"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Provide detailed fractional attributes for Lovelace cards."""
+        devices = self._family_devices
+
+        offline_devices = [
+            getattr(d, "name", getattr(d, "serial", "unknown"))
+            for d in devices
+            if str(getattr(d, "status", "offline")).lower()
+            not in ("online", "alerting", "dormant")
+        ]
+
+        return {
+            "total_devices": len(devices),
+            "online_devices": len(devices) - len(offline_devices),
+            "offline_devices": offline_devices,
+            "hardware_family": self._family_name,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Sensor is available as long as the coordinator has data."""
+        return bool(self.coordinator.data)

--- a/tests/sensor/test_network_health.py
+++ b/tests/sensor/test_network_health.py
@@ -1,0 +1,70 @@
+"""Tests for the Meraki network health sensor."""
+
+from unittest.mock import MagicMock
+from homeassistant.core import HomeAssistant
+from custom_components.meraki_ha.sensor.network_health import MerakiNetworkHealthSensor
+
+class MockDevice:
+    def __init__(self, serial, network_id, model, status):
+        self.serial = serial
+        self.network_id = network_id
+        self.model = model
+        self.status = status
+
+async def test_network_health_sensor_states(hass: HomeAssistant) -> None:
+    """Test the Meraki network health sensor states."""
+    coordinator = MagicMock()
+    coordinator.data = {}
+    config_entry = MagicMock()
+
+    # Mock network data
+    network = MagicMock()
+    network.id = "N_123"
+    network.name = "Test Network"
+
+    # Define devices
+    devices = [
+        MockDevice("MX1", "N_123", "MX64", "online"),
+        MockDevice("MX2", "N_123", "MX64", "online"),
+        MockDevice("MS1", "N_123", "MS120", "online"),
+        MockDevice("MR1", "N_123", "MR33", "offline"),
+    ]
+
+    coordinator.data = {"devices_by_serial": {d.serial: d for d in devices}}
+
+    # MX Health Sensor (All online)
+    mx_sensor = MerakiNetworkHealthSensor(coordinator, config_entry, network, "MX", "Gateways")
+    assert mx_sensor.native_value == "Online"
+    assert mx_sensor.extra_state_attributes["total_devices"] == 2
+    assert mx_sensor.extra_state_attributes["online_devices"] == 2
+
+    # MS Health Sensor (All online)
+    ms_sensor = MerakiNetworkHealthSensor(coordinator, config_entry, network, "MS", "Switches")
+    assert ms_sensor.native_value == "Online"
+
+    # MR Health Sensor (One offline)
+    mr_sensor = MerakiNetworkHealthSensor(coordinator, config_entry, network, "MR", "Access Points")
+    assert mr_sensor.native_value == "Offline"
+    assert mr_sensor.extra_state_attributes["total_devices"] == 1
+    assert mr_sensor.extra_state_attributes["online_devices"] == 0
+    assert "MR1" in mr_sensor.extra_state_attributes["offline_devices"]
+
+async def test_network_health_sensor_degraded(hass: HomeAssistant) -> None:
+    """Test the Meraki network health sensor degraded state."""
+    coordinator = MagicMock()
+    coordinator.data = {}
+    config_entry = MagicMock()
+    network = MagicMock()
+    network.id = "N_123"
+    network.name = "Test Network"
+
+    devices = [
+        MockDevice("MX1", "N_123", "MX64", "online"),
+        MockDevice("MX2", "N_123", "MX64", "offline"),
+    ]
+    coordinator.data = {"devices_by_serial": {d.serial: d for d in devices}}
+
+    mx_sensor = MerakiNetworkHealthSensor(coordinator, config_entry, network, "MX", "Gateways")
+    assert mx_sensor.native_value == "Degraded"
+    assert mx_sensor.extra_state_attributes["total_devices"] == 2
+    assert mx_sensor.extra_state_attributes["online_devices"] == 1


### PR DESCRIPTION
Implemented a new set of aggregated "Network Health" sensors for the Meraki integration. These sensors group devices by network and hardware family (MX Gateways, MS Switches, MR Access Points) to provide a unified health status (Online, Degraded, Offline). 

Key features:
- **Aggregated Status:** Logic to determine if a family is Online (all devices up), Offline (all devices down), or Degraded (some devices up, some down).
- **Fractional Data:** `extra_state_attributes` expose total/online device counts and the list of offline device names/serials.
- **Performance Optimized:** Uses a local device cache updated via coordinator callbacks to avoid redundant O(N*M) scans of the device dictionary.
- **Discovery:** Automatically instantiated for every network discovered by the integration.
- **Tests:** Included unit tests covering all status transitions and attribute accuracy.

Fixes #2553

---
*PR created automatically by Jules for task [16473034075100290495](https://jules.google.com/task/16473034075100290495) started by @brewmarsh*