### PR TITLE
Fix Guest WiFi QR Card Editor Selection Issues

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/frontend/src/meraki-wifi-qr-card.ts
+++ b/frontend/src/meraki-wifi-qr-card.ts
@@ -11,6 +11,7 @@ declare const __VERSION__: string;
 interface Config {
   type: string;
   ssid: string;
+  networkId?: string;
   password?: string;
   name?: string;
 }
@@ -25,6 +26,9 @@ export class MerakiWifiQrCardEditor extends LitElement {
 
   public setConfig(config: Config): void {
     this._config = config;
+    if (config.networkId) {
+      this._selectedNetwork = config.networkId;
+    }
   }
 
   protected firstUpdated(changedProperties: PropertyValues) {
@@ -60,18 +64,20 @@ export class MerakiWifiQrCardEditor extends LitElement {
 
   private _handleNetworkChange(ev: any) {
     ev.stopPropagation();
-    const newNetworkId = ev.detail.value;
+    const newNetworkId = ev.target.value;
     // Defensive check: only update if we have a valid selection
     if (newNetworkId !== undefined && newNetworkId !== this._selectedNetwork) {
       this._selectedNetwork = newNetworkId;
-      this._updateConfig('ssid', '');
+      const newConfig = { ...this._config, networkId: newNetworkId, ssid: '' } as Config;
+      this._config = newConfig;
+      this._dispatchEvent('config-changed', { config: newConfig });
     }
   }
 
   private _handleSSIDChange(ev: any) {
     ev.stopPropagation();
-    const newSsidName = ev.detail.value;
-    if (newSsidName && newSsidName !== this._config?.ssid) {
+    const newSsidName = ev.target.value;
+    if (newSsidName !== this._config?.ssid) {
       this._updateConfig('ssid', newSsidName);
     }
   }
@@ -87,10 +93,18 @@ export class MerakiWifiQrCardEditor extends LitElement {
   private _updateConfig(field: keyof Config, value: string) {
     if (!this._config) return;
     const newConfig = { ...this._config, [field]: value };
-    this._config = newConfig;
     
-    this.dispatchEvent(new CustomEvent('config-changed', {
-      detail: { config: newConfig },
+    if (value === "" || value === undefined) {
+      delete newConfig[field];
+    }
+
+    this._config = newConfig;
+    this._dispatchEvent('config-changed', { config: newConfig });
+  }
+
+  private _dispatchEvent(type: string, detail: any) {
+    this.dispatchEvent(new CustomEvent(type, {
+      detail,
       bubbles: true,
       composed: true,
     }));
@@ -105,8 +119,7 @@ export class MerakiWifiQrCardEditor extends LitElement {
         <ha-select
           label="Network (Optional - to populate SSID)"
           .value=${this._selectedNetwork}
-          @value-changed=${this._handleNetworkChange}
-          @closed=${(e: Event) => e.stopPropagation()}
+          @closed=${this._handleNetworkChange}
           fixedMenuPosition
           naturalMenuWidth
         >
@@ -118,8 +131,7 @@ export class MerakiWifiQrCardEditor extends LitElement {
           label="SSID"
           .value=${this._config?.ssid || ''}
           .disabled=${!this._selectedNetwork}
-          @value-changed=${this._handleSSIDChange}
-          @closed=${(e: Event) => e.stopPropagation()}
+          @closed=${this._handleSSIDChange}
           fixedMenuPosition
           naturalMenuWidth
         >

--- a/index_test.html
+++ b/index_test.html
@@ -1,0 +1,11 @@
+
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <script type="module" src="/custom_components/meraki_ha/www/meraki-card.js"></script>
+        </head>
+        <body>
+            <meraki-wifi-qr-card></meraki-wifi-qr-card>
+            <meraki-wifi-qr-card-editor></meraki-wifi-qr-card-editor>
+        </body>
+        </html>

--- a/index_test_render.html
+++ b/index_test_render.html
@@ -1,0 +1,38 @@
+
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <script type="module" src="/custom_components/meraki_ha/www/meraki-card.js"></script>
+        </head>
+        <body>
+            <div id="container"></div>
+            <script type="module">
+                const card = document.createElement('meraki-wifi-qr-card');
+                card.hass = {
+                    states: {},
+                    callWS: () => Promise.resolve([]),
+                    user: { name: 'Test User' }
+                };
+                card.setConfig({
+                    type: 'custom:meraki-wifi-qr-card',
+                    ssid: 'Test SSID',
+                    password: 'testpassword',
+                    name: 'Test Wi-Fi'
+                });
+                document.getElementById('container').appendChild(card);
+
+                const editor = document.createElement('meraki-wifi-qr-card-editor');
+                editor.hass = {
+                    states: {},
+                    callWS: () => Promise.resolve([])
+                };
+                editor.setConfig({
+                    type: 'custom:meraki-wifi-qr-card',
+                    ssid: 'Test SSID',
+                    password: 'testpassword',
+                    name: 'Test Wi-Fi'
+                });
+                document.getElementById('container').appendChild(editor);
+            </script>
+        </body>
+        </html>


### PR DESCRIPTION
I have fixed the Meraki Wi-Fi QR Card editor by updating the event handling for the Network and SSID dropdowns. 

Specific improvements:
1.  **Fixed Selection Registration**: Changed `@value-changed` to `@closed` and updated handlers to use `ev.target.value`, ensuring user selections are correctly captured and applied to the card configuration.
2.  **Added Persistence**: The editor now saves the `networkId` in the card configuration. This ensures that when the editor is reopened, the previously selected network is restored, and the SSID list is correctly filtered.
3.  **Improved Value Clearing**: Updated the SSID change handler to correctly handle empty string selections, allowing users to clear the SSID.
4.  **Cache Busting**: Incremented the version to 1.0.7 in `package.json` and rebuilt the frontend artifact (`meraki-card.js`) to ensure users receive the updated code.

I verified the changes by:
- Inspecting the code and ensuring all `config-changed` events are correctly dispatched.
- Running a Playwright script to verify that the components are correctly defined in the built bundle and can be rendered.
- Confirming that the version string is present in the final build artifact.

Fixes #2578

---
*PR created automatically by Jules for task [673806791430895785](https://jules.google.com/task/673806791430895785) started by @brewmarsh*