### PR TITLE
Restore and Harden MX Appliance Ports

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/appliance_port.py
@@ -74,7 +74,8 @@ class AppliancePortBinarySensor(CoordinatorEntity, BinarySensorEntity):
                 return
 
             for port in appliance_ports:
-                if not hasattr(port, "number"):
+                # Defensive check: ensure port and its number attribute exist
+                if port is None or getattr(port, "number", None) is None:
                     continue
                 if port.number == self._port.number:
                     self._port = port
@@ -84,7 +85,7 @@ class AppliancePortBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        if not self._port.enabled:
+        if not self._port or not getattr(self._port, "enabled", False):
             return False
         return (
             self._port.status is not None and self._port.status.lower() == "connected"

--- a/custom_components/meraki_ha/core/parsers/appliance.py
+++ b/custom_components/meraki_ha/core/parsers/appliance.py
@@ -88,6 +88,15 @@ def parse_appliance_ports(
     for device in devices:
         serial: str | None = device.serial
         if serial and (ports_data := ports_by_serial.get(serial)):
-            device.appliance_ports = [
-                MerakiAppliancePort.from_dict(port) for port in ports_data
-            ]
+            appliance_ports = []
+            for port in ports_data:
+                try:
+                    appliance_ports.append(MerakiAppliancePort.from_dict(port))
+                except Exception as e:
+                    _LOGGER.error(
+                        "Failed to parse appliance port data for device %s: %s. Data: %s",
+                        serial,
+                        e,
+                        port,
+                    )
+            device.appliance_ports = appliance_ports

--- a/custom_components/meraki_ha/discovery/providers/appliance.py
+++ b/custom_components/meraki_ha/discovery/providers/appliance.py
@@ -36,11 +36,30 @@ class AppliancePortProvider:
             return []
 
         entities: list[Entity] = []
-        if device.appliance_ports:
-            for port in device.appliance_ports:
+        if not device.appliance_ports:
+            return entities
+
+        for port in device.appliance_ports:
+            try:
+                # Basic validation: ensure port has a number
+                if port.number is None:
+                    _LOGGER.warning(
+                        "Skipping appliance port on device %s: missing port number",
+                        device.serial,
+                    )
+                    continue
+
                 entities.append(MerakiAppliancePortSensor(coordinator, device, port))
                 entities.append(AppliancePortBinarySensor(coordinator, device, port))
                 entities.append(
                     MerakiAppliancePortSwitch(coordinator, device, port, config_entry)
+                )
+            except Exception as err:
+                _LOGGER.error(
+                    "Failed to initialize appliance port %s on device %s: %s",
+                    getattr(port, "number", "unknown"),
+                    device.serial,
+                    err,
+                    exc_info=True,
                 )
         return entities

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -70,10 +70,15 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
             self._device = device
             appliance_ports = getattr(device, "appliance_ports", [])
             if not isinstance(appliance_ports, list):
+                _LOGGER.debug(
+                    "No appliance ports found for device %s during update",
+                    self._device.serial,
+                )
                 return
 
             for port in appliance_ports:
-                if not hasattr(port, "number"):
+                # Defensive check: ensure port and its number attribute exist
+                if port is None or getattr(port, "number", None) is None:
                     continue
                 if port.number == self._port.number:
                     self._port = port
@@ -84,7 +89,11 @@ class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> str:
         """Return the state of the sensor."""
         # Strictly return "connected" or "disconnected"
-        if self._port.status and self._port.status.lower() == "connected":
+        if (
+            self._port
+            and self._port.status
+            and self._port.status.lower() == "connected"
+        ):
             return "connected"
         return "disconnected"
 

--- a/custom_components/meraki_ha/switch/switch_port.py
+++ b/custom_components/meraki_ha/switch/switch_port.py
@@ -108,7 +108,20 @@ class _MerakiPortSwitchBase(MerakiEntity, SwitchEntity, ABC):
             )
             return
 
-        for port_data in self._get_device_ports():
+        device_ports = self._get_device_ports()
+        if not isinstance(device_ports, list):
+            _LOGGER.warning(
+                "Ports data for device %s is not a list: %s",
+                self._device.serial,
+                type(device_ports),
+            )
+            return
+
+        for port_data in device_ports:
+            # Defensive check for None items in the list
+            if port_data is None:
+                continue
+
             port_dict = (
                 port_data if isinstance(port_data, dict) else port_data.to_dict()
             )
@@ -129,6 +142,8 @@ class _MerakiPortSwitchBase(MerakiEntity, SwitchEntity, ABC):
 
     def _get_port_identifier(self) -> str | None:
         """Get the primary identifier for the port."""
+        if self._port is None:
+            return None
         return _get_port_identifier_from_data(self._port)
 
     def _update_internal_state(self) -> None:
@@ -136,7 +151,9 @@ class _MerakiPortSwitchBase(MerakiEntity, SwitchEntity, ABC):
         # If there is a command in flight, don't let the poller overwrite the state yet
         if self.unique_id and self.coordinator.is_pending(self.unique_id):
             return
-        self._attr_is_on = self._port.get("enabled", False)
+        self._attr_is_on = (
+            self._port.get("enabled", False) if self._port is not None else False
+        )
 
     async def _toggle_port(self, enabled: bool) -> None:
         """Execute a port toggle command with optimistic update."""


### PR DESCRIPTION
This submission hardens the MX Appliance Port entities and their discovery/parsing logic. It addresses the issue of disappearing entities by isolating individual port failures using the Resilient Entity Factory pattern and ensuring defensive programming across the associated sensor, binary sensor, and switch platforms. Relevant unit tests have been verified to pass.

Fixes #2630

---
*PR created automatically by Jules for task [14250441624978422430](https://jules.google.com/task/14250441624978422430) started by @brewmarsh*