### PR TITLE
Fix AttributeError in Meraki Options Flow

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -83,7 +83,7 @@ class MerakiOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        # The base class automatically exposes self.config_entry, so no assignment is needed here.
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
The `meraki_ha` integration was crashing with an `AttributeError: property 'config_entry' of 'MerakiOptionsFlowHandler' object has no setter` when attempting to open the Options menu. This was because the code was trying to manually assign `self.config_entry` in the `MerakiOptionsFlowHandler.__init__` method, which is not allowed in modern Home Assistant versions where `config_entry` is a read-only property provided by the base `OptionsFlow` class.

I have removed the line `self.config_entry = config_entry` from the `__init__` method in `custom_components/meraki_ha/config_flow.py`. The class now correctly relies on the native `self.config_entry` property provided by the base class. I've verified the fix by running the existing config flow tests.

Fixes #2659

---
*PR created automatically by Jules for task [15553621816606718429](https://jules.google.com/task/15553621816606718429) started by @brewmarsh*