### PR TITLE
Fix IPv6 UI overflow and sensor naming bugs

### DIFF
--- a/custom_components/meraki_ha/sensor/device/network_settings.py
+++ b/custom_components/meraki_ha/sensor/device/network_settings.py
@@ -55,6 +55,25 @@ class MerakiDeviceUplinkBaseSensor(MerakiEntity, SensorEntity):
                     return uplink
         return None
 
+    def _truncate_value(self, value: str | None) -> str | None:
+        """Abbreviate long IPv6 addresses for UI display."""
+        if not value:
+            return value
+
+        def truncate_ip(ip: str) -> str:
+            """Truncate a single IP if it is a long IPv6 address."""
+            if ":" in ip:
+                blocks = ip.split(":")
+                if len(blocks) > 4:
+                    return f"{blocks[0]}:{blocks[1]}...{blocks[-2]}:{blocks[-1]}"
+            return ip
+
+        # Handle comma-separated lists (e.g., DNS)
+        if "," in value:
+            return ", ".join(truncate_ip(v.strip()) for v in value.split(","))
+
+        return truncate_ip(value)
+
 
 class MerakiDeviceIPSensor(MerakiDeviceUplinkBaseSensor):
     """Sensor for Meraki device IP address."""
@@ -69,20 +88,32 @@ class MerakiDeviceIPSensor(MerakiDeviceUplinkBaseSensor):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device_data, config_entry, interface)
+
+        # Clean up interface name for display (e.g., lanIp -> LAN, publicIp -> Public)
+        display_interface = interface.replace("Ip", "").replace("IP", "")
+        if not display_interface: # for "ip" or "IP" interfaces
+             display_interface = "IP"
+        else:
+             display_interface = display_interface.upper()
+
         self.entity_description = SensorEntityDescription(
             key=f"{interface}_ip",
-            name=name or f"{interface.upper()} IP",
+            name=name or f"{display_interface} IP",
             icon="mdi:ip-network",
         )
+        self._attr_name = cast(str | None, self.entity_description.name)
         self._update_state()
 
     @callback
     def _update_state(self) -> None:
         """Update the sensor state."""
         device = self.coordinator.get_device(self._device_serial)
+        ip_value: str | None = None
+
         if self._interface == "lanIp" and device:
             if device.model and device.model.startswith("MT"):
                 self._attr_native_value = "N/A (Bluetooth)"
+                self._attr_extra_state_attributes = {}
                 return
             lan_ip = device.lan_ip
             if (
@@ -91,21 +122,24 @@ class MerakiDeviceIPSensor(MerakiDeviceUplinkBaseSensor):
                 and (device.model.startswith("MX") or device.model.startswith("Z3"))
             ):
                 self._attr_native_value = "Multiple (VLANs)"
-            else:
-                self._attr_native_value = lan_ip
-            return
-        if self._interface == "publicIp" and device:
+                self._attr_extra_state_attributes = {}
+                return
+            ip_value = lan_ip
+        elif self._interface == "publicIp" and device:
             if device.model and device.model.startswith("MT"):
                 self._attr_native_value = "N/A (Bluetooth)"
-            else:
-                self._attr_native_value = device.public_ip
-            return
-
-        uplink_data = self._get_uplink_data()
-        if uplink_data:
-            self._attr_native_value = uplink_data.get("ip")
+                self._attr_extra_state_attributes = {}
+                return
+            ip_value = device.public_ip
         else:
-            self._attr_native_value = None
+            uplink_data = self._get_uplink_data()
+            if uplink_data:
+                ip_value = uplink_data.get("ip")
+
+        self._attr_native_value = self._truncate_value(ip_value)
+        self._attr_extra_state_attributes = {
+            "full_ip_address": ip_value or "Unknown"
+        }
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -127,21 +161,29 @@ class MerakiDeviceGatewaySensor(MerakiDeviceUplinkBaseSensor):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device_data, config_entry, interface)
+
+        display_interface = interface.replace("Ip", "").replace("IP", "").upper()
+
         self.entity_description = SensorEntityDescription(
             key=f"{interface}_gateway",
-            name=name or f"{interface.upper()} Gateway",
+            name=name or f"{display_interface} Gateway",
             icon="mdi:gateway",
         )
+        self._attr_name = cast(str | None, self.entity_description.name)
         self._update_state()
 
     @callback
     def _update_state(self) -> None:
         """Update the sensor state."""
         uplink_data = self._get_uplink_data()
+        gateway_value = None
         if uplink_data:
-            self._attr_native_value = uplink_data.get("gateway")
-        else:
-            self._attr_native_value = None
+            gateway_value = uplink_data.get("gateway")
+
+        self._attr_native_value = self._truncate_value(gateway_value)
+        self._attr_extra_state_attributes = {
+            "full_gateway_address": gateway_value or "Unknown"
+        }
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -163,25 +205,33 @@ class MerakiDeviceDNSSensor(MerakiDeviceUplinkBaseSensor):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device_data, config_entry, interface)
+
+        display_interface = interface.replace("Ip", "").replace("IP", "").upper()
+
         self.entity_description = SensorEntityDescription(
             key=f"{interface}_dns",
-            name=name or f"{interface.upper()} DNS",
+            name=name or f"{display_interface} DNS",
             icon="mdi:dns",
         )
+        self._attr_name = cast(str | None, self.entity_description.name)
         self._update_state()
 
     @callback
     def _update_state(self) -> None:
         """Update the sensor state."""
         uplink_data = self._get_uplink_data()
+        dns_value = None
         if uplink_data:
             dns_servers = uplink_data.get("dns")
             if isinstance(dns_servers, list):
-                self._attr_native_value = cast(StateType, ", ".join(dns_servers))
+                dns_value = ", ".join(dns_servers)
             else:
-                self._attr_native_value = cast(StateType, dns_servers)
-        else:
-            self._attr_native_value = None
+                dns_value = dns_servers
+
+        self._attr_native_value = cast(StateType, self._truncate_value(dns_value))
+        self._attr_extra_state_attributes = {
+            "full_dns_servers": dns_value or "Unknown"
+        }
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -78,4 +78,9 @@ This document verifies the state of the codebase against the requirements for th
 - **R18: Schema Consistency:**
   - **[IN PROGRESS]** Implementation of configuration schema consistency to ensure alignment between constants, translation files, and automated testing scripts. This includes migrating legacy keys (e.g., `meraki_api_key`) to standardized keys (e.g., `api_key`).
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18) are now considered part of the standard for this integration.
+- **R19: UI Data Integrity (IPv6 Truncation):**
+  - **[VERIFIED]** Implemented IPv6 truncation for display in Meraki IP, Gateway, and DNS sensors to prevent UI overflow.
+  - **[VERIFIED]** Ensured full IP addresses are preserved in `extra_state_attributes` for diagnostic access.
+  - **[VERIFIED]** Fixed bug where sensor names were incorrectly set to the IP value; names are now static and correctly formatted (e.g., "LAN IP", "Public IP", "WAN1 Gateway").
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19) are now considered part of the standard for this integration.

--- a/tests/sensor/device/test_ipv6_truncation.py
+++ b/tests/sensor/device/test_ipv6_truncation.py
@@ -1,0 +1,99 @@
+"""Tests for IPv6 truncation and static naming in Meraki Network Settings Sensors."""
+
+from unittest.mock import MagicMock
+import pytest
+from custom_components.meraki_ha.sensor.device.network_settings import (
+    MerakiDeviceIPSensor,
+    MerakiDeviceGatewaySensor,
+    MerakiDeviceDNSSensor,
+)
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mocked Meraki coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = {"devices_by_serial": {}}
+
+    def get_device(serial):
+        return coordinator.data["devices_by_serial"].get(serial)
+
+    coordinator.get_device.side_effect = get_device
+    return coordinator
+
+def test_ipv6_truncation_logic(mock_coordinator):
+    """Test that long IPv6 addresses are truncated correctly."""
+    config_entry = MagicMock()
+    config_entry.options = {}
+
+    serial = "Q2XX-XXXX-XXXX"
+    long_ipv6 = "2601:246:102:df00:fe5f:2a53:fe5f:2a53"
+    short_ipv6 = "2001:db8::1"
+    ipv4 = "192.168.1.1"
+
+    device_data = MerakiDevice(
+        serial=serial,
+        name="Test Device",
+        model="MR56",
+        mac="00:11:22:33:44:55",
+        status="online",
+        public_ip=long_ipv6,
+        lan_ip=ipv4
+    )
+    mock_coordinator.data["devices_by_serial"][serial] = device_data
+
+    # 1. Test Long IPv6 (Public IP)
+    sensor = MerakiDeviceIPSensor(mock_coordinator, device_data, config_entry, "publicIp")
+    # Expected: 2601:246...fe5f:2a53
+    assert sensor.native_value == "2601:246...fe5f:2a53"
+    assert sensor.extra_state_attributes["full_ip_address"] == long_ipv6
+    assert sensor.name == "PUBLIC IP"
+
+    # 2. Test IPv4 (LAN IP)
+    sensor_lan = MerakiDeviceIPSensor(mock_coordinator, device_data, config_entry, "lanIp")
+    assert sensor_lan.native_value == ipv4
+    assert sensor_lan.extra_state_attributes["full_ip_address"] == ipv4
+    assert sensor_lan.name == "LAN IP"
+
+    # 3. Test Short IPv6
+    device_data.public_ip = short_ipv6
+    sensor_short = MerakiDeviceIPSensor(mock_coordinator, device_data, config_entry, "publicIp")
+    assert sensor_short.native_value == short_ipv6
+    assert sensor_short.extra_state_attributes["full_ip_address"] == short_ipv6
+
+def test_gateway_and_dns_truncation(mock_coordinator):
+    """Test truncation for Gateway and DNS sensors."""
+    config_entry = MagicMock()
+    config_entry.options = {}
+
+    serial = "Q2YY-YYYY-YYYY"
+    long_ipv6_gw = "2601:246:102:df00:0000:0000:0000:0001"
+    dns_list = ["2601:246:102:df00:fe5f:2a53:fe5f:2a53", "8.8.8.8"]
+
+    device_data = MerakiDevice(
+        serial=serial,
+        name="Test Device 2",
+        model="MX68",
+        mac="00:11:22:33:44:66",
+        status="online",
+        uplinks=[{
+            "interface": "wan1",
+            "ip": "1.2.3.4",
+            "gateway": long_ipv6_gw,
+            "dns": dns_list
+        }]
+    )
+    mock_coordinator.data["devices_by_serial"][serial] = device_data
+
+    # Gateway Test
+    gw_sensor = MerakiDeviceGatewaySensor(mock_coordinator, device_data, config_entry, "wan1")
+    assert gw_sensor.native_value == "2601:246...0000:0001"
+    assert gw_sensor.extra_state_attributes["full_gateway_address"] == long_ipv6_gw
+    assert gw_sensor.name == "WAN1 Gateway"
+
+    # DNS Test
+    dns_sensor = MerakiDeviceDNSSensor(mock_coordinator, device_data, config_entry, "wan1")
+    # Expected: "2601:246...fe5f:2a53, 8.8.8.8"
+    assert dns_sensor.native_value == "2601:246...fe5f:2a53, 8.8.8.8"
+    assert dns_sensor.extra_state_attributes["full_dns_servers"] == "2601:246:102:df00:fe5f:2a53:fe5f:2a53, 8.8.8.8"
+    assert dns_sensor.name == "WAN1 DNS"


### PR DESCRIPTION
This change implements IPv6 address truncation for display in Meraki IP, Gateway, and DNS sensors to prevent UI overflow in the Home Assistant diagnostic card. Full addresses are preserved in `extra_state_attributes` for diagnostic access. Additionally, it fixes a bug where sensor names were dynamically following the IP value or being redundantly named (e.g., 'PUBLICIP IP') by ensuring they are static labels and cleaning up interface slugs during initialization. Comprehensive unit tests have been added to verify these fixes.

Fixes #2625

---
*PR created automatically by Jules for task [10298205153934996072](https://jules.google.com/task/10298205153934996072) started by @brewmarsh*