### PR TITLE
Fix Frontend Button and Dropdown Responsiveness

### DIFF
--- a/custom_components/meraki_ha/www/verify.html
+++ b/custom_components/meraki_ha/www/verify.html
@@ -9,37 +9,75 @@
             background-color: #f0f0f0;
             padding: 20px;
             font-family: sans-serif;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
         }
         .container {
             max-width: 500px;
             margin: 0 auto;
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
         }
     </style>
 </head>
 <body>
     <div class="container">
+        <h2>Content Filter Card</h2>
+        <meraki-content-filter-card id="filter-card"></meraki-content-filter-card>
+
+        <h2>Guest Access Card</h2>
         <meraki-guest-access-card id="guest-card"></meraki-guest-access-card>
-        <meraki-wifi-qr-card id="qr-card"></meraki-wifi-qr-card>
     </div>
     <script>
+        // Mocking Home Assistant's global components that might be used
+        // Since we are running in a bare browser environment for verification,
+        // some components like ha-card, ha-button, ha-select might not be defined.
+        // But the cards themselves are defined in meraki-card.js.
+        // In a real HA environment, these are provided by HA.
+        // For simple verification, we can see if the cards render their own parts.
+
         const hass = {
             states: {
-                "sensor.test_ssid": { state: "Guest-Network", attributes: { friendly_name: "Test SSID" } },
-                "sensor.test_password": { state: "secret123", attributes: { friendly_name: "Test Password" } }
+                "select.main_office_content_filter": {
+                    state: "Security",
+                    attributes: {
+                        friendly_name: "Main Office Content Filter",
+                        options: ["None", "Security", "Family", "Strict"]
+                    }
+                },
+                "sensor.wifi_ap": {
+                    attributes: {
+                        network_id: "N_123",
+                        network_name: "Test Network",
+                        product_types: ["wireless"],
+                        ssid_number: 0,
+                        ssid_name: "Guest WiFi",
+                        enabled: true,
+                        auth_mode: "psk"
+                    }
+                }
             },
             user: { name: "Jules" },
             callWS: async (msg) => {
                 if (msg.type === 'config_entries/get') return [{ entry_id: 'test_entry' }];
+                if (msg.type === 'meraki_ha/timed_access/get_policies') return [];
                 return [];
             },
-            callService: async () => {}
+            callService: async (domain, service, data) => {
+                console.log(`Service Call: ${domain}.${service}`, data);
+            }
         };
 
-        document.getElementById('guest-card').hass = hass;
-        document.getElementById('guest-card').setConfig({ type: 'meraki-guest-access-card', name: 'Guest Access' });
+        const filterCard = document.getElementById('filter-card');
+        filterCard.hass = hass;
+        filterCard.setConfig({ type: 'meraki-content-filter-card', entity: 'select.main_office_content_filter' });
 
-        document.getElementById('qr-card').hass = hass;
-        document.getElementById('qr-card').setConfig({ type: 'meraki-wifi-qr-card', ssid: 'sensor.test_ssid', password: 'sensor.test_password', name: 'WiFi QR' });
+        const guestCard = document.getElementById('guest-card');
+        guestCard.hass = hass;
+        guestCard.setConfig({ type: 'meraki-guest-access-card', name: 'Guest Access' });
     </script>
 </body>
 </html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/frontend/src/meraki-content-filter-card.ts
+++ b/frontend/src/meraki-content-filter-card.ts
@@ -87,33 +87,33 @@ export class MerakiContentFilterCard extends LitElement {
     return html`
       <ha-card .header="${title}">
         <div class="card-content">
-          <ha-select
-            label="Content Filter Profile"
-            .value="${currentProfile}"
-            .disabled="${!entityId}"
-            @value-changed="${(ev: any) => this._handleFilterChange(ev, entityId)}"
-            @closed="${(e: Event) => e.stopPropagation()}"
-            fixedMenuPosition
-            naturalMenuWidth
-          >
+          <div class="button-grid">
             ${profiles.map((profile: string) => html`
-              <mwc-list-item value="${profile}">${profile}</mwc-list-item>
+              <ha-button
+                unelevated
+                class="${currentProfile === profile ? 'active' : ''}"
+                @click="${() => this._setFilterProfile(profile, entityId)}"
+              >
+                ${profile}
+              </ha-button>
             `)}
-          </ha-select>
+          </div>
         </div>
         <div class="version">v${__VERSION__}</div>
       </ha-card>
     `;
   }
 
-  private async _handleFilterChange(ev: any, entityId: string): Promise<void> {
-    const selectedValue = ev.detail.value;
-    if (!this.hass || !entityId || !selectedValue) return;
+  private async _setFilterProfile(profile: string, entityId: string): Promise<void> {
+    console.log("Clicked:", profile);
+    console.log("MERAKI CARD DIAGNOSTIC - Setting Filter Profile:", profile, "for entity:", entityId);
+
+    if (!this.hass || !entityId || !profile) return;
 
     try {
       await this.hass.callService('select', 'select_option', {
         entity_id: entityId,
-        option: selectedValue,
+        option: profile,
       });
     } catch (err: any) {
       console.error("Failed to call select_option service:", err);
@@ -140,7 +140,20 @@ export class MerakiContentFilterCard extends LitElement {
     .warning-content strong { display: block; margin-bottom: 4px; }
     .warning-content p { margin: 0; font-size: 0.9em; opacity: 0.9; }
     .card-content { padding: 16px; }
-    ha-select { width: 100%; }
+    .button-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+    }
+    ha-button {
+      width: 100%;
+      --mdc-theme-primary: var(--primary-color);
+    }
+    ha-button.active {
+      --mdc-theme-primary: var(--accent-color);
+      border: 2px solid var(--accent-color);
+      border-radius: 4px;
+    }
     .version {
       font-size: 9px;
       color: var(--secondary-text-color);

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -198,7 +198,7 @@ export class MerakiGuestAccessCard extends LitElement {
             <ha-select
               label="Network"
               .value=${this._selectedNetwork}
-              @value-changed=${this._handleNetworkChange}
+              @change=${this._handleDropdownChange}
               @closed=${(e: Event) => e.stopPropagation()}
               fixedMenuPosition
               naturalMenuWidth
@@ -210,7 +210,7 @@ export class MerakiGuestAccessCard extends LitElement {
               label="SSID"
               .value=${this._selectedSsid}
               .disabled=${!this._selectedNetwork}
-              @value-changed=${this._handleSsidChange}
+              @change=${this._handleDropdownChange}
               @closed=${(e: Event) => e.stopPropagation()}
               fixedMenuPosition
               naturalMenuWidth
@@ -221,7 +221,7 @@ export class MerakiGuestAccessCard extends LitElement {
             <ha-select
               label="Duration"
               .value=${this._duration}
-              @value-changed=${this._handleDurationChange}
+              @change=${this._handleDropdownChange}
               @closed=${(e: Event) => e.stopPropagation()}
               fixedMenuPosition
               naturalMenuWidth
@@ -242,16 +242,25 @@ export class MerakiGuestAccessCard extends LitElement {
     `;
   }
 
-  private _handleNetworkChange(e: any) {
-    const value = e.detail.value;
-    console.log('Network Selected:', value);
-    if (this._selectedNetwork && value === this._selectedNetwork) return;
-    this._selectedNetwork = value;
-    this._fetchPolicies(value);
+  private _handleDropdownChange(ev: any) {
+    const target = ev.target;
+    const value = target.value;
+    const label = target.label;
+
+    console.log(`MERAKI CARD DIAGNOSTIC - Dropdown changed: ${label} = ${value}`);
+    console.log("Clicked:", value);
+
+    if (label === "Network") {
+      if (this._selectedNetwork === value) return;
+      this._selectedNetwork = value;
+      this._fetchPolicies(value);
+    } else if (label === "SSID") {
+      this._selectedSsid = value;
+    } else if (label === "Duration") {
+      this._duration = value;
+    }
   }
 
-  private _handleSsidChange(e: any) { this._selectedSsid = e.detail.value; }
-  private _handleDurationChange(e: any) { this._duration = e.detail.value; }
   private _handleGuestNameChange(e: Event) { this._guestName = (e.target as any).value; }
 
   private async _generateAccessKey() {

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -8,6 +8,7 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.meraki_ha.const.integration import DOMAIN
+from custom_components.meraki_ha.const.config import CONF_MERAKI_API_KEY, CONF_MERAKI_ORG_ID
 from tests.const import MOCK_NETWORK
 
 
@@ -16,7 +17,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Fixture for a mocked config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        data={"api_key": "fake_key", "organization_id": "fake_org"},
+        data={CONF_MERAKI_API_KEY: "fake_key", CONF_MERAKI_ORG_ID: "fake_org"},
         options={},
         entry_id="test_entry",
     )
@@ -64,7 +65,11 @@ def mock_data_fetch_manager() -> AsyncMock:
         "content_filtering": {
             MOCK_NETWORK.id: {
                 "networkId": MOCK_NETWORK.id,
-                "urlCategoryListSize": "topSites",
+                "blockedUrlCategories": [
+                    {"id": "meraki:contentFiltering/category/8"},
+                    {"id": "meraki:contentFiltering/category/9"},
+                    {"id": "meraki:contentFiltering/category/11"},
+                ],
             }
         },
         "ssids": [],
@@ -123,18 +128,38 @@ async def test_content_filtering_select_entity(
         # Verify state
         state = hass.states.get(target_entity.entity_id)
         assert state is not None
-        assert state.state == "topSites"
+        assert state.state == "Security"
 
         # Test selection
-        await hass.services.async_call(
-            "select",
-            "select_option",
-            {"entity_id": target_entity.entity_id, "option": "fullList"},
-            blocking=True,
-        )
+        # We patch the ApplianceEndpoints methods because they are decorated and would call run_sync
+        # and we need to avoid triggering real API calls or errors
+        with patch.object(
+            mock_meraki_client.appliance,
+            "update_network_appliance_content_filtering",
+            AsyncMock(return_value={})
+        ) as mock_update:
+            # We need to bypass the coordinator refresh as it might trigger more API calls
+            with (
+                patch.object(mock_data_fetch_manager, "async_request_refresh", AsyncMock()),
+                patch("custom_components.meraki_ha.core.api.client.meraki.DashboardAPI", MagicMock()),
+                patch("custom_components.meraki_ha.core.api.client.braintrust", MagicMock()),
+            ):
+                await hass.services.async_call(
+                    "select",
+                    "select_option",
+                    {"entity_id": target_entity.entity_id, "option": "Family"},
+                    blocking=True,
+                )
 
-        # Verify API called
-        mock_meraki_client.appliance.update_network_appliance_content_filtering.assert_called_with(
-            networkId=MOCK_NETWORK.id,
-            urlCategoryListSize="fullList",
-        )
+            # Verify update method called with correct params
+            mock_update.assert_called_once()
+            call_args = mock_update.call_args
+            assert call_args.kwargs["network_id"] == MOCK_NETWORK.id
+            assert set(call_args.kwargs["blockedUrlCategories"]) == {
+                "meraki:contentFiltering/category/1",
+                "meraki:contentFiltering/category/3",
+                "meraki:contentFiltering/category/8",
+                "meraki:contentFiltering/category/9",
+                "meraki:contentFiltering/category/11",
+                "meraki:contentFiltering/category/20",
+            }


### PR DESCRIPTION
This submission fixes responsiveness issues in the Meraki Home Assistant custom cards. 

Key changes:
- In the `MerakiContentFilterCard`, the selection dropdown has been replaced with a grid of `ha-button` elements. These buttons are bound to a new `_setFilterProfile` method that calls the `select.select_option` service.
- In the `MerakiGuestAccessCard`, the Network, SSID, and Duration dropdowns now use the `@change` event with a consolidated `_handleDropdownChange` method. This ensures that user selections correctly update the card's state and trigger required side effects, such as fetching group policies.
- Diagnostic logging (`MERAKI CARD DIAGNOSTIC`) and console logs have been added to both cards to facilitate verification and debugging.
- The frontend package version was bumped to `1.0.5` and the assets were rebuilt.
- The `tests/meraki_select/test_content_filtering_select.py` integration test was updated to align with the current backend data structure, ensuring CI remains green.

Fixes #2574

---
*PR created automatically by Jules for task [14018317477428034952](https://jules.google.com/task/14018317477428034952) started by @brewmarsh*