### PR TITLE
fix: resolve AttributeError on MerakiFirewallRuleEntity config entry

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_firewall_rule_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_firewall_rule_entity.py
@@ -39,6 +39,7 @@ class MerakiFirewallRuleEntity(BaseMerakiEntity):
             config_entry=config_entry,
             network_id=network_id,
         )
+        self._config_entry = config_entry
         self._rule = rule
         self._rule_index = rule_index
         if self._network_id is None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,14 +22,16 @@ from custom_components.meraki_ha.const.integration import DOMAIN
 from .const import MERAKI_TEST_API_KEY, MERAKI_TEST_ORG_ID
 
 
+from custom_components.meraki_ha.const.config import CONF_MERAKI_API_KEY, CONF_MERAKI_ORG_ID
+
 async def async_get_config_entry(
     hass: HomeAssistant, data: dict[str, Any] | None = None
 ) -> MockConfigEntry:
     """Create a mock config entry for testing."""
     if data is None:
         data = {
-            "api_key": MERAKI_TEST_API_KEY,
-            "organization_id": MERAKI_TEST_ORG_ID,
+            CONF_MERAKI_API_KEY: MERAKI_TEST_API_KEY,
+            CONF_MERAKI_ORG_ID: MERAKI_TEST_ORG_ID,
         }
 
     config_entry = MockConfigEntry(


### PR DESCRIPTION
Fixes an `AttributeError` caused by `MerakiFirewallRuleEntity` attempting to access `self._config_entry` when `BaseMerakiEntity` does not store the passed `config_entry`. Also updates test constants in `tests/__init__.py` to use imported configuration keys (`CONF_MERAKI_API_KEY`, `CONF_MERAKI_ORG_ID`) instead of hardcoded strings, ensuring the mock payload matches the current component implementation.

---
*PR created automatically by Jules for task [9019575717909218789](https://jules.google.com/task/9019575717909218789) started by @brewmarsh*