### PR TITLE
Improve Content Filtering Rule Selection

### DIFF
--- a/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
+++ b/custom_components/meraki_ha/meraki_select/meraki_content_filtering.py
@@ -17,20 +17,21 @@ from ..helpers.device_info_helpers import resolve_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
-# Profiles mapped to Meraki category slugs (Requirement: send slug format)
+# Profiles mapped to exact Meraki category names
 CONTENT_FILTERING_PROFILES: dict[str, list[str]] = {
     "None": [],
     "Security": [
-        "malware_sites",
-        "phishing",
-        "spam",
+        "Malware Sites",
+        "Phishing and Other Frauds",
+        "Bot Nets",
+        "Spyware and Adware",
+        "Proxy Avoidance and Anonymizers",
     ],
     "Family": [
-        "adult",
-        "gambling",
-        "malware_sites",
+        "Adult and Pornography",
+        "Nudity",
+        "Malware Sites",
     ],
-    # "Strict" profile temporarily disabled until all 20 category slugs are verified
 }
 
 
@@ -65,6 +66,36 @@ class MerakiContentFilteringSelect(MerakiEntity[MerakiMainCoordinator], SelectEn
         )
         self._attr_options = list(CONTENT_FILTERING_PROFILES.keys())
 
+        # Category mapping cache
+        self._category_id_to_name: dict[str, str] = {}
+        self._category_name_to_id: dict[str, str] = {}
+
+    async def async_added_to_hass(self) -> None:
+        """Fetch category mapping when added to Home Assistant."""
+        await super().async_added_to_hass()
+        await self._async_fetch_category_mapping()
+
+    async def _async_fetch_category_mapping(self) -> None:
+        """Fetch and cache Meraki content filtering categories."""
+        try:
+            response = await self._meraki_client.appliance.get_network_appliance_content_filtering_categories(
+                self._network_id
+            )
+            categories = response.get("categories", [])
+            self._category_id_to_name = {cat["id"]: cat["name"] for cat in categories}
+            self._category_name_to_id = {cat["name"]: cat["id"] for cat in categories}
+            _LOGGER.debug(
+                "Fetched %d content filtering categories for network %s",
+                len(categories),
+                self._network_id,
+            )
+        except Exception as e:
+            _LOGGER.warning(
+                "Failed to fetch content filtering categories for network %s: %s",
+                self._network_id,
+                e,
+            )
+
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return device information to link this entity to the network device."""
@@ -92,38 +123,28 @@ class MerakiContentFilteringSelect(MerakiEntity[MerakiMainCoordinator], SelectEn
             content_filtering.get("blockedUrlCategories", []), key_to_extract="id"
         )
 
-        # Normalize categories to slugs to match CONTENT_FILTERING_PROFILES
-        # API might return URNs like 'meraki:contentFiltering/category/1' or numeric IDs like '1'
-        # We also need a mapping from numeric ID to slug for complete normalization
-        id_to_slug = {
-            "1": "adult",
-            "3": "gambling",
-            "8": "malware_sites",
-            "9": "phishing",
-            "12": "spam",
-        }
-
-        blocked_categories = set()
-        for cat in raw_categories:
-            # Handle URN format: meraki:contentFiltering/category/X
-            if cat.startswith("meraki:contentFiltering/category/"):
-                cat_id = cat.split("/")[-1]
-                blocked_categories.add(id_to_slug.get(cat_id, cat))
-            # Handle numeric format: X
-            elif cat.isdigit():
-                blocked_categories.add(id_to_slug.get(cat, cat))
-            # Already a slug
+        # Use fetched mapping to resolve IDs to names
+        blocked_category_names = set()
+        for cat_id in raw_categories:
+            if name := self._category_id_to_name.get(cat_id):
+                blocked_category_names.add(name)
+            elif name := self._category_id_to_name.get(
+                f"meraki:contentFiltering/category/{cat_id}"
+            ):
+                blocked_category_names.add(name)
             else:
-                blocked_categories.add(cat)
+                # If name not found, we can't accurately match profiles by name
+                _LOGGER.debug(
+                    "Category ID %s not found in mapping for network %s",
+                    cat_id,
+                    self._network_id,
+                )
 
         # Reverse map to find the best matching profile
-        # We look for an exact match first
         for profile, categories in CONTENT_FILTERING_PROFILES.items():
-            if set(categories) == blocked_categories:
+            if set(categories) == blocked_category_names:
                 return profile
 
-        # Fallback to "None" if no match, or perhaps we should find the closest?
-        # For now, let's keep it simple as requested.
         return None
 
     async def async_select_option(self, option: str) -> None:
@@ -131,13 +152,31 @@ class MerakiContentFilteringSelect(MerakiEntity[MerakiMainCoordinator], SelectEn
         if option not in CONTENT_FILTERING_PROFILES:
             raise ValueError(f"Invalid option: {option}")
 
-        categories = CONTENT_FILTERING_PROFILES[option]
+        # Ensure we have the latest mapping
+        await self._async_fetch_category_mapping()
+
+        desired_names = CONTENT_FILTERING_PROFILES[option]
+        api_ids = []
+        missing_names = []
+
+        for name in desired_names:
+            if cat_id := self._category_name_to_id.get(name):
+                api_ids.append(cat_id)
+            else:
+                missing_names.append(name)
+
+        if missing_names:
+            _LOGGER.warning(
+                "The following categories were not found on Meraki for network %s: %s",
+                self._network_id,
+                ", ".join(missing_names),
+            )
 
         try:
             appliance = self._meraki_client.appliance
             await appliance.update_network_appliance_content_filtering(
                 network_id=self._network_id,
-                blockedUrlCategories=categories,
+                blockedUrlCategories=api_ids,
             )
             await self.coordinator.async_request_refresh()
         except Exception as e:

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -35,7 +35,13 @@ def mock_meraki_client() -> MagicMock:
     client.appliance.get_network_appliance_content_filtering_categories = AsyncMock(
         return_value={
             "categories": [
-                {"id": "malware_sites", "name": "Malware Sites"},
+                {"id": "meraki:contentFiltering/category/1", "name": "Adult and Pornography"},
+                {"id": "meraki:contentFiltering/category/2", "name": "Nudity"},
+                {"id": "meraki:contentFiltering/category/8", "name": "Malware Sites"},
+                {"id": "meraki:contentFiltering/category/9", "name": "Phishing and Other Frauds"},
+                {"id": "meraki:contentFiltering/category/11", "name": "Bot Nets"},
+                {"id": "meraki:contentFiltering/category/12", "name": "Spyware and Adware"},
+                {"id": "meraki:contentFiltering/category/15", "name": "Proxy Avoidance and Anonymizers"},
             ]
         }
     )
@@ -67,9 +73,11 @@ def mock_data_fetch_manager() -> AsyncMock:
             MOCK_NETWORK.id: {
                 "networkId": MOCK_NETWORK.id,
                 "blockedUrlCategories": [
-                    {"id": "malware_sites"},
-                    {"id": "phishing"},
-                    {"id": "spam"},
+                    {"id": "meraki:contentFiltering/category/8"},
+                    {"id": "meraki:contentFiltering/category/9"},
+                    {"id": "meraki:contentFiltering/category/11"},
+                    {"id": "meraki:contentFiltering/category/12"},
+                    {"id": "meraki:contentFiltering/category/15"},
                 ],
             }
         },
@@ -140,8 +148,12 @@ async def test_content_filtering_select_entity(
             blocking=True,
         )
 
-        # Verify API called with Family categories
+        # Verify API called with Family categories (URN format)
         mock_meraki_client.appliance.update_network_appliance_content_filtering.assert_called_with(
             network_id=MOCK_NETWORK.id,
-            blockedUrlCategories=["adult", "gambling", "malware_sites"],
+            blockedUrlCategories=[
+                "meraki:contentFiltering/category/1",
+                "meraki:contentFiltering/category/2",
+                "meraki:contentFiltering/category/8",
+            ],
         )


### PR DESCRIPTION
Improved rule selection on the Content Filtering select entity to resolve a 400 Bad Request error. The entity now dynamically fetches category mappings from the Meraki API and translates human-readable profile names into the required URN-based category IDs.

Fixes #2582

---
*PR created automatically by Jules for task [17715204174706188007](https://jules.google.com/task/17715204174706188007) started by @brewmarsh*