### PR TITLE
Dynamic Population for Meraki Guest Access Card

### DIFF
--- a/custom_components/meraki_ha/core/entities/meraki_network_entity.py
+++ b/custom_components/meraki_ha/core/entities/meraki_network_entity.py
@@ -10,6 +10,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
+from typing import Any
+
 from ...core.models.network import MerakiNetwork
 from ...core.utils.naming_utils import standardize_device_name
 from ...helpers.device_info_helpers import resolve_device_info
@@ -39,6 +41,18 @@ class MerakiNetworkEntity(BaseMerakiEntity):
         # Set has_entity_name to False to allow custom prefixed naming as requested
         # for network-level entities
         self._attr_has_entity_name = False
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes for the network."""
+        network = self.network_data or self._network
+        return {
+            "network_id": self._network_id,
+            "network_name": network.name if network else None,
+            "product_types": network.product_types
+            if network and hasattr(network, "product_types")
+            else [],
+        }
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/meraki_ha/sensor/network/base.py
+++ b/custom_components/meraki_ha/sensor/network/base.py
@@ -94,6 +94,20 @@ class MerakiSSIDBaseSensor(MerakiEntity, SensorEntity):
         return None
 
     @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes for the SSID."""
+        ssid_data = self._get_current_ssid_data() or self._ssid_data_at_init
+        network = self.coordinator.get_network(self._network_id)
+        return {
+            "network_id": self._network_id,
+            "network_name": network.name if network else None,
+            "ssid_number": self._ssid_number,
+            "ssid_name": ssid_data.get("name") if ssid_data else None,
+            "enabled": ssid_data.get("enabled") if ssid_data else False,
+            "auth_mode": ssid_data.get("authMode") if ssid_data else None,
+        }
+
+    @property
     def available(self) -> bool:
         """Return True if entity is available."""
         if self.coordinator.data is None or not super().available:

--- a/custom_components/meraki_ha/sensor/network/ssid_details.py
+++ b/custom_components/meraki_ha/sensor/network/ssid_details.py
@@ -116,6 +116,15 @@ class MerakiSSIDDetailSensor(MerakiEntity, SensorEntity):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        network = self.coordinator.get_network(self._network_id)
+        self._attr_extra_state_attributes = {
+            "network_id": self._network_id,
+            "network_name": network.name if network else None,
+            "ssid_number": self._ssid_number,
+            "ssid_name": self._ssid_data.get("name"),
+            "enabled": self._ssid_data.get("enabled", False),
+            "auth_mode": self._ssid_data.get("authMode"),
+        }
 
 
 class MerakiSSIDWalledGardenSensor(MerakiSSIDDetailSensor):
@@ -129,12 +138,13 @@ class MerakiSSIDWalledGardenSensor(MerakiSSIDDetailSensor):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        super()._update_state()
         self._attr_native_value = (
             "enabled" if self._ssid_data.get("walledGardenEnabled") else "disabled"
         )
-        self._attr_extra_state_attributes = {
-            "ranges": self._ssid_data.get("walledGardenRanges", [])
-        }
+        self._attr_extra_state_attributes.update(
+            {"ranges": self._ssid_data.get("walledGardenRanges", [])}
+        )
 
 
 class MerakiSSIDTotalUploadLimitSensor(MerakiSSIDDetailSensor):
@@ -149,6 +159,7 @@ class MerakiSSIDTotalUploadLimitSensor(MerakiSSIDDetailSensor):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        super()._update_state()
         self._attr_native_value = self._ssid_data.get("perSsidBandwidthLimitUp")
 
 
@@ -164,6 +175,7 @@ class MerakiSSIDTotalDownloadLimitSensor(MerakiSSIDDetailSensor):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        super()._update_state()
         self._attr_native_value = self._ssid_data.get("perSsidBandwidthLimitDown")
 
 
@@ -178,6 +190,7 @@ class MerakiSSIDMandatoryDhcpSensor(MerakiSSIDDetailSensor):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        super()._update_state()
         self._attr_native_value = (
             "enabled" if self._ssid_data.get("mandatoryDhcpEnabled") else "disabled"
         )
@@ -195,6 +208,7 @@ class MerakiSSIDMinBitrate24GhzSensor(MerakiSSIDDetailSensor):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        super()._update_state()
         if self._rf_profile and self._rf_profile.get("twoFourGhzSettings"):
             self._attr_native_value = self._rf_profile["twoFourGhzSettings"].get(
                 "minBitrate"
@@ -215,6 +229,7 @@ class MerakiSSIDMinBitrate5GhzSensor(MerakiSSIDDetailSensor):
 
     def _update_state(self) -> None:
         """Update the sensor state from current data."""
+        super()._update_state()
         if self._rf_profile and self._rf_profile.get("fiveGhzSettings"):
             self._attr_native_value = self._rf_profile["fiveGhzSettings"].get(
                 "minBitrate"

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -35,7 +35,9 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        return {"vlans": self._vlan_list}
+        attrs = super().extra_state_attributes
+        attrs["vlans"] = self._vlan_list
+        return attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -105,6 +105,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Provide detailed fractional attributes for Lovelace cards."""
+        base_attributes = super().extra_state_attributes
         devices = self._family_devices
 
         offline_devices = [
@@ -114,12 +115,15 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             not in ("online", "alerting", "dormant")
         ]
 
-        return {
-            "total_devices": len(devices),
-            "online_devices": len(devices) - len(offline_devices),
-            "offline_devices": offline_devices,
-            "hardware_family": self._family_name,
-        }
+        base_attributes.update(
+            {
+                "total_devices": len(devices),
+                "online_devices": len(devices) - len(offline_devices),
+                "offline_devices": offline_devices,
+                "hardware_family": self._family_name,
+            }
+        )
+        return base_attributes
 
     @property
     def available(self) -> bool:

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -32,11 +32,10 @@ export class MerakiGuestAccessCard extends LitElement {
   @state() private _error: string | null = null;
   @state() private _success: string | null = null;
 
-  @state() private _networks: Network[] = [];
-  @state() private _ssids: SSID[] = [];
   @state() private _policies: any[] = [];
   @state() private _isLoading: boolean = true;
   @state() private _initDone: boolean = false;
+  @state() private _configEntryId: string = '';
 
   public static async getConfigElement() {
     return document.createElement("meraki-guest-access-card-editor");
@@ -49,64 +48,112 @@ export class MerakiGuestAccessCard extends LitElement {
     this._config = config;
   }
 
-  protected firstUpdated(changedProperties: PropertyValues) {
-    super.firstUpdated(changedProperties);
-    this._fetchInitialData();
-  }
-
   protected updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
     if (changedProperties.has('hass') && this.hass) {
-      if (!this._initDone && this.hass) {
-        this._fetchInitialData();
+      if (!this._initDone) {
+        this._initDone = true;
+        this._fetchConfigEntry();
       }
+
+      this._autoSelectAndLoad();
+
       if (this.hass.user?.name && !this._guestName) {
         this._guestName = this.hass.user.name;
       }
     }
   }
 
-  private async _fetchInitialData() {
-    this._initDone = true;
+  private async _fetchConfigEntry() {
     if (!this.hass) return;
-    this._isLoading = true;
     try {
       const configEntries = await this.hass.callWS<any[]>({
         type: 'config_entries/get',
         domain: 'meraki_ha',
       });
-
-      const entryId = this._config?.config_entry_id || (configEntries.length > 0 ? configEntries[0].entry_id : null);
-      if (!entryId) {
-        this._error = 'Meraki integration not found.';
-        return;
+      this._configEntryId = this._config?.config_entry_id || (configEntries.length > 0 ? configEntries[0].entry_id : '');
+      if (this._selectedNetwork) {
+        this._fetchPolicies(this._selectedNetwork);
       }
-
-      const data = await safeCallWS<any>(this.hass, {
-        type: WsCommand.GET_CONFIG,
-        config_entry_id: entryId,
-      });
-
-      this._networks = (Array.isArray(data.networks) ? data.networks : []).filter((n: any) => n.productTypes?.includes('wireless'));
-      this._ssids = Array.isArray(data.ssids) ? data.ssids : [];
-
-      if (this._networks.length > 0 && !this._selectedNetwork) {
-        this._selectedNetwork = this._networks[0].id;
-        await this._fetchPolicies(this._selectedNetwork, entryId);
-      }
-    } catch (err: any) {
-      this._error = `Failed to fetch Meraki data: ${err.message || err}`;
-    } finally {
-      this._isLoading = false;
+    } catch (err) {
+      console.error("Failed to fetch Meraki config entries", err);
     }
   }
 
-  private async _fetchPolicies(networkId: string, configEntryId?: string) {
+  private _autoSelectAndLoad() {
+    const networks = this._getNetworks();
+    if (networks.length > 0) {
+      if (!this._selectedNetwork) {
+        this._selectedNetwork = networks[0].id;
+        this._fetchPolicies(this._selectedNetwork);
+      }
+      this._isLoading = false;
+    } else {
+        // If we have hass but still no networks, we might be in an empty state
+        // We'll give it a moment to load, but we shouldn't block rendering forever.
+        // If hass is fully loaded (initDone is true), we can stop loading after a bit.
+        if (this._isLoading && this._initDone) {
+            // After 2 seconds of no networks, stop loading to show the "No networks" message
+            setTimeout(() => {
+                if (this._getNetworks().length === 0) {
+                    this._isLoading = false;
+                    this.requestUpdate();
+                }
+            }, 2000);
+        }
+    }
+  }
+
+  private _getNetworks(): Network[] {
+    if (!this.hass) return [];
+    const networks: Record<string, Network> = {};
+
+    Object.values(this.hass.states).forEach(state => {
+      const attrs = state.attributes;
+      if (attrs.network_id && attrs.network_name) {
+        const productTypes = attrs.product_types || [];
+        if (productTypes.includes('wireless')) {
+          networks[attrs.network_id] = {
+            id: attrs.network_id,
+            name: attrs.network_name,
+            productTypes: productTypes
+          };
+        }
+      }
+    });
+
+    return Object.values(networks);
+  }
+
+  private _getSsids(networkId: string): SSID[] {
+    if (!this.hass || !networkId) return [];
+    const ssids: Record<string, SSID> = {};
+
+    Object.values(this.hass.states).forEach(state => {
+      const attrs = state.attributes;
+      if (attrs.network_id === networkId && attrs.ssid_number !== undefined && attrs.ssid_name) {
+        ssids[attrs.ssid_number] = {
+          name: attrs.ssid_name,
+          number: attrs.ssid_number,
+          networkId: attrs.network_id,
+          enabled: attrs.enabled !== false,
+          authMode: attrs.auth_mode
+        };
+      }
+    });
+
+    return Object.values(ssids).sort((a, b) => a.number - b.number);
+  }
+
+  private async _fetchPolicies(networkId: string) {
     if (!this.hass) return;
+    const entryId = this._configEntryId || this._config?.config_entry_id;
+    if (!entryId) return;
+
     try {
       const policies = await safeCallWS<any[]>(this.hass, {
         type: WsCommand.TIMED_ACCESS_GET_POLICIES,
-        config_entry_id: configEntryId || this._config?.config_entry_id,
+        config_entry_id: entryId,
         network_id: networkId,
       });
       this._policies = Array.isArray(policies) ? policies : (policies as any)?.policies || [];
@@ -127,7 +174,19 @@ export class MerakiGuestAccessCard extends LitElement {
       `;
     }
 
-    const filteredSsids = (this._ssids || []).filter(s => s.networkId === this._selectedNetwork);
+    const networks = this._getNetworks();
+    const filteredSsids = this._getSsids(this._selectedNetwork);
+
+    if (networks.length === 0) {
+        return html`
+          <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
+            <div class="card-content">
+              <ha-alert alert-type="warning">No Meraki wireless networks found. Ensure the integration is configured and entities are enabled.</ha-alert>
+            </div>
+            <div class="version">v${__VERSION__}</div>
+          </ha-card>
+        `;
+    }
 
     return html`
       <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
@@ -137,11 +196,11 @@ export class MerakiGuestAccessCard extends LitElement {
 
           <div class="form-container">
             <ha-select label="Network" .value=${this._selectedNetwork} @selected=${this._handleNetworkChange}>
-              ${(this._networks || []).map(n => html`<mwc-list-item value="${n.id}">${n.name}</mwc-list-item>`)}
+              ${networks.map(n => html`<mwc-list-item value="${n.id}">${n.name}</mwc-list-item>`)}
             </ha-select>
 
             <ha-select label="SSID" .value=${this._selectedSsid} .disabled=${!this._selectedNetwork} @selected=${this._handleSsidChange}>
-              ${(filteredSsids || []).map(s => html`<mwc-list-item value="${String(s.number)}">${s.name} (SSID ${s.number})</mwc-list-item>`)}
+              ${filteredSsids.map(s => html`<mwc-list-item value="${String(s.number)}">${s.name} (SSID ${s.number})</mwc-list-item>`)}
             </ha-select>
 
             <ha-select label="Duration" .value=${this._duration} @selected=${this._handleDurationChange}>


### PR DESCRIPTION
This change transitions the `meraki-guest-access-card` from using a custom WebSocket command for discovery to utilizing the Home Assistant state machine (`hass.states`). 

Key improvements:
1. **Backend Enrichment**: Modified `MerakiNetworkEntity`, `MerakiSSIDBaseSensor`, and `MerakiSSIDDetailSensor` to include `network_id`, `network_name`, and SSID-specific metadata in their `extra_state_attributes`. This allows any frontend card to discover Meraki-specific relationships by inspecting standard entity states.
2. **Dynamic Frontend Discovery**: The `meraki-guest-access-card` now scans `this.hass.states` to build its Network and SSID dropdowns. This makes the card more reactive and standardizes its data-fetching pattern.
3. **Robust Initialization**: Restored the `config_entry_id` lookup via WebSocket to ensure that fetching group policies remains functional. Added logic to gracefully handle the loading state until Meraki entities appear in the state machine, preventing infinite spinners or unpopulated cards.
4. **Verified Attributes**: Confirmed via unit tests that the new `extra_state_attributes` are correctly populated across the various network and SSID sensor platforms.

Fixes #2565

---
*PR created automatically by Jules for task [8975845860742234497](https://jules.google.com/task/8975845860742234497) started by @brewmarsh*