### PR TITLE
Fix Camera 500 Errors and Stream Compatibility

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -176,6 +176,10 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return a still image from the camera."""
+        if not self._device_serial:
+            _LOGGER.debug("Cannot fetch snapshot: Camera serial is missing.")
+            return None
+
         if self.device_data.status != "online":
             _LOGGER.debug("Skipping snapshot for offline camera: %s", self.name)
             return None
@@ -188,21 +192,32 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
             session = async_get_clientsession(self.hass)
             async with session.get(url) as response:
+                # Meraki API sometimes returns 500 HTML on transient failures
+                if response.status >= 500:
+                    _LOGGER.warning(
+                        "Meraki API returned %d for snapshot: %s",
+                        response.status,
+                        self.name,
+                    )
+                    return None
                 response.raise_for_status()
                 return await response.read()
         except Exception as err:
-            _LOGGER.warning("Failed to fetch camera snapshot: %s", err)
+            _LOGGER.warning("Failed to fetch camera snapshot for %s: %s", self.name, err)
             return None
 
     @property
     def is_streaming(self) -> bool:
         """Return True if the camera is streaming."""
-        if self.device_data.rtsp_url is None:
+        if not self._device_serial or self.device_data.rtsp_url is None:
             return False
         return True
 
     async def async_stream_source(self) -> str | None:
         """Return the source of the stream."""
+        if not self._device_serial:
+            _LOGGER.debug("Cannot fetch stream: Camera serial is missing.")
+            return None
         return await self._camera_service.get_video_stream_url(self._device_serial)
 
     @property
@@ -215,6 +230,9 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
     async def async_turn_on(self) -> None:
         """Turn on the camera stream."""
+        if not self._device_serial:
+            _LOGGER.warning("Cannot turn on stream: Camera serial is missing.")
+            return
         _LOGGER.debug("Turning on stream for camera %s", self._device_serial)
         await self._camera_service.async_set_rtsp_stream_enabled(
             self._device_serial, True
@@ -223,6 +241,9 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
     async def async_turn_off(self) -> None:
         """Turn off the camera stream."""
+        if not self._device_serial:
+            _LOGGER.warning("Cannot turn off stream: Camera serial is missing.")
+            return
         _LOGGER.debug("Turning off stream for camera %s", self._device_serial)
         await self._camera_service.async_set_rtsp_stream_enabled(
             self._device_serial, False

--- a/custom_components/meraki_ha/core/api/endpoints/camera.py
+++ b/custom_components/meraki_ha/core/api/endpoints/camera.py
@@ -37,6 +37,9 @@ class CameraEndpoints:
     @async_timed_cache()
     async def get_camera_sense_settings(self, serial: str) -> dict[str, Any]:
         """Get sense settings for a specific camera."""
+        if not serial:
+            _LOGGER.warning("get_camera_sense_settings: serial is required")
+            return {}
         settings = await self._api_client.run_sync(
             self._api_client.dashboard.camera.getDeviceCameraSense, serial=serial
         )
@@ -50,6 +53,9 @@ class CameraEndpoints:
     @async_timed_cache()
     async def get_camera_video_settings(self, serial: str) -> dict[str, Any]:
         """Get video settings for a specific camera."""
+        if not serial:
+            _LOGGER.warning("get_camera_video_settings: serial is required")
+            return {}
         settings = await self._api_client.run_sync(
             self._api_client.dashboard.camera.getDeviceCameraVideoSettings,
             serial=serial,
@@ -64,6 +70,9 @@ class CameraEndpoints:
     @async_timed_cache(timeout=30)
     async def get_device_camera_video_link(self, serial: str) -> dict[str, Any]:
         """Get video link for a specific camera."""
+        if not serial:
+            _LOGGER.warning("get_device_camera_video_link: serial is required")
+            return {}
         link = await self._api_client.run_sync(
             self._api_client.dashboard.camera.getDeviceCameraVideoLink, serial=serial
         )
@@ -78,6 +87,9 @@ class CameraEndpoints:
         self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Update video settings for a specific camera."""
+        if not serial:
+            _LOGGER.warning("update_camera_video_settings: serial is required")
+            return {}
         # Map snake_case keys to camelCase keys for the Meraki API
         payload = {}
         mapping = {
@@ -106,6 +118,9 @@ class CameraEndpoints:
         self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Update sense settings for a specific camera."""
+        if not serial:
+            _LOGGER.warning("update_camera_sense_settings: serial is required")
+            return {}
         # Map snake_case keys to camelCase keys for the Meraki API
         payload = {}
         mapping = {
@@ -137,6 +152,9 @@ class CameraEndpoints:
         self, serial: str, object_type: str = "person"
     ) -> list[dict[str, Any]]:
         """Get recent analytics for a specific camera."""
+        if not serial:
+            _LOGGER.warning("get_device_camera_analytics_recent: serial is required")
+            return []
         recent = await self._api_client.run_sync(
             self._api_client.dashboard.camera.getDeviceCameraAnalyticsRecent,
             serial=serial,
@@ -154,6 +172,9 @@ class CameraEndpoints:
         self, serial: str
     ) -> list[dict[str, Any]]:
         """Get analytics zones for a specific camera."""
+        if not serial:
+            _LOGGER.warning("get_device_camera_analytics_zones: serial is required")
+            return []
         zones = await self._api_client.run_sync(
             self._api_client.dashboard.camera.getDeviceCameraAnalyticsZones,
             serial=serial,
@@ -169,6 +190,9 @@ class CameraEndpoints:
         self, serial: str, **kwargs: Any
     ) -> dict[str, Any]:
         """Generate a snapshot of what the camera sees."""
+        if not serial:
+            _LOGGER.warning("generate_device_camera_snapshot: serial is required")
+            return {}
         snapshot = await self._api_client.run_sync(
             self._api_client.dashboard.camera.generateDeviceCameraSnapshot,
             serial=serial,

--- a/custom_components/meraki_ha/core/repositories/camera_repository.py
+++ b/custom_components/meraki_ha/core/repositories/camera_repository.py
@@ -37,6 +37,10 @@ class CameraRepository:
         and other properties. For now, we'll assume all cameras support basic
         features, but this can be expanded later.
         """
+        if not serial:
+            _LOGGER.debug("Cannot fetch features: Serial is missing.")
+            return []
+
         # In the future, this could involve a call to get device details
         # and then a lookup based on the model.
         # For now, we'll hardcode some features for demonstration.
@@ -61,6 +65,10 @@ class CameraRepository:
         self, serial: str, object_type: str
     ) -> list[dict[str, Any]] | None:
         """Fetch object detection and motion data."""
+        if not serial:
+            _LOGGER.debug("Cannot fetch analytics: Serial is missing.")
+            return None
+
         try:
             recent = await self._api_client.camera.get_device_camera_analytics_recent(
                 serial, object_type
@@ -76,6 +84,10 @@ class CameraRepository:
 
         This method validates that the URL is a valid RTSP stream URL.
         """
+        if not serial:
+            _LOGGER.debug("Cannot fetch RTSP URL: Serial is missing.")
+            return None
+
         # MV2 cameras do not support historical viewing without cloud archive,
         # so we should not attempt to fetch a video link for them.
         try:
@@ -140,6 +152,10 @@ class CameraRepository:
 
     async def generate_snapshot(self, serial: str) -> str | None:
         """Generate a snapshot and return the URL."""
+        if not serial:
+            _LOGGER.debug("Cannot generate snapshot: Serial is missing.")
+            return None
+
         try:
             snapshot_data = (
                 await self._api_client.camera.generate_device_camera_snapshot(serial)
@@ -151,6 +167,10 @@ class CameraRepository:
 
     async def set_rtsp_stream_enabled(self, serial: str, enabled: bool) -> None:
         """Enable or disable RTSP stream for a camera."""
+        if not serial:
+            _LOGGER.debug("Cannot set RTSP stream: Serial is missing.")
+            return
+
         try:
             await self._api_client.camera.update_camera_video_settings(
                 serial, externalRtspEnabled=enabled

--- a/tests/camera/test_camera_serial_guard.py
+++ b/tests/camera/test_camera_serial_guard.py
@@ -1,0 +1,115 @@
+"""Tests for the Meraki camera serial guards and error handling."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import aiohttp
+from homeassistant.core import HomeAssistant
+from homeassistant.components.camera import CameraEntityFeature
+
+from custom_components.meraki_ha.camera import MerakiRTSPStreamCamera
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+
+
+@pytest.fixture
+def mock_camera(
+    mock_coordinator: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_camera_service: AsyncMock,
+) -> MerakiRTSPStreamCamera:
+    """Create a mock MerakiRTSPStreamCamera entity."""
+    device = MerakiDevice(
+        serial="Q234-ABCD-5678",
+        name="Test Device",
+        mac="00:11:22:33:44:55",
+        model="MV12",
+        network_id="N_12345",
+        product_type="camera",
+        lan_ip="1.2.3.4",
+        status="online",
+    )
+
+    mock_coordinator.get_device.return_value = device
+
+    return MerakiRTSPStreamCamera(
+        coordinator=mock_coordinator,
+        device=device,
+        camera_service=mock_camera_service,
+        config_entry=mock_config_entry,
+    )
+
+
+@pytest.mark.asyncio
+async def test_camera_supported_features(
+    mock_camera: MerakiRTSPStreamCamera,
+) -> None:
+    """Test that camera supports the STREAM feature."""
+    assert mock_camera.supported_features == CameraEntityFeature.STREAM
+
+
+@pytest.mark.asyncio
+async def test_camera_image_no_serial(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+) -> None:
+    """Test that camera image returns None when serial is missing."""
+    mock_camera.hass = hass
+    # Force _device_serial to None for the test
+    mock_camera._device_serial = None
+
+    with patch("custom_components.meraki_ha.camera._LOGGER") as mock_logger:
+        image = await mock_camera.async_camera_image()
+
+        assert image is None
+        mock_logger.debug.assert_called_with("Cannot fetch snapshot: Camera serial is missing.")
+
+
+@pytest.mark.asyncio
+async def test_camera_image_500_error(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+    mock_camera_service: AsyncMock,
+) -> None:
+    """Test that camera image returns None and logs warning on 500 error."""
+    mock_camera.hass = hass
+    mock_camera_service.generate_snapshot.return_value = "https://meraki.com/snapshot.jpg"
+
+    # Mock the aiohttp response to return a 500 status
+    mock_response = MagicMock()
+    mock_response.status = 500
+    mock_response.read = AsyncMock(return_value=b"Internal Server Error HTML")
+
+    mock_context_manager = MagicMock()
+    mock_context_manager.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_context_manager.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("custom_components.meraki_ha.camera.async_get_clientsession") as mock_session:
+        mock_session.return_value.get.return_value = mock_context_manager
+
+        with patch("custom_components.meraki_ha.camera._LOGGER") as mock_logger:
+            image = await mock_camera.async_camera_image()
+
+            assert image is None
+            mock_logger.warning.assert_called()
+            # Verify the warning contains the status code and camera name
+            # When using _LOGGER.warning("msg %d", arg), the call args will be ("msg %d", arg)
+            warning_call = mock_logger.warning.call_args
+            assert "Meraki API returned %d" in warning_call[0][0]
+            assert warning_call[0][1] == 500
+
+
+@pytest.mark.asyncio
+async def test_camera_stream_source_no_serial(
+    hass: HomeAssistant,
+    mock_camera: MerakiRTSPStreamCamera,
+) -> None:
+    """Test that stream source returns None when serial is missing."""
+    mock_camera.hass = hass
+    # Force _device_serial to None for the test
+    mock_camera._device_serial = None
+
+    with patch("custom_components.meraki_ha.camera._LOGGER") as mock_logger:
+        source = await mock_camera.async_stream_source()
+
+        assert source is None
+        mock_logger.debug.assert_called_with("Cannot fetch stream: Camera serial is missing.")


### PR DESCRIPTION
This submission fixes aggressive 500 Internal Server Errors in the Meraki camera platform caused by passing `None` as a device identifier. It also ensures full compatibility with Home Assistant's stream service.

Key changes:
1.  **Robust Serial Retrieval:** Added explicit checks for `_device_serial` in `MerakiRTSPStreamCamera`, `CameraRepository`, and `CameraEndpoints` to prevent invalid API calls.
2.  **Graceful Snapshot Handling:** Enhanced `async_camera_image` to catch exceptions and explicitly handle $\ge 500$ status codes (often returning HTML error pages from Meraki), returning `None` instead of crashing.
3.  **Stream Support:** Verified `CameraEntityFeature.STREAM` flag and ensured `async_stream_source` uses safe serial retrieval.
4.  **Testing:** Introduced `tests/camera/test_camera_serial_guard.py` covering feature flags, serial guards, and 500 error handling scenarios.

Fixes #2626

---
*PR created automatically by Jules for task [12767432690324927405](https://jules.google.com/task/12767432690324927405) started by @brewmarsh*