### PR TITLE
Fix Options Flow Amnesia Bug

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -8,15 +8,10 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import selector
 
 from homeassistant import config_entries
 
 from .const.config import (
-    CONF_ENABLE_CAMERA_ENTITIES,
-    CONF_ENABLE_DEVICE_SENSORS,
-    CONF_ENABLE_DEVICE_STATUS,
-    CONF_ENABLE_PORT_SENSORS,
     CONF_MERAKI_API_KEY,
     CONF_MERAKI_ORG_ID,
 )
@@ -102,13 +97,11 @@ class MerakiOptionsFlowHandler(config_entries.OptionsFlow):
                 title="", data=self.config_entry.options | user_input
             )
 
-        from .schemas import OPTIONS_SCHEMA_GENERAL
+        from .schemas import get_options_schema_general
 
         return self.async_show_form(
             step_id="general",
-            data_schema=self.add_suggested_values_to_schema(
-                OPTIONS_SCHEMA_GENERAL, self.config_entry.options
-            ),
+            data_schema=get_options_schema_general(self.config_entry.options),
         )
 
     async def async_step_sensors(
@@ -120,13 +113,11 @@ class MerakiOptionsFlowHandler(config_entries.OptionsFlow):
                 title="", data=self.config_entry.options | user_input
             )
 
-        from .schemas import OPTIONS_SCHEMA_SENSORS
+        from .schemas import get_options_schema_sensors
 
         return self.async_show_form(
             step_id="sensors",
-            data_schema=self.add_suggested_values_to_schema(
-                OPTIONS_SCHEMA_SENSORS, self.config_entry.options
-            ),
+            data_schema=get_options_schema_sensors(self.config_entry.options),
         )
 
     async def async_step_cameras(
@@ -138,13 +129,11 @@ class MerakiOptionsFlowHandler(config_entries.OptionsFlow):
                 title="", data=self.config_entry.options | user_input
             )
 
-        from .schemas import OPTIONS_SCHEMA_CAMERAS
+        from .schemas import get_options_schema_cameras
 
         return self.async_show_form(
             step_id="cameras",
-            data_schema=self.add_suggested_values_to_schema(
-                OPTIONS_SCHEMA_CAMERAS, self.config_entry.options
-            ),
+            data_schema=get_options_schema_cameras(self.config_entry.options),
         )
 
     async def async_step_advanced(
@@ -156,11 +145,9 @@ class MerakiOptionsFlowHandler(config_entries.OptionsFlow):
                 title="", data=self.config_entry.options | user_input
             )
 
-        from .schemas import OPTIONS_SCHEMA_ADVANCED
+        from .schemas import get_options_schema_advanced
 
         return self.async_show_form(
             step_id="advanced",
-            data_schema=self.add_suggested_values_to_schema(
-                OPTIONS_SCHEMA_ADVANCED, self.config_entry.options
-            ),
+            data_schema=get_options_schema_advanced(self.config_entry.options),
         )

--- a/custom_components/meraki_ha/const/config.py
+++ b/custom_components/meraki_ha/const/config.py
@@ -31,6 +31,9 @@ CONF_RTSP_STREAM_ENABLED: Final = "rtsp_stream_enabled"
 CONF_ENABLE_DEVICE_TRACKER: Final = "enable_device_tracker"
 """Configuration key for enabling device tracker."""
 
+DEFAULT_ENABLE_DEVICE_TRACKER: Final = True
+"""Default value for enabling device tracker."""
+
 CONF_ENABLE_VLAN_MANAGEMENT: Final = "enable_vlan_management"
 """Configuration key for enabling vlan management."""
 

--- a/custom_components/meraki_ha/schemas.py
+++ b/custom_components/meraki_ha/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 import voluptuous as vol
 from homeassistant.helpers import selector
 
@@ -30,6 +31,7 @@ from custom_components.meraki_ha.const.config import (
     DEFAULT_ENABLE_CLIENT_STATUS_SENSORS,
     DEFAULT_ENABLE_DEVICE_SENSORS,
     DEFAULT_ENABLE_DEVICE_STATUS,
+    DEFAULT_ENABLE_DEVICE_TRACKER,
     DEFAULT_ENABLE_FIREWALL_RULES,
     DEFAULT_ENABLE_NETWORK_SENSORS,
     DEFAULT_ENABLE_ORG_SENSORS,
@@ -61,93 +63,158 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
-OPTIONS_SCHEMA_GENERAL = vol.Schema(
-    {
-        vol.Required(
-            CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[
-                    selector.SelectOptionDict(label="Fast (60s)", value="60"),
-                    selector.SelectOptionDict(label="Normal (300s)", value="300"),
-                    selector.SelectOptionDict(label="Slow (900s)", value="900"),
-                ],
-                mode=selector.SelectSelectorMode.DROPDOWN,
-            )
-        ),
-        vol.Optional(
-            CONF_ENABLED_NETWORKS, default=DEFAULT_ENABLED_NETWORKS
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[],
-                multiple=True,
-                custom_value=True,
-                mode=selector.SelectSelectorMode.DROPDOWN,
-            )
-        ),
-        vol.Required(
-            CONF_ENABLE_DEVICE_TRACKER, default=True
-        ): selector.BooleanSelector(),
-    }
-)
 
-OPTIONS_SCHEMA_SENSORS = vol.Schema(
-    {
-        vol.Required(
-            CONF_ENABLE_DEVICE_STATUS, default=DEFAULT_ENABLE_DEVICE_STATUS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_ORG_SENSORS, default=DEFAULT_ENABLE_ORG_SENSORS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_DEVICE_SENSORS, default=DEFAULT_ENABLE_DEVICE_SENSORS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_NETWORK_SENSORS, default=DEFAULT_ENABLE_NETWORK_SENSORS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_VLAN_SENSORS, default=DEFAULT_ENABLE_VLAN_SENSORS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_PORT_SENSORS, default=DEFAULT_ENABLE_PORT_SENSORS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_SSID_SENSORS, default=DEFAULT_ENABLE_SSID_SENSORS
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_CLIENT_STATUS_SENSORS,
-            default=DEFAULT_ENABLE_CLIENT_STATUS_SENSORS,
-        ): selector.BooleanSelector(),
-    }
-)
+def get_options_schema_general(options: dict[str, Any]) -> vol.Schema:
+    """Return the general options schema with defaults."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_SCAN_INTERVAL,
+                default=options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        selector.SelectOptionDict(label="Fast (60s)", value="60"),
+                        selector.SelectOptionDict(label="Normal (300s)", value="300"),
+                        selector.SelectOptionDict(label="Slow (900s)", value="900"),
+                    ],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(
+                CONF_ENABLED_NETWORKS,
+                default=options.get(CONF_ENABLED_NETWORKS, DEFAULT_ENABLED_NETWORKS),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[],
+                    multiple=True,
+                    custom_value=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Required(
+                CONF_ENABLE_DEVICE_TRACKER,
+                default=options.get(
+                    CONF_ENABLE_DEVICE_TRACKER, DEFAULT_ENABLE_DEVICE_TRACKER
+                ),
+            ): selector.BooleanSelector(),
+        }
+    )
 
-OPTIONS_SCHEMA_CAMERAS = vol.Schema(
-    {
-        vol.Required(
-            CONF_ENABLE_CAMERA_ENTITIES, default=DEFAULT_ENABLE_CAMERA_ENTITIES
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_CAMERA_SENSE, default=DEFAULT_ENABLE_CAMERA_SENSE
-        ): selector.BooleanSelector(),
-    }
-)
 
-OPTIONS_SCHEMA_ADVANCED = vol.Schema(
-    {
-        vol.Required(
-            CONF_ENABLE_VLAN_MANAGEMENT, default=DEFAULT_ENABLE_VLAN_MANAGEMENT
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_TRAFFIC_SHAPING, default=DEFAULT_ENABLE_TRAFFIC_SHAPING
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_FIREWALL_RULES, default=DEFAULT_ENABLE_FIREWALL_RULES
-        ): selector.BooleanSelector(),
-        vol.Required(
-            CONF_ENABLE_VPN_MANAGEMENT, default=DEFAULT_ENABLE_VPN_MANAGEMENT
-        ): selector.BooleanSelector(),
-    }
-)
+def get_options_schema_sensors(options: dict[str, Any]) -> vol.Schema:
+    """Return the sensors options schema with defaults."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_ENABLE_DEVICE_STATUS,
+                default=options.get(
+                    CONF_ENABLE_DEVICE_STATUS, DEFAULT_ENABLE_DEVICE_STATUS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_ORG_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_ORG_SENSORS, DEFAULT_ENABLE_ORG_SENSORS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_DEVICE_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_DEVICE_SENSORS, DEFAULT_ENABLE_DEVICE_SENSORS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_NETWORK_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_NETWORK_SENSORS, DEFAULT_ENABLE_NETWORK_SENSORS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_VLAN_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_VLAN_SENSORS, DEFAULT_ENABLE_VLAN_SENSORS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_PORT_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_PORT_SENSORS, DEFAULT_ENABLE_PORT_SENSORS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_SSID_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_SSID_SENSORS, DEFAULT_ENABLE_SSID_SENSORS
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_CLIENT_STATUS_SENSORS,
+                default=options.get(
+                    CONF_ENABLE_CLIENT_STATUS_SENSORS,
+                    DEFAULT_ENABLE_CLIENT_STATUS_SENSORS,
+                ),
+            ): selector.BooleanSelector(),
+        }
+    )
+
+
+def get_options_schema_cameras(options: dict[str, Any]) -> vol.Schema:
+    """Return the cameras options schema with defaults."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_ENABLE_CAMERA_ENTITIES,
+                default=options.get(
+                    CONF_ENABLE_CAMERA_ENTITIES, DEFAULT_ENABLE_CAMERA_ENTITIES
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_CAMERA_SENSE,
+                default=options.get(
+                    CONF_ENABLE_CAMERA_SENSE, DEFAULT_ENABLE_CAMERA_SENSE
+                ),
+            ): selector.BooleanSelector(),
+        }
+    )
+
+
+def get_options_schema_advanced(options: dict[str, Any]) -> vol.Schema:
+    """Return the advanced options schema with defaults."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_ENABLE_VLAN_MANAGEMENT,
+                default=options.get(
+                    CONF_ENABLE_VLAN_MANAGEMENT, DEFAULT_ENABLE_VLAN_MANAGEMENT
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_TRAFFIC_SHAPING,
+                default=options.get(
+                    CONF_ENABLE_TRAFFIC_SHAPING, DEFAULT_ENABLE_TRAFFIC_SHAPING
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_FIREWALL_RULES,
+                default=options.get(
+                    CONF_ENABLE_FIREWALL_RULES, DEFAULT_ENABLE_FIREWALL_RULES
+                ),
+            ): selector.BooleanSelector(),
+            vol.Required(
+                CONF_ENABLE_VPN_MANAGEMENT,
+                default=options.get(
+                    CONF_ENABLE_VPN_MANAGEMENT, DEFAULT_ENABLE_VPN_MANAGEMENT
+                ),
+            ): selector.BooleanSelector(),
+        }
+    )
+
+
+OPTIONS_SCHEMA_GENERAL = get_options_schema_general({})
+OPTIONS_SCHEMA_SENSORS = get_options_schema_sensors({})
+OPTIONS_SCHEMA_CAMERAS = get_options_schema_cameras({})
+OPTIONS_SCHEMA_ADVANCED = get_options_schema_advanced({})
 
 OPTIONS_SCHEMA = (
     OPTIONS_SCHEMA_GENERAL.extend(OPTIONS_SCHEMA_SENSORS.schema)

--- a/tests/test_options_flow_defaults.py
+++ b/tests/test_options_flow_defaults.py
@@ -1,0 +1,58 @@
+"""Test the Meraki HA options flow defaults."""
+
+from typing import Any
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.meraki_ha.const.config import (
+    CONF_ENABLE_DEVICE_STATUS,
+    CONF_MERAKI_API_KEY,
+    CONF_SCAN_INTERVAL,
+)
+from custom_components.meraki_ha.const.integration import DOMAIN
+from homeassistant import config_entries
+
+async def test_options_flow_defaults(hass: HomeAssistant) -> None:
+    """Test that the options flow correctly pre-fills defaults from existing options."""
+    options = {
+        CONF_SCAN_INTERVAL: "900",
+        CONF_ENABLE_DEVICE_STATUS: False,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_MERAKI_API_KEY: "test-api-key"},
+        options=options,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.MENU
+
+    # Check General Settings Step
+    result_general = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "general"},
+    )
+    assert result_general["type"] == FlowResultType.FORM
+
+    # In Home Assistant, the suggested values are passed to the form.
+    # Since we are setting them as defaults in the schema,
+    # we should check if the schema has the correct default values.
+    schema = result_general["data_schema"].schema
+    for key in schema:
+        if key == CONF_SCAN_INTERVAL:
+            assert key.default() == "900"
+
+    # Check Sensors Step
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result_sensors = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "sensors"},
+    )
+    assert result_sensors["type"] == FlowResultType.FORM
+    schema = result_sensors["data_schema"].schema
+    for key in schema:
+        if key == CONF_ENABLE_DEVICE_STATUS:
+            assert key.default() == False


### PR DESCRIPTION
Fixed the "Options Flow amnesia" bug by dynamically populating form defaults from the user's currently saved configuration in `MerakiOptionsFlowHandler`. This prevents accidental deletion of entities (like switch ports) when saving options. Included a new test case to verify the fix.

Fixes #2677

---
*PR created automatically by Jules for task [10476662228707921798](https://jules.google.com/task/10476662228707921798) started by @brewmarsh*