### PR TITLE
Unify Custom Card Loading and Fix Startup Bug

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -83,4 +83,10 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** Ensured full IP addresses are preserved in `extra_state_attributes` for diagnostic access.
   - **[VERIFIED]** Fixed bug where sensor names were incorrectly set to the IP value; names are now static and correctly formatted (e.g., "LAN IP", "Public IP", "WAN1 Gateway").
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19) are now considered part of the standard for this integration.
+- **R20: Unified High-Contrast Loading States:**
+  - **[VERIFIED]** Extracted loading UI into a shared `renderLoadingState` function in `shared-ui.ts`.
+  - **[VERIFIED]** Fixed CSS contrast for light and dark modes in `status-card` (warning and loading states) using high-contrast text colors and Home Assistant CSS variables.
+  - **[VERIFIED]** Unified all custom cards (`meraki-guest-access-card`, `meraki-wifi-qr-card`, `meraki-content-filter-card`, `meraki-network-vitals-card`) to use the new centralized loading UI.
+  - **[VERIFIED]** Fixed a regression in `meraki-guest-access-card-editor.ts` that caused the guest access card to skip its polling countdown due to a class naming conflict.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20) are now considered part of the standard for this integration.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.1734",
+  "version": "2.3.0-beta.3502",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.1734",
+      "version": "2.3.0-beta.3502",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.3.0-beta.3501",
+  "version": "2.3.0-beta.3502",
   "type": "module",
   "scripts": {
     "build": "vite build"

--- a/frontend/src/meraki-content-filter-card.ts
+++ b/frontend/src/meraki-content-filter-card.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
-import { renderWarning, sharedStyles } from './shared-ui';
+import { renderWarning, renderLoadingState, sharedStyles } from './shared-ui';
 import { MerakiDataProvider } from './utils/meraki-data';
 
 declare const __VERSION__: string;
@@ -77,17 +77,11 @@ export class MerakiContentFilterCard extends LitElement {
     if (!this.hass || !this._config) return html``;
 
     if (this._isLoading) {
-      return html`
-        <ha-card .header="${this._config?.name || 'Meraki Content Filter'}">
-          <div class="card-content" style="text-align: center; padding: 32px;">
-            <ha-circular-progress active></ha-circular-progress>
-            <div style="margin-top: 16px; color: var(--secondary-text-color);">
-              ${this._loadingMessage}
-            </div>
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
+      return renderLoadingState(
+        this._config?.name || 'Meraki Content Filter',
+        this._loadingMessage,
+        __VERSION__
+      );
     }
 
     const entityId = this._config.entity || this._discoverEntity();
@@ -98,14 +92,11 @@ export class MerakiContentFilterCard extends LitElement {
     const title = this._config.name || (this._config.entity ? `${titleFriendlyName} Content Filter` : "Meraki Content Filter");
 
     if (!entityId || !stateObj) {
-      return html`
-        <ha-card .header="${title}">
-          <div class="card-content">
-             ${renderWarning("Entity Missing", "No content filter entity was found. Please check your configuration.")}
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
+      return renderWarning(
+        "Entity Missing",
+        "No content filter entity was found. Please check your configuration.",
+        __VERSION__
+      );
     }
 
     const currentProfile = stateObj.state || 'Unknown';

--- a/frontend/src/meraki-guest-access-card-editor.ts
+++ b/frontend/src/meraki-guest-access-card-editor.ts
@@ -1,17 +1,6 @@
-import { LitElement, html, css, PropertyValues } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
-import { renderWarning, renderLoading, sharedStyles } from './shared-ui';
-import { MerakiDataProvider, GroupPolicy } from './utils/meraki-data';
-import './meraki-content-filter-card';
-import './meraki-wifi-qr-card';
-import './meraki-network-vitals-card';
-import './meraki-guest-access-card-editor';
-import { Network, SSID } from './types/meraki';
-import { WsCommand } from './types/websocket';
-import { safeCallWS } from './utils/api';
-
-declare const __VERSION__: string;
 
 interface Config {
   type: string;
@@ -19,293 +8,56 @@ interface Config {
   config_entry_id?: string;
 }
 
-export class MerakiGuestAccessCard extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+export class MerakiGuestAccessCardEditor extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: Config;
 
-  @state() private _formData = {
-    network: '',
-    ssid: '',
-    duration: '60',
-    guestName: '',
-    groupPolicy: 'NONE',
-  };
-
-  @state() private _networks: Network[] = [];
-  @state() private _ssids: SSID[] = [];
-  @state() private _groupPolicies: GroupPolicy[] = [];
-  @state() private _creating: boolean = false;
-  @state() private _error: string | null = null;
-  @state() private _success: string | null = null;
-  @state() private _isLoading: boolean = true;
-  @state() private _configEntryId: string | null = null;
-
-  public static async getConfigElement() {
-    return document.createElement('meraki-guest-access-card-editor');
-  }
-
   public setConfig(config: Config): void {
-    if (!config) throw new Error('Invalid configuration');
     this._config = config;
   }
 
-  protected firstUpdated(changedProperties: PropertyValues) {
-    super.firstUpdated(changedProperties);
-    this._loadCentralizedData();
-  }
-
-  protected updated(changedProperties: PropertyValues) {
-    super.updated(changedProperties);
-    if (
-      changedProperties.has('hass') &&
-      this.hass &&
-      this.hass.user?.name &&
-      !this._formData.guestName
-    ) {
-      this._formData = { ...this._formData, guestName: this.hass.user.name };
-    }
-  }
-
-  private async _loadCentralizedData() {
-    if (!this.hass) return;
-    this._isLoading = true;
-
-    const { networks, ssids, groupPolicies, entryId } =
-      await MerakiDataProvider.fetchConfig(this.hass);
-    this._networks = networks;
-    this._ssids = ssids;
-    this._groupPolicies = groupPolicies || [];
-    this._configEntryId = this._config?.config_entry_id || entryId;
-
-    if (networks.length > 0 && !this._formData.network) {
-      this._formData = { ...this._formData, network: networks[0].id };
-    }
-
-    this._isLoading = false;
-  }
-
-  private _formValueChanged(ev: CustomEvent) {
-    const newValues = ev.detail.value;
-    const oldNetwork = this._formData.network;
-
-    this._formData = { ...this._formData, ...newValues };
-
-    // Clear SSID if network changes
-    if (this._formData.network !== oldNetwork) {
-      this._formData = { ...this._formData, ssid: '', groupPolicy: 'NONE' };
-    }
-  }
-
   private _computeLabel = (schema: any): string => {
-    if (schema.name === 'network') return 'Network';
-    if (schema.name === 'ssid') return 'SSID';
-    if (schema.name === 'duration') return 'Duration';
-    if (schema.name === 'guestName') return 'Guest Name';
-    if (schema.name === 'groupPolicy') return 'Group Policy';
+    if (schema.name === "name") return "Title (Optional)";
+    if (schema.name === "config_entry_id") return "Config Entry ID (Optional override)";
     return schema.name;
-  };
+  }
 
   protected render() {
-    if (this._isLoading) {
-      return html`
-        <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
-          <div class="card-content flex justify-center p-8">
-            ${renderLoading('Loading...')}
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
-    }
-
-    if (this._networks.length === 0) {
-      return html`
-        <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
-          <div class="card-content">
-            ${renderWarning(
-              'No Wireless Networks',
-              'No Meraki wireless networks found. Ensure the integration is configured.'
-            )}
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
-    }
-
-    const networkOptions = MerakiDataProvider.getNetworkOptions(
-      this._networks
-    );
-    const ssidOptions = MerakiDataProvider.getSsidOptions(
-      this._ssids,
-      this._formData.network,
-      'number'
-    );
-    const groupPolicyOptions = MerakiDataProvider.getGroupPolicyOptions(
-      this._groupPolicies,
-      this._formData.network
-    );
+    if (!this.hass || !this._config) return html``;
 
     const schema = [
-      {
-        name: 'network',
-        selector: { select: { options: networkOptions, mode: 'dropdown' } },
-      },
-      {
-        name: 'ssid',
-        selector: { select: { options: ssidOptions, mode: 'dropdown' } },
-      },
-      {
-        name: 'groupPolicy',
-        selector: {
-          select: { options: groupPolicyOptions, mode: 'dropdown' },
-        },
-      },
-      {
-        name: 'duration',
-        selector: {
-          select: {
-            options: [
-              { value: '60', label: '1 Hour' },
-              { value: '1440', label: '24 Hours' },
-            ],
-            mode: 'dropdown',
-          },
-        },
-      },
-      { name: 'guestName', selector: { text: {} } },
+      { name: "name", selector: { text: {} } },
+      { name: "config_entry_id", selector: { text: {} } }
     ];
 
-    const isFormValid = this._formData.network && this._formData.ssid;
-
     return html`
-      <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
-        <div class="card-content">
-          ${this._error
-            ? html`<ha-alert
-                alert-type="error"
-                dismissable
-                @alert-dismissed-clicked="${() => (this._error = null)}"
-                >${this._error}</ha-alert
-              >`
-            : ''}
-          ${this._success
-            ? html`<ha-alert
-                alert-type="success"
-                dismissable
-                @alert-dismissed-clicked="${() => (this._success = null)}"
-                >${this._success}</ha-alert
-              >`
-            : ''}
-
-          <div class="form-container">
-            <ha-form
-              .hass=${this.hass}
-              .data=${this._formData}
-              .schema=${schema}
-              .computeLabel=${this._computeLabel}
-              @value-changed=${this._formValueChanged}
-            ></ha-form>
-
-            <ha-button
-              raised
-              .disabled=${this._creating || !isFormValid}
-              @click=${this._generateAccessKey}
-            >
-              ${this._creating
-                ? html`<ha-circular-progress
-                    active
-                    size="small"
-                  ></ha-circular-progress>`
-                : 'Generate Access Key'}
-            </ha-button>
-          </div>
-        </div>
-        <div class="version">v${__VERSION__}</div>
-      </ha-card>
+      <div class="editor-container">
+        <ha-form
+          .hass=${this.hass}
+          .data=${this._config}
+          .schema=${schema}
+          .computeLabel=${this._computeLabel}
+          @value-changed=${this._valueChanged}
+        ></ha-form>
+      </div>
     `;
   }
 
-  private async _generateAccessKey() {
-    if (!this._formData.network || !this._formData.ssid) return;
-    this._creating = true;
-    this._error = null;
-    this._success = null;
-
-    try {
-      // Build a clean payload dynamically to avoid sending undefined values
-      const payload: any = {
-        network_id: this._formData.network,
-        ssid: parseInt(this._formData.ssid, 10),
-        duration: parseInt(this._formData.duration, 10),
-      };
-
-      if (this._formData.guestName) {
-        payload.guest_name = this._formData.guestName;
-      }
-
-      if (
-        this._formData.groupPolicy &&
-        this._formData.groupPolicy !== 'NONE'
-      ) {
-        payload.group_policy = this._formData.groupPolicy;
-      }
-
-      await this.hass.callService(
-        'meraki_ha',
-        'generate_guest_access',
-        payload
-      );
-      this._success = 'Guest access key created successfully!';
-    } catch (err: any) {
-      this._error = `Failed to create guest key: ${err.message || err}`;
-    } finally {
-      this._creating = false;
-    }
+  private _valueChanged(ev: CustomEvent): void {
+    if (!this._config) return;
+    const config = { ...this._config, ...ev.detail.value };
+    this.dispatchEvent(new CustomEvent("config-changed", {
+      detail: { config },
+      bubbles: true,
+      composed: true,
+    }));
   }
 
-  static styles = [
-    sharedStyles,
-    css`
-      .form-container {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-      }
-      ha-button {
-        width: 100%;
-        margin-top: 8px;
-      }
-      .flex {
-        display: flex;
-      }
-      .justify-center {
-        justify-content: center;
-      }
-      .p-8 {
-        padding: 32px;
-      }
-    `,
-  ];
+  static styles = css`
+    .editor-container { padding: 16px; }
+  `;
 }
 
-declare global {
-  interface HTMLElementTagNameMap {
-    'meraki-guest-access-card': MerakiGuestAccessCard;
-  }
-}
-if (!customElements.get('meraki-guest-access-card')) {
-  customElements.define('meraki-guest-access-card', MerakiGuestAccessCard);
-}
-(window as any).customCards = (window as any).customCards || [];
-if (
-  !(window as any).customCards.some(
-    (c: any) => c.type === 'meraki-guest-access-card'
-  )
-) {
-  (window as any).customCards.push({
-    type: 'meraki-guest-access-card',
-    name: 'Meraki Guest Access',
-    description: `Manage temporary guest WiFi access. Version: ${__VERSION__}`,
-    preview: true,
-    version: __VERSION__,
-  });
+if (!customElements.get('meraki-guest-access-card-editor')) {
+  customElements.define('meraki-guest-access-card-editor', MerakiGuestAccessCardEditor);
 }

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
-import { renderWarning, renderLoading, sharedStyles } from './shared-ui';
+import { renderWarning, renderLoadingState, sharedStyles } from './shared-ui';
 import { MerakiDataProvider } from './utils/meraki-data';
 import './meraki-content-filter-card';
 import './meraki-wifi-qr-card';
@@ -234,31 +234,19 @@ export class MerakiGuestAccessCard extends LitElement {
     });
 
     if (this._isLoading) {
-      return html`
-        <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
-          <div class="card-content" style="display: flex; flex-direction: column; align-items: center; padding: 32px;">
-            <ha-circular-progress active></ha-circular-progress>
-            <div style="margin-top: 16px; color: var(--secondary-text-color); text-align: center;">
-              ${this._loadingMessage}
-            </div>
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
+      return renderLoadingState(
+        this._config?.name || 'Meraki Guest Access',
+        this._loadingMessage,
+        __VERSION__
+      );
     }
 
     if (this._networks.length === 0) {
-      return html`
-        <ha-card .header="${this._config?.name || 'Meraki Guest Access'}">
-          <div class="card-content">
-            ${renderWarning(
-              'No Wireless Networks',
-              'No Meraki wireless networks found. Ensure the integration is configured.'
-            )}
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
+      return renderWarning(
+        'No Wireless Networks',
+        'No Meraki wireless networks found. Ensure the integration is configured.',
+        __VERSION__
+      );
     }
 
     const networkOptions = MerakiDataProvider.getNetworkOptions(

--- a/frontend/src/meraki-network-vitals-card.ts
+++ b/frontend/src/meraki-network-vitals-card.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
+import { renderLoadingState, sharedStyles } from './shared-ui';
 import { MerakiDataProvider } from './utils/meraki-data';
 
 declare const __VERSION__: string;
@@ -157,17 +158,11 @@ export class MerakiNetworkVitalsCard extends LitElement {
     }
 
     if (this._isLoading) {
-      return html`
-        <ha-card>
-          <div class="card-content" style="text-align: center; padding: 16px;">
-            <ha-circular-progress active size="small"></ha-circular-progress>
-            <div style="margin-top: 8px; font-size: 12px; color: var(--secondary-text-color);">
-              ${this._loadingMessage}
-            </div>
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
+      return renderLoadingState(
+        this._config?.name || 'Meraki Network Vitals',
+        this._loadingMessage,
+        __VERSION__
+      );
     }
 
     const throughputEntity = this._config.throughput_entity;
@@ -219,69 +214,72 @@ export class MerakiNetworkVitalsCard extends LitElement {
     `;
   }
 
-  static styles = css`
-    :host {
-      display: block;
-    }
-    ha-card {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
-    .card-content {
-      padding: 12px 16px;
-    }
-    .vitals-container {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-    .status-dots {
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 16px;
-    }
-    .status-item {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    .status-item.clickable {
-      cursor: pointer;
-    }
-    .status-icon {
-      --mdc-icon-size: 16px;
-      color: var(--secondary-text-color);
-    }
-    .status-label {
-      font-size: 14px;
-      font-weight: 500;
-      color: var(--primary-text-color);
-      white-space: nowrap;
-    }
-    .throughput-container {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      color: var(--secondary-text-color);
-    }
-    .throughput-value {
-      font-size: 14px;
-      font-weight: 600;
-      white-space: nowrap;
-    }
-    .version {
-      font-size: 9px;
-      color: var(--secondary-text-color);
-      text-align: right;
-      padding: 0 12px 4px;
-      opacity: 0.4;
-    }
-  `;
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: block;
+      }
+      ha-card {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+      .card-content {
+        padding: 12px 16px;
+      }
+      .vitals-container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+      .status-dots {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      .status-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .status-item.clickable {
+        cursor: pointer;
+      }
+      .status-icon {
+        --mdc-icon-size: 16px;
+        color: var(--secondary-text-color);
+      }
+      .status-label {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--primary-text-color);
+        white-space: nowrap;
+      }
+      .throughput-container {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        color: var(--secondary-text-color);
+      }
+      .throughput-value {
+        font-size: 14px;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+      .version {
+        font-size: 9px;
+        color: var(--secondary-text-color);
+        text-align: right;
+        padding: 0 12px 4px;
+        opacity: 0.4;
+      }
+    `
+  ];
 }
 
 export class MerakiNetworkVitalsCardEditor extends LitElement {

--- a/frontend/src/meraki-wifi-qr-card.ts
+++ b/frontend/src/meraki-wifi-qr-card.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HomeAssistant } from './types/ha';
 import { Network, SSID } from './types/meraki';
-import { renderWarning, sharedStyles } from './shared-ui';
+import { renderWarning, renderLoadingState, sharedStyles } from './shared-ui';
 import { MerakiDataProvider } from './utils/meraki-data';
 import QRCode from 'qrcode';
 
@@ -260,17 +260,11 @@ export class MerakiWifiQrCard extends LitElement {
     if (!this._config || !this.hass) return html``;
 
     if (this._isLoading) {
-      return html`
-        <ha-card .header=${this._config?.name || 'Wi-Fi Access'}>
-          <div class="card-content" style="text-align: center; padding: 32px;">
-            <ha-circular-progress active></ha-circular-progress>
-            <div style="margin-top: 16px; color: var(--secondary-text-color);">
-              ${this._loadingMessage}
-            </div>
-          </div>
-          <div class="version">v${__VERSION__}</div>
-        </ha-card>
-      `;
+      return renderLoadingState(
+        this._config?.name || 'Wi-Fi Access',
+        this._loadingMessage,
+        __VERSION__
+      );
     }
 
     const ssid = this._getValue(this._config.ssid);

--- a/frontend/src/shared-ui.ts
+++ b/frontend/src/shared-ui.ts
@@ -1,13 +1,25 @@
 import { html, css } from 'lit';
 
-export const renderWarning = (title: string, message: string) => html`
-  <div class="meraki-warning">
-    <ha-icon icon="mdi:information"></ha-icon>
-    <div class="warning-content">
-      <strong>${title}</strong>
-      <p>${message}</p>
+export const renderWarning = (title: string, message: string, version?: string) => html`
+  <ha-card class="status-card warning">
+    <div class="card-content flex-col align-center p-8">
+      <ha-icon icon="mdi:alert-circle" style="--mdc-icon-size: 48px; margin-bottom: 16px;"></ha-icon>
+      <h1 class="status-title">${title}</h1>
+      <div class="status-message mt-4">${message}</div>
     </div>
-  </div>
+    ${version ? html`<div class="version">v${version}</div>` : ''}
+  </ha-card>
+`;
+
+export const renderLoadingState = (title: string, message: string, version: string) => html`
+  <ha-card class="status-card loading">
+    <div class="card-content flex-col align-center p-8">
+      <h1 class="status-title">${title}</h1>
+      <ha-circular-progress active></ha-circular-progress>
+      <div class="status-message mt-4">${message}</div>
+    </div>
+    <div class="version">v${version}</div>
+  </ha-card>
 `;
 
 export const renderLoading = (title: string) => html`
@@ -18,6 +30,63 @@ export const renderLoading = (title: string) => html`
 `;
 
 export const sharedStyles = css`
+  ha-card.status-card {
+    --ha-card-background: var(--warning-color, #ffeb3b);
+    background-color: var(--warning-color, #ffeb3b) !important;
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  ha-card.status-card.loading {
+    --ha-card-background: var(--info-color, #2196f3);
+    background-color: var(--info-color, #2196f3) !important;
+  }
+  ha-card.status-card.warning {
+    --ha-card-background: var(--warning-color, #ffeb3b);
+    background-color: var(--warning-color, #ffeb3b) !important;
+  }
+
+  /* Force high-contrast dark text on bright colored backgrounds in light mode */
+  .status-card .status-title,
+  .status-card .status-message {
+    color: #111111 !important;
+    text-align: center;
+  }
+
+  .status-card .status-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: bold;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    ha-card.status-card.warning {
+      --ha-card-background: rgba(255, 193, 7, 0.2);
+      background-color: rgba(255, 193, 7, 0.2) !important;
+    }
+    ha-card.status-card.loading {
+      --ha-card-background: rgba(33, 150, 243, 0.2);
+      background-color: rgba(33, 150, 243, 0.2) !important;
+    }
+    .status-card .status-title,
+    .status-card .status-message {
+      color: var(--primary-text-color) !important;
+    }
+  }
+
+  .flex-col { display: flex; flex-direction: column; }
+  .align-center { align-items: center; }
+  .p-8 { padding: 32px; }
+  .mt-4 { margin-top: 16px; }
+
+  .version {
+    font-size: 9px;
+    color: var(--secondary-text-color);
+    text-align: right;
+    padding: 4px 12px;
+    opacity: 0.4;
+  }
+
+  /* Legacy styles for backward compatibility during transition */
   .meraki-warning {
     display: flex;
     align-items: flex-start;
@@ -27,15 +96,6 @@ export const sharedStyles = css`
     color: var(--primary-text-color);
     border-radius: 8px;
   }
-  .warning-content strong {
-    display: block;
-    margin-bottom: 4px;
-  }
-  .warning-content p {
-    margin: 0;
-    font-size: 0.9em;
-    opacity: 0.9;
-  }
   .meraki-loading {
     display: flex;
     flex-direction: column;
@@ -43,12 +103,5 @@ export const sharedStyles = css`
     justify-content: center;
     padding: 24px;
     gap: 12px;
-  }
-  .version {
-    font-size: 9px;
-    color: var(--secondary-text-color);
-    text-align: right;
-    padding: 4px 12px;
-    opacity: 0.4;
   }
 `;


### PR DESCRIPTION
This submission fixes several issues with the Meraki custom dashboard cards:

1. **Unification of Loading UI**: Extracted the duplicated loading logic into a shared `renderLoadingState` function in `shared-ui.ts`.
2. **Accessibility Compliance**: Fixed the CSS contrast for loading and warning states. In light mode, it now forces high-contrast dark text on bright backgrounds. In dark mode, it uses muted background colors with native Home Assistant primary text color.
3. **Guest Access Card Startup Fix**: Resolved a critical bug where `meraki-guest-access-card-editor.ts` incorrectly redefined the `MerakiGuestAccessCard` class, causing a registration conflict that bypassed the card's polling and initialization logic.
4. **Card Harmonization**: Updated all custom cards (`meraki-guest-access-card`, `meraki-wifi-qr-card`, `meraki-content-filter-card`, and `meraki-network-vitals-card`) to utilize the new centralized UI and styles.
5. **Documentation and Versioning**: Updated `docs/requirements/requirements.md` with Requirement R20 and bumped the frontend version in `package.json`.

The changes have been verified visually via Playwright and through a comprehensive code review.

Fixes #2645

---
*PR created automatically by Jules for task [7050558530223670402](https://jules.google.com/task/7050558530223670402) started by @brewmarsh*