### PR TITLE
Fix update listener to use native async_reload method

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -329,5 +329,5 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
         entry: The config entry.
 
     """
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    _LOGGER.info("Options updated, reloading integration...")
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -90,4 +90,8 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** Unified all custom cards (`meraki-guest-access-card`, `meraki-wifi-qr-card`, `meraki-content-filter-card`, `meraki-network-vitals-card`) to use the new centralized loading UI.
   - **[VERIFIED]** Fixed a regression in `meraki-guest-access-card-editor.ts` that caused the guest access card to skip its polling countdown due to a class naming conflict.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20) are now considered part of the standard for this integration.
+- **R21: Safe Configuration Reloading:**
+  - **[VERIFIED]** Fixed `update_listener` in `__init__.py` to use Home Assistant's native `async_reload` method instead of manually calling setup/unload sequences. This prevents `ConfigEntryError` and ensures a safe teardown and rebuild of the integration during options updates.
+  - **[VERIFIED]** Added unit tests in `tests/test_config_flow.py` to ensure the reload mechanism is correctly triggered upon configuration changes.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21) are now considered part of the standard for this integration.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -102,13 +102,33 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     assert result["step_id"] == "init"
 
     # Save Settings
-    result_save = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            CONF_ENABLE_DEVICE_STATUS: True,
-            "enable_device_sensors": True,
-            "enable_port_sensors": False,
-            CONF_ENABLE_CAMERA_ENTITIES: True,
-        },
-    )
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        return_value=None,
+    ) as mock_reload:
+        result_save = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ENABLE_DEVICE_STATUS: True,
+                "enable_device_sensors": True,
+                "enable_port_sensors": False,
+                CONF_ENABLE_CAMERA_ENTITIES: True,
+            },
+        )
+        await hass.async_block_till_done()
+
     assert result_save["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_update_listener(hass: HomeAssistant) -> None:
+    """Test the update listener."""
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="test_entry_id")
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        return_value=None,
+    ) as mock_reload:
+        from custom_components.meraki_ha import update_listener
+
+        await update_listener(hass, entry)
+
+    mock_reload.assert_called_once_with(entry.entry_id)


### PR DESCRIPTION
The `meraki_ha` integration was crashing with a `ConfigEntryError` when users updated settings via the Options UI because the `update_listener` was incorrectly calling `async_setup_entry` directly while the integration was already loaded. This PR fixes the issue by delegating the reload process to Home Assistant's native configuration entry reload method (`async_reload`).

Key changes:
- Modified `update_listener` in `custom_components/meraki_ha/__init__.py` to call `await hass.config_entries.async_reload(entry.entry_id)`.
- Added a new unit test in `tests/test_config_flow.py` to verify that `async_reload` is called when the listener is triggered.
- Documented the fix as Requirement R21 in `docs/requirements/requirements.md`.
- Verified the fix with `pytest`.

Fixes #2665

---
*PR created automatically by Jules for task [1417445101602250004](https://jules.google.com/task/1417445101602250004) started by @brewmarsh*