### PR TITLE
Fix Switch Port Availability Race Condition

### DIFF
--- a/custom_components/meraki_ha/__init__.py
+++ b/custom_components/meraki_ha/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import secrets
 import string
@@ -173,20 +174,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_coordinator.ssids_by_network_and_number
         )
 
-    # 2. Start heavy fetching for other coordinators in the background.
-    # This prevents blocking the Home Assistant UI and avoids setup timeouts.
-    for coord, name in [
-        (main_coordinator, "meraki_main_init"),
-        (switch_coordinator, "meraki_switch_init"),
-        (camera_coordinator, "meraki_camera_init"),
-        (sensor_coordinator, "meraki_sensor_init"),
-        (wireless_coordinator, "meraki_wireless_init"),
-        (appliance_coordinator, "meraki_appliance_init"),
-        (client_coordinator, "meraki_client_init"),
-    ]:
-        entry.async_create_background_task(
-            hass, coord.async_request_refresh(), name=name
-        )
+    # 2. Block until heavy fetching for all specialized coordinators completes.
+    # This guarantees that all required data is present before entity discovery runs,
+    # preventing race conditions that lead to missing entities (like switch ports).
+    await asyncio.gather(
+        main_coordinator.async_config_entry_first_refresh(),
+        switch_coordinator.async_config_entry_first_refresh(),
+        camera_coordinator.async_config_entry_first_refresh(),
+        sensor_coordinator.async_config_entry_first_refresh(),
+        wireless_coordinator.async_config_entry_first_refresh(),
+        appliance_coordinator.async_config_entry_first_refresh(),
+        client_coordinator.async_config_entry_first_refresh(),
+    )
 
     repo = MerakiRepository(api_client)
     device_control_service = DeviceControlService(repo)
@@ -229,8 +228,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "discovery_service": discovery_service,
     }
 
-    await discovery_service.discover_entities()
-
     # Set up services
     services_manager = ServicesManager(
         hass,
@@ -261,6 +258,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             e,
         )
 
+    # 3. Run discovery ONLY when data is present and services are initialized
+    await discovery_service.discover_entities()
+
+    # 4. Finally, forward to platforms (sensor, switch, etc.)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(update_listener))

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -93,4 +93,7 @@ This document verifies the state of the codebase against the requirements for th
   - **[VERIFIED]** Fixed `update_listener` in `__init__.py` to use Home Assistant's native `async_reload` method instead of manually calling setup/unload sequences. This prevents `ConfigEntryError` and ensures a safe teardown and rebuild of the integration during options updates.
   - **[VERIFIED]** Added unit tests in `tests/test_config_flow.py` to ensure the reload mechanism is correctly triggered upon configuration changes.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21) are now considered part of the standard for this integration.
+- **R22: Guaranteed Initialization Order:**
+  - **[VERIFIED]** Implementation of guaranteed initialization order to prevent race conditions during entity discovery. All specialized coordinators must complete their initial data refresh before the discovery service is invoked.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22) are now considered part of the standard for this integration.


### PR DESCRIPTION
This change resolves a race condition where dynamic entities (specifically switch ports) were not being generated because the discovery service was executing before the data coordinators had finished their initial data fetch.

Key modifications:
- Added `import asyncio` to `custom_components/meraki_ha/__init__.py`.
- Updated `async_setup_entry` to await `async_config_entry_first_refresh()` for all specialized coordinators (Main, Switch, Camera, Sensor, Wireless, Appliance, and Client) in parallel using `asyncio.gather`.
- Reordered the initialization sequence to ensure `discovery_service.discover_entities()` runs strictly after all coordinators have data and after services/webhooks are initialized.
- Ensured `async_forward_entry_setups` is called only after discovery is complete.
- Updated `docs/requirements/requirements.md` to document and verify Requirement R22 (Guaranteed Initialization Order).

Fixes #2674

---
*PR created automatically by Jules for task [4259137546457652685](https://jules.google.com/task/4259137546457652685) started by @brewmarsh*