### PR TITLE
Add precise diagnostic logging for unavailable entities

### DIFF
--- a/custom_components/meraki_ha/button/reboot.py
+++ b/custom_components/meraki_ha/button/reboot.py
@@ -52,18 +52,40 @@ class MerakiRebootButton(MerakiEntity, ButtonEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        # 1. Check parent availability (ensures coordinator has data AND device is not offline)
-        if not super().available:
+        # 1. Check parent availability (ensures coordinator has data)
+        # We don't call super().available because we want reboot to work even if device is 'offline'
+        if not self.coordinator.data:
+            _LOGGER.warning("[%s] Unavailable: coordinator.data is empty", self.name)
+            return False
+
+        if not self._serial:
+            _LOGGER.warning("[%s] Unavailable: serial missing", self.name)
+            return False
+
+        device = self.device_data
+        if device is None:
+            _LOGGER.warning(
+                "[%s] Unavailable: device_data is None for serial %s",
+                self.name,
+                self._serial,
+            )
             return False
 
         # 2. Check static hardware capabilities based on device model
         # Strip suffixes like "-8LP" or " HW" to get the base model (e.g., "MS120")
         model_str = self._device.model or ""
         model = model_str.split("-")[0].split(" ")[0]
-        
+
         # Use DEFAULT_CAPS to assume basic network gear can reboot if model isn't hardcoded.
         capabilities = DEVICE_CAPABILITIES.get(model, DEFAULT_CAPS)
-        return "reboot" in capabilities
+        has_reboot = "reboot" in capabilities
+        if not has_reboot:
+            _LOGGER.warning(
+                "[%s] Unavailable: reboot capability missing for model %s",
+                self.name,
+                model,
+            )
+        return has_reboot
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -63,11 +63,17 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
     def available(self) -> bool:
         """Return if entity is available."""
         if not self.coordinator.data:
+            _LOGGER.warning("[%s] Unavailable: coordinator.data is empty", self.name)
             return False
 
         if self._serial:
             device = self.device_data
             if device is None:
+                _LOGGER.warning(
+                    "[%s] Unavailable: device_data is None for serial %s",
+                    self.name,
+                    self._serial,
+                )
                 return False
 
             # Defensively check status
@@ -82,7 +88,14 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
                 return True
 
             # If status is present, ensure it's not explicitly offline
-            return str(status).lower() in ("online", "alerting", "dormant")
+            is_online = str(status).lower() in ("online", "alerting", "dormant")
+            if not is_online:
+                _LOGGER.warning(
+                    "[%s] Unavailable: status '%s' is explicitly offline",
+                    self.name,
+                    status,
+                )
+            return is_online
 
         return True
         

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -47,7 +47,8 @@ This document verifies the state of the codebase against the requirements for th
 
 - **R12: Diagnostic Observability:**
   - **[VERIFIED]** Implementation of diagnostic tracing in critical parsers to ensure visibility into data mapping during the batch distribution phase.
-  - **[VERIFIED]** Established O(1) dictionary traversal as the project standard for entity data retrieval from the centralized coordinator. Temporary diagnostic logging in `available` properties and parsers has been removed following the stabilization of the 'God Module' data structure (nested under `devices_by_serial`, `networks_by_id`, and `sensor_readings`).
+  - **[VERIFIED]** Established O(1) dictionary traversal as the project standard for entity data retrieval from the centralized coordinator.
+  - **[VERIFIED]** Persistent diagnostic logging implemented in the `available` property of `MerakiEntity` and overrides (e.g., `MerakiRebootButton`) to provide precise reasons (missing coordinator data, missing device data, offline status, missing capabilities) for entity unavailability.
 
 - **R13: Webhook Lifecycle Management:**
   - **[VERIFIED]** Implementation of idempotent webhook registration to prevent exhausting the Meraki API limit (100 HTTP servers per network).


### PR DESCRIPTION
This PR injects detailed diagnostic logging into the `available` property of `MerakiEntity` and `MerakiRebootButton`. This will help troubleshoot issues where entities are consistently reporting as unavailable by providing specific reasons (e.g., missing coordinator data, missing device data, or explicitly offline status) in the logs. 

Key changes:
- Added logging for empty coordinator data in `MerakiEntity`.
- Added logging for missing device data in `MerakiEntity`.
- Added logging for explicitly offline status in `MerakiEntity`.
- Refactored `MerakiRebootButton.available` to log base entity failures or missing hardware capabilities.
- Decoupled `MerakiRebootButton` availability from the 'offline' device status to support troubleshooting reboots.
- Updated `docs/requirements/requirements.md` to reflect these changes as a project standard.

Fixes #2559

---
*PR created automatically by Jules for task [9883370793069350584](https://jules.google.com/task/9883370793069350584) started by @brewmarsh*