### PR TITLE
Make user logs more helpful by mapping raw endpoints to friendly strings

### DIFF
--- a/custom_components/meraki_ha/core/api/client.py
+++ b/custom_components/meraki_ha/core/api/client.py
@@ -48,6 +48,19 @@ from .shared_cache import MerakiApiCache
 
 _LOGGER = logging.getLogger(__name__)
 
+FRIENDLY_FEATURE_NAMES = {
+    "getNetworkTraffic": "Network traffic analysis",
+    "getNetworkApplianceVlans": "VLAN tracking",
+    "getNetworkAppliancePorts": "Appliance port tracking",
+    "getNetworkApplianceTraffic": "Appliance traffic analysis",
+    "getNetworkApplianceFirewallL3FirewallRules": "L3 firewall rules",
+    "getNetworkApplianceL7FirewallRules": "L7 firewall rules",
+    "getNetworkApplianceContentFiltering": "Content filtering",
+    "getNetworkApplianceVpnSiteToSiteVpn": "Site-to-site VPN",
+    "getNetworkEvents": "Network events",
+    "getDeviceCameraAnalyticsRecent": "Camera analytics",
+}
+
 # Initialize Braintrust for observability
 load_dotenv()
 if os.getenv("BRAINTRUST_API_KEY"):
@@ -196,8 +209,13 @@ class MerakiClient:
                     "not enabled" in error_msg.lower()
                     or "must be enabled" in error_msg.lower()
                 ):
+                    feature_name = FRIENDLY_FEATURE_NAMES.get(endpoint, endpoint)
                     _LOGGER.warning(
-                        "Endpoint unsupported, adding to blacklist: %s", endpoint
+                        "%s is not enabled for network %s and will not be checked until the integration restarts. "
+                        "To add %s support, enable it on the Cisco Meraki dashboard.",
+                        feature_name.capitalize(),
+                        network_id or "Unknown",
+                        feature_name.lower(),
                     )
                     self.mark_feature_disabled(endpoint, network_id)
                     return []

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -96,4 +96,8 @@ This document verifies the state of the codebase against the requirements for th
 - **R22: Guaranteed Initialization Order:**
   - **[VERIFIED]** Implementation of guaranteed initialization order to prevent race conditions during entity discovery. All specialized coordinators must complete their initial data refresh before the discovery service is invoked.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22) are now considered part of the standard for this integration.
+- **R23: User-Friendly Logging:**
+  - [VERIFIED] Translation of raw Meraki API endpoint names (e.g., `getNetworkTraffic`) into user-friendly, actionable warning messages in `MerakiClient.run_sync`.
+  - [VERIFIED] Warning logs now include the affected network ID and specific instructions on how to enable the feature via the Cisco Meraki dashboard.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23) are now considered part of the standard for this integration.

--- a/tests/test_friendly_logging.py
+++ b/tests/test_friendly_logging.py
@@ -1,0 +1,88 @@
+"""Test user-friendly logging in MerakiClient."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import meraki
+from custom_components.meraki_ha.core.api.client import MerakiClient, FRIENDLY_FEATURE_NAMES
+
+class FakeAPIError(meraki.APIError):
+    def __init__(self, message, status, headers=None):
+        self.message = message
+        self.status = status
+        self.response = MagicMock()
+        self.response.headers = headers or {}
+    def __str__(self):
+        return self.message
+
+@pytest.mark.asyncio
+async def test_run_sync_friendly_logging(hass):
+    """Test that run_sync logs friendly error messages for 400 errors."""
+    client = MerakiClient(hass, "api_key", "org_id")
+    await client.async_setup()
+
+    # Mock dashboard and an endpoint
+    mock_func = MagicMock()
+    mock_func.__name__ = "getNetworkTraffic"
+
+    # Create a fake APIError
+    error = FakeAPIError(
+        "Traffic analysis is not enabled for this network",
+        400,
+        {"X-Cisco-Meraki-API-Request-Id": "req_id"}
+    )
+
+    # Use patch to mock loop.run_in_executor
+    with patch("asyncio.get_event_loop") as mock_loop, \
+         patch("custom_components.meraki_ha.core.api.client._LOGGER") as mock_logger:
+
+        mock_loop.return_value.run_in_executor.side_effect = error
+
+        # We need to provide a networkId to trigger the logging properly
+        result = await client.run_sync(mock_func, networkId="N_123")
+
+        assert result == []
+        assert client.is_feature_disabled("getNetworkTraffic", "N_123")
+
+        # Verify the log message
+        friendly_name = FRIENDLY_FEATURE_NAMES["getNetworkTraffic"]
+
+        mock_logger.warning.assert_any_call(
+            "%s is not enabled for network %s and will not be checked until the integration restarts. "
+            "To add %s support, enable it on the Cisco Meraki dashboard.",
+            friendly_name.capitalize(),
+            "N_123",
+            friendly_name.lower()
+        )
+
+@pytest.mark.asyncio
+async def test_run_sync_fallback_logging(hass):
+    """Test that run_sync falls back to raw endpoint name if not in FRIENDLY_FEATURE_NAMES."""
+    client = MerakiClient(hass, "api_key", "org_id")
+    await client.async_setup()
+
+    # Mock dashboard and an unknown endpoint
+    mock_func = MagicMock()
+    mock_func.__name__ = "unknownEndpoint"
+
+    # Create a fake APIError
+    error = FakeAPIError(
+        "this feature must be enabled",
+        400
+    )
+
+    with patch("asyncio.get_event_loop") as mock_loop, \
+         patch("custom_components.meraki_ha.core.api.client._LOGGER") as mock_logger:
+
+        mock_loop.return_value.run_in_executor.side_effect = error
+
+        result = await client.run_sync(mock_func, networkId="N_456")
+
+        assert result == []
+
+        mock_logger.warning.assert_any_call(
+            "%s is not enabled for network %s and will not be checked until the integration restarts. "
+            "To add %s support, enable it on the Cisco Meraki dashboard.",
+            "Unknownendpoint", # capitalize() makes only first letter uppercase
+            "N_456",
+            "unknownendpoint"
+        )


### PR DESCRIPTION
This change improves the quality of user logs in the Meraki HA integration by translating technical API endpoint names into descriptive feature names. When an API call fails with a 400 error indicating a feature is not enabled (e.g., VLANs or Traffic Analysis), the integration now logs a clear, actionable message that identifies the specific network and directs the user to the Cisco Meraki dashboard to enable the required setting. This significantly improves the user experience for non-technical users and simplifies troubleshooting.

Fixes #2680

---
*PR created automatically by Jules for task [7942955826334664620](https://jules.google.com/task/7942955826334664620) started by @brewmarsh*