### PR TITLE
Fix throughput indicator on Meraki Network Vitals Card

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/frontend/src/meraki-network-vitals-card.ts
+++ b/frontend/src/meraki-network-vitals-card.ts
@@ -155,14 +155,19 @@ export class MerakiNetworkVitalsCard extends LitElement {
     const apEntity = this._getApEntity();
     const throughputEntity = this._getThroughputEntity();
 
-    if (throughputEntity && this.hass.states[throughputEntity]) {
-      console.log("MERAKI CARD DIAGNOSTIC - Throughput Raw Entity State:", this.hass.states[throughputEntity]);
-    }
-
+    const gatewayStateObj = gatewayEntity ? this.hass.states[gatewayEntity] : undefined;
     const throughputStateObj = throughputEntity ? this.hass.states[throughputEntity] : undefined;
-    const throughputState = throughputStateObj
-      ? (throughputStateObj.state || '0') + ' ' + (throughputStateObj.attributes?.unit_of_measurement || '')
-      : 'N/A';
+
+    console.log("MERAKI CARD DIAGNOSTIC - Gateway State:", gatewayStateObj);
+    console.log("MERAKI CARD DIAGNOSTIC - Throughput Entity State:", throughputStateObj);
+
+    const throughputState = gatewayStateObj?.attributes?.uplink_performance?.throughput
+      ? `${gatewayStateObj.attributes.uplink_performance.throughput} Mbps`
+      : (throughputStateObj
+          ? `${throughputStateObj.state} ${throughputStateObj.attributes?.unit_of_measurement || ""}`.trim()
+          : "0 Mbps");
+
+    console.log("MERAKI CARD DIAGNOSTIC - Extracted Throughput:", throughputState);
 
     return html`
       <ha-card>


### PR DESCRIPTION
The throughput indicator on the Meraki Network Vitals card was broken due to changes in the backend data structure. I've updated the frontend card to defensively extract throughput data from the new 'uplink_performance' attribute of the gateway entity, while maintaining a fallback to the standard state. I also incremented the version and rebuilt the bundle to ensure the fix is applied in the browser.

Fixes #2577

---
*PR created automatically by Jules for task [12397048790010739704](https://jules.google.com/task/12397048790010739704) started by @brewmarsh*