### PR TITLE
Isolate API Blacklisting to Specific Endpoints

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -149,6 +149,17 @@ class MerakiClient:
         if not serial and args and isinstance(args[0], str):
             serial = args[0]
 
+        # Extract network_id for endpoint-specific blacklisting
+        network_id = kwargs.get("networkId") or kwargs.get("network_id")
+        if not network_id and args and isinstance(args[0], str) and args[0].startswith(("N_", "L_")):
+            network_id = args[0]
+
+        # Action 3: Pre-flight check for blacklisted endpoints
+        endpoint = func.__name__
+        if self.is_feature_disabled(endpoint, network_id):
+            _LOGGER.debug("Skipping blacklisted endpoint: %s", endpoint)
+            return []
+
         braintrust.current_span().log(
             metadata={
                 "organization_id": org_id,
@@ -178,6 +189,19 @@ class MerakiClient:
                 )
 
                 error_msg = str(e)
+                status_code = getattr(e, "status", None)
+
+                # Action 2: Endpoint-specific blacklisting for 400 errors
+                if status_code == 400 and (
+                    "not enabled" in error_msg.lower()
+                    or "must be enabled" in error_msg.lower()
+                ):
+                    _LOGGER.warning(
+                        "Endpoint unsupported, adding to blacklist: %s", endpoint
+                    )
+                    self.mark_feature_disabled(endpoint, network_id)
+                    return []
+
                 if (
                     "Traffic Analysis with Hostname Visibility" in error_msg
                     or "VLANs are not enabled" in error_msg

--- a/custom_components/meraki_ha/core/utils/api/handlers.py
+++ b/custom_components/meraki_ha/core/utils/api/handlers.py
@@ -46,7 +46,6 @@ def handle_feature_disabled(
 ) -> Any:
     """Handle disabled features by marking them in the client & returning safe value."""
     error_msg = str(err)
-    is_traffic_analysis = "Traffic Analysis with Hostname Visibility" in error_msg
 
     _LOGGER.debug("Meraki feature disabled (skipping): %s", error_msg)
 
@@ -58,12 +57,18 @@ def handle_feature_disabled(
         network_id = kwargs.get("networkId") or kwargs.get("network_id")
         if not network_id and len(args) > 1:
             # network_id is typically the first argument after 'self'
-            network_id = args[1]
+            # Check if it's a serial or network_id
+            arg_val = args[1]
+            if isinstance(arg_val, str) and (
+                arg_val.startswith(("N_", "L_"))
+                or (not arg_val.startswith("M") and len(arg_val) > 12)
+            ):
+                network_id = arg_val
 
-        if network_id and isinstance(network_id, str):
-            feature = "traffic" if is_traffic_analysis else "vlans"
-            if hasattr(client, "mark_feature_disabled"):
-                client.mark_feature_disabled(feature, network_id)
+        # Action 2: Use the exact endpoint name as the feature key
+        feature = func.__name__
+        if hasattr(client, "mark_feature_disabled"):
+            client.mark_feature_disabled(feature, network_id)
 
     return get_safe_return_value(func, error_msg)
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -109,6 +109,7 @@
 | The integration should handle API errors, network issues, and other exceptions gracefully.  | Included |
 | Logging should be used for debugging and error reporting.                                   | Included |
 | The integration must implement an adaptive back-off algorithm when 429 errors are detected. | Included |
+| The integration must implement granular, endpoint-specific API blacklisting to prevent failures in one feature from inadvertently disabling unrelated functionality. | Included |
 
 ### Data Coordination
 

--- a/tests/core/utils/test_api_silencing.py
+++ b/tests/core/utils/test_api_silencing.py
@@ -76,8 +76,8 @@ async def test_api_silencing_traffic():
     result = await endpoint.get_traffic("N_123")
 
     assert result == []
-    client.mark_feature_disabled.assert_called_once_with("traffic", "N_123")
-    assert "traffic_N_123" in client._disabled_features
+    client.mark_feature_disabled.assert_called_once_with("get_traffic", "N_123")
+    assert "get_traffic_N_123" in client._disabled_features
 
 
 @pytest.mark.asyncio
@@ -96,5 +96,5 @@ async def test_api_silencing_vlans():
     result = await endpoint.get_vlans("N_123")
 
     assert result == []
-    client.mark_feature_disabled.assert_called_once_with("vlans", "N_123")
-    assert "vlans_N_123" in client._disabled_features
+    client.mark_feature_disabled.assert_called_once_with("get_vlans", "N_123")
+    assert "get_vlans_N_123" in client._disabled_features


### PR DESCRIPTION
The Meraki HA integration's pre-flight feature blacklist was too aggressive. When certain endpoints failed with a 400 error (e.g., `getNetworkAppliancePorts` when VLANs are disabled), the error handling logic would blacklist broad categories like "vlans," which inadvertently blocked unrelated endpoints such as `getDeviceSwitchPortsStatuses`. This prevented valid switch port sensors from being generated.

This PR implements granular, endpoint-specific blacklisting. By using the exact name of the failing SDK endpoint (combined with the network ID) as the blacklist key, we ensure that a failure in one area of the Meraki dashboard does not contaminate or disable unrelated functionality.

Key changes:
- **`MerakiClient.run_sync`**: Added a pre-flight check to skip blacklisted calls and an error handler to blacklist endpoints returning 400 "not enabled" errors.
- **`handle_feature_disabled`**: Updated to derive the blacklist key from the function name (`func.__name__`) and the extracted `network_id`.
- **Test Suite**: Updated `test_api_silencing.py` to verify that endpoint-specific keys (e.g., `get_vlans_N_123`) are correctly used and honored.
- **Requirements**: Added a new technical requirement for granular API blacklisting.

Fixes #2669

---
*PR created automatically by Jules for task [9248380068742703629](https://jules.google.com/task/9248380068742703629) started by @brewmarsh*