### PR TITLE
Connect Custom Card Dropdowns and Fix Event Binding

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/frontend/src/meraki-content-filter-card.ts
+++ b/frontend/src/meraki-content-filter-card.ts
@@ -87,32 +87,33 @@ export class MerakiContentFilterCard extends LitElement {
     return html`
       <ha-card .header="${title}">
         <div class="card-content">
-          <div class="current-profile">
-            Current Profile: <strong>${currentProfile}</strong>
-          </div>
-          <div class="profile-buttons">
+          <ha-select
+            label="Content Filter Profile"
+            .value="${currentProfile}"
+            .disabled="${!entityId}"
+            @value-changed="${(ev: any) => this._handleFilterChange(ev, entityId)}"
+            @closed="${(e: Event) => e.stopPropagation()}"
+            fixedMenuPosition
+            naturalMenuWidth
+          >
             ${profiles.map((profile: string) => html`
-              <div
-                class="profile-button ${currentProfile === profile ? 'active' : ''}"
-                @click="${() => this._handleProfileSelect(entityId, profile)}"
-              >
-                <span class="profile-name">${profile}</span>
-              </div>
+              <mwc-list-item value="${profile}">${profile}</mwc-list-item>
             `)}
-          </div>
+          </ha-select>
         </div>
         <div class="version">v${__VERSION__}</div>
       </ha-card>
     `;
   }
 
-  private async _handleProfileSelect(entityId: string, profile: string): Promise<void> {
-    if (!this.hass || !entityId) return;
+  private async _handleFilterChange(ev: any, entityId: string): Promise<void> {
+    const selectedValue = ev.detail.value;
+    if (!this.hass || !entityId || !selectedValue) return;
 
     try {
       await this.hass.callService('select', 'select_option', {
         entity_id: entityId,
-        option: profile,
+        option: selectedValue,
       });
     } catch (err: any) {
       console.error("Failed to call select_option service:", err);
@@ -139,25 +140,7 @@ export class MerakiContentFilterCard extends LitElement {
     .warning-content strong { display: block; margin-bottom: 4px; }
     .warning-content p { margin: 0; font-size: 0.9em; opacity: 0.9; }
     .card-content { padding: 16px; }
-    .current-profile { color: var(--secondary-text-color); font-size: 0.9em; margin-bottom: 16px; }
-    .profile-buttons { display: flex; flex-wrap: wrap; gap: 8px; }
-    .profile-button {
-      flex: 1 1 calc(50% - 4px);
-      border: 1px solid var(--divider-color);
-      border-radius: 8px;
-      padding: 12px 8px;
-      text-align: center;
-      cursor: pointer;
-      transition: all 0.2s ease-in-out;
-      background-color: var(--card-background-color);
-    }
-    .profile-button:hover { background-color: var(--secondary-background-color); }
-    .profile-button.active {
-      background-color: var(--primary-color);
-      color: var(--text-primary-color);
-      border-color: var(--primary-color);
-    }
-    .profile-name { font-weight: bold; display: block; }
+    ha-select { width: 100%; }
     .version {
       font-size: 9px;
       color: var(--secondary-text-color);

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -195,15 +195,37 @@ export class MerakiGuestAccessCard extends LitElement {
           ${this._success ? html`<ha-alert alert-type="success" dismissable @alert-dismissed-clicked="${() => (this._success = null)}">${this._success}</ha-alert>` : ''}
 
           <div class="form-container">
-            <ha-select label="Network" .value=${this._selectedNetwork} @selected=${this._handleNetworkChange}>
+            <ha-select
+              label="Network"
+              .value=${this._selectedNetwork}
+              @value-changed=${this._handleNetworkChange}
+              @closed=${(e: Event) => e.stopPropagation()}
+              fixedMenuPosition
+              naturalMenuWidth
+            >
               ${networks.map(n => html`<mwc-list-item value="${n.id}">${n.name}</mwc-list-item>`)}
             </ha-select>
 
-            <ha-select label="SSID" .value=${this._selectedSsid} .disabled=${!this._selectedNetwork} @selected=${this._handleSsidChange}>
+            <ha-select
+              label="SSID"
+              .value=${this._selectedSsid}
+              .disabled=${!this._selectedNetwork}
+              @value-changed=${this._handleSsidChange}
+              @closed=${(e: Event) => e.stopPropagation()}
+              fixedMenuPosition
+              naturalMenuWidth
+            >
               ${filteredSsids.map(s => html`<mwc-list-item value="${String(s.number)}">${s.name} (SSID ${s.number})</mwc-list-item>`)}
             </ha-select>
 
-            <ha-select label="Duration" .value=${this._duration} @selected=${this._handleDurationChange}>
+            <ha-select
+              label="Duration"
+              .value=${this._duration}
+              @value-changed=${this._handleDurationChange}
+              @closed=${(e: Event) => e.stopPropagation()}
+              fixedMenuPosition
+              naturalMenuWidth
+            >
               <mwc-list-item value="60">1 Hour</mwc-list-item>
               <mwc-list-item value="1440">24 Hours</mwc-list-item>
             </ha-select>
@@ -220,16 +242,16 @@ export class MerakiGuestAccessCard extends LitElement {
     `;
   }
 
-  private _handleNetworkChange(e: Event) {
-    const target = e.target as any;
-    console.log('Network Selected:', target.value);
-    if (this._selectedNetwork && target.value === this._selectedNetwork) return;
-    this._selectedNetwork = target.value;
-    this._fetchPolicies(target.value);
+  private _handleNetworkChange(e: any) {
+    const value = e.detail.value;
+    console.log('Network Selected:', value);
+    if (this._selectedNetwork && value === this._selectedNetwork) return;
+    this._selectedNetwork = value;
+    this._fetchPolicies(value);
   }
 
-  private _handleSsidChange(e: Event) { this._selectedSsid = (e.target as any).value; }
-  private _handleDurationChange(e: Event) { this._duration = (e.target as any).value; }
+  private _handleSsidChange(e: any) { this._selectedSsid = e.detail.value; }
+  private _handleDurationChange(e: any) { this._duration = e.detail.value; }
   private _handleGuestNameChange(e: Event) { this._guestName = (e.target as any).value; }
 
   private async _generateAccessKey() {

--- a/frontend/src/meraki-wifi-qr-card.ts
+++ b/frontend/src/meraki-wifi-qr-card.ts
@@ -60,7 +60,7 @@ export class MerakiWifiQrCardEditor extends LitElement {
 
   private _handleNetworkChange(ev: any) {
     ev.stopPropagation();
-    const newNetworkId = ev.target.value;
+    const newNetworkId = ev.detail.value;
     // Defensive check: only update if we have a valid selection
     if (newNetworkId !== undefined && newNetworkId !== this._selectedNetwork) {
       this._selectedNetwork = newNetworkId;
@@ -70,7 +70,7 @@ export class MerakiWifiQrCardEditor extends LitElement {
 
   private _handleSSIDChange(ev: any) {
     ev.stopPropagation();
-    const newSsidName = ev.target.value;
+    const newSsidName = ev.detail.value;
     if (newSsidName && newSsidName !== this._config?.ssid) {
       this._updateConfig('ssid', newSsidName);
     }
@@ -105,7 +105,7 @@ export class MerakiWifiQrCardEditor extends LitElement {
         <ha-select
           label="Network (Optional - to populate SSID)"
           .value=${this._selectedNetwork}
-          @selected=${this._handleNetworkChange}
+          @value-changed=${this._handleNetworkChange}
           @closed=${(e: Event) => e.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth
@@ -118,7 +118,7 @@ export class MerakiWifiQrCardEditor extends LitElement {
           label="SSID"
           .value=${this._config?.ssid || ''}
           .disabled=${!this._selectedNetwork}
-          @selected=${this._handleSSIDChange}
+          @value-changed=${this._handleSSIDChange}
           @closed=${(e: Event) => e.stopPropagation()}
           fixedMenuPosition
           naturalMenuWidth

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -14,9 +14,14 @@ from tests.const import MOCK_NETWORK
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
+    from custom_components.meraki_ha.const.config import (
+        CONF_MERAKI_API_KEY,
+        CONF_MERAKI_ORG_ID,
+    )
+
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"api_key": "fake_key", "organization_id": "fake_org"},
+        data={CONF_MERAKI_API_KEY: "fake_key", CONF_MERAKI_ORG_ID: "fake_org"},
         options={},
         entry_id="test_entry",
     )

--- a/tests/meraki_select/test_meraki_content_filtering_repro.py
+++ b/tests/meraki_select/test_meraki_content_filtering_repro.py
@@ -26,9 +26,14 @@ TEST_NETWORK = MerakiNetwork.from_dict(
 @pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
+    from custom_components.meraki_ha.const.config import (
+        CONF_MERAKI_API_KEY,
+        CONF_MERAKI_ORG_ID,
+    )
+
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"api_key": "fake_key", "organization_id": TEST_ORG_ID},
+        data={CONF_MERAKI_API_KEY: "fake_key", CONF_MERAKI_ORG_ID: TEST_ORG_ID},
         options={},
         entry_id="test_entry",
     )


### PR DESCRIPTION
This change fixes a bug where selecting items in the Meraki custom card dropdowns (Content Filter, Guest Access, and WiFi QR Editor) had no effect. The fix involves correctly binding the `@value-changed` event of the `<ha-select>` component and extracting the selection via `ev.detail.value`, as required by Home Assistant's UI components. Additionally, the Content Filter card was updated to use a dropdown instead of buttons for a more compact and standard UI. Backend tests were also patched to ensure continued compatibility with the integration's configuration keys.

Fixes #2570

---
*PR created automatically by Jules for task [10282568521239462155](https://jules.google.com/task/10282568521239462155) started by @brewmarsh*