### PR TITLE
Support for Meraki Go (GS series) switches

### DIFF
--- a/custom_components/meraki_ha/const/device.py
+++ b/custom_components/meraki_ha/const/device.py
@@ -122,6 +122,7 @@ DEVICE_CAPABILITIES: Final[dict[str, list[str]]] = {
     "MS120": _MS_CAPS,
     "MS225": _MS_CAPS,
     "MS250": _MS_CAPS,
+    "GS": _MS_CAPS,
     # MV Family
     "MV12": _MV_CAPS,
     "MV22": _MV_CAPS,

--- a/custom_components/meraki_ha/helpers/device_info_helpers.py
+++ b/custom_components/meraki_ha/helpers/device_info_helpers.py
@@ -95,11 +95,16 @@ def _resolve_physical_device_info(data: dict[str, Any]) -> DeviceInfo | None:
         # Identify Sensor Logic: strictly enforce [Sensor] prefix for
         # all MT sensor models
         is_sensor = product_type.lower() == "sensor" or model.startswith("MT")
+        # Identify Switch Logic: strictly enforce [Switch] prefix for
+        # both MS and GS models
+        is_switch = product_type.lower() == "switch" or model.startswith(("MS", "GS"))
 
         if is_camera:
             prefix = "Camera"
         elif is_sensor:
             prefix = "Sensor"
+        elif is_switch:
+            prefix = "Switch"
         else:
             prefix = DEVICE_TYPE_MAPPING.get(product_type, "Device")
 

--- a/custom_components/meraki_ha/helpers/schema.py
+++ b/custom_components/meraki_ha/helpers/schema.py
@@ -47,7 +47,7 @@ def get_filtered_schema(
 
         if "camera" in p_type.lower() or (model and model.startswith("MV")):
             has_cameras = True
-        if "switch" in p_type.lower() or (model and model.startswith("MS")):
+        if "switch" in p_type.lower() or (model and model.startswith(("MS", "GS"))):
             has_switches = True
 
     filtered_schema_dict = {}

--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -68,7 +68,13 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             d
             for d in devices
             if getattr(d, "network_id", None) == self._network_id
-            and (getattr(d, "model", "") or "").startswith(self._family_prefix)
+            and (
+                (getattr(d, "model", "") or "").startswith(self._family_prefix)
+                or (
+                    self._family_prefix == "MS"
+                    and (getattr(d, "model", "") or "").startswith("GS")
+                )
+            )
         ]
 
     @callback

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -100,4 +100,10 @@ This document verifies the state of the codebase against the requirements for th
   - [VERIFIED] Translation of raw Meraki API endpoint names (e.g., `getNetworkTraffic`) into user-friendly, actionable warning messages in `MerakiClient.run_sync`.
   - [VERIFIED] Warning logs now include the affected network ID and specific instructions on how to enable the feature via the Cisco Meraki dashboard.
 
-This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23) are now considered part of the standard for this integration.
+- **R24: Full Cisco Meraki Go (GS) Support:**
+  - **[VERIFIED]** GS series switches are granted full feature parity with MS enterprise switches in `DEVICE_CAPABILITIES`.
+  - **[VERIFIED]** Network health sensors now include GS switches when calculating "Switches" family health.
+  - **[VERIFIED]** Naming conventions consistently apply the `[Switch]` prefix to all GS and MS models.
+  - **[VERIFIED]** Configuration schema correctly detects switches when only GS models are present in the organization.
+
+This verification confirms the need for the planned refactoring steps. The new requirements (R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24) are now considered part of the standard for this integration.


### PR DESCRIPTION
This change ensures that Cisco Meraki Go (GS series) switches are treated with full feature parity compared to the Enterprise (MS series) switches.

Key changes:
1. **Capabilities**: Added "GS" to the `DEVICE_CAPABILITIES` mapping in `const/device.py` to enable switch-specific features like port status and PoE monitoring.
2. **Health Monitoring**: Updated `MerakiNetworkHealthSensor` in `sensor/network_health.py` to include "GS" models when aggregating health for the "Switches" family.
3. **Schema Logic**: Updated `get_filtered_schema` in `helpers/schema.py` to correctly detect switches when only GS models are present, ensuring relevant configuration options are available.
4. **Naming Conventions**: Updated `_resolve_physical_device_info` in `helpers/device_info_helpers.py` to explicitly identify GS models as switches, resulting in the standardized `[Switch]` prefix in Home Assistant.
5. **Documentation**: Added Requirement R24 to `docs/requirements/requirements.md` and marked it as verified.

Tests performed:
- Ran `tests/sensor/test_network_health.py`
- Ran `tests/helpers/test_device_info_helpers.py`
- Ran `tests/helpers/test_schema.py`
- Ran `tests/discovery/handlers/test_switch.py`
- Ran `tests/core/fetch_strategies/test_switch_strategy.py`
All 14 tests passed successfully.

Fixes #2684

---
*PR created automatically by Jules for task [11597577205816976733](https://jules.google.com/task/11597577205816976733) started by @brewmarsh*