### PR TITLE
Standardize Meraki device naming and centralize device_info

### DIFF
--- a/custom_components/meraki_ha/binary_sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/appliance_port.py
@@ -4,24 +4,22 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from custom_components.meraki_ha.const.integration import DOMAIN
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...core.models import MerakiAppliancePort
 from ...core.models.device import MerakiDevice
-from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiBinarySensor
 
 if TYPE_CHECKING:
     from ...coordinators import MerakiApplianceCoordinator
 
 
-class AppliancePortBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class AppliancePortBinarySensor(MerakiBinarySensor):
     """Representation of a Meraki appliance port binary sensor."""
 
     coordinator: MerakiApplianceCoordinator
@@ -44,23 +42,6 @@ class AppliancePortBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_name = f"Port {self._port.number}"
         self._last_state = None
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        # Action 3: Robust lookup for correct parent linkage
-        device = self.coordinator.get_device(self._device_serial) or self._device
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_serial)},
-            name=format_device_name(
-                device,
-                self.coordinator.config_entry.options
-                if self.coordinator.config_entry
-                else {},
-            ),
-            model=getattr(device, "model", "Unknown"),
-            manufacturer="Cisco Meraki",
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/binary_sensor/device/camera_motion.py
+++ b/custom_components/meraki_ha/binary_sensor/device/camera_motion.py
@@ -13,8 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from ...coordinators import MerakiCameraCoordinator
-from ...entity import MerakiEntity
-from ...helpers.device_info_helpers import resolve_device_info
+from ...entity import MerakiBinarySensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -24,7 +23,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiMotionSensor(MerakiEntity, BinarySensorEntity):
+class MerakiMotionSensor(MerakiBinarySensor):
     """Representation of a motion sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.MOTION
@@ -39,16 +38,13 @@ class MerakiMotionSensor(MerakiEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._device = device
+        self._device_serial = device.serial
         self._camera_service = camera_service
         self._config_entry = config_entry
         self._attr_unique_id = f"{device.serial}-motion"
         self._attr_name = "Motion"
         self._motion_events: list[dict[str, Any]] = []
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information."""
-        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
+++ b/custom_components/meraki_ha/binary_sensor/device/meraki_mt_binary_base.py
@@ -35,12 +35,6 @@ class MerakiMtBinarySensor(MerakiBinarySensor):
         if self.entity_description.name is not UNDEFINED:
             self._attr_name = cast(str | None, self.entity_description.name)
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information."""
-        if not self.coordinator.config_entry:
-            return None
-        return resolve_device_info(self._device, self.coordinator.config_entry)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/binary_sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/binary_sensor/device/switch_port.py
@@ -12,12 +12,12 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ...const.integration import DOMAIN
 from ...coordinators import MerakiSwitchCoordinator
 from ...core.models.device import MerakiDevice
+from ...entity import MerakiBinarySensor
 
 
-class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
+class SwitchPortSensor(MerakiBinarySensor):
     """Representation of a Meraki switch port sensor."""
 
     coordinator: MerakiSwitchCoordinator
@@ -48,26 +48,6 @@ class SwitchPortSensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_name = f"Port {port_id}"
         self._last_state = None
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info linking this port to its parent hardware."""
-        from ...core.utils.naming_utils import format_device_name
-
-        # Action 3: Robust lookup for correct parent linkage
-        device = self.coordinator.get_device(self._device_serial) or self._device
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_serial)},
-            name=format_device_name(
-                device,
-                self.coordinator.config_entry.options
-                if self.coordinator.config_entry
-                else {},
-            ),
-            manufacturer="Cisco Meraki",
-            model=getattr(device, "model", "Unknown"),
-            sw_version=getattr(device, "firmware", ""),
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/button/device/camera_snapshot.py
+++ b/custom_components/meraki_ha/button/device/camera_snapshot.py
@@ -40,10 +40,6 @@ class MerakiSnapshotButton(MerakiEntity, ButtonEntity):
         self._attr_has_entity_name = True
         self._attr_name = "Snapshot"
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information."""
-        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/button/device/mt15_refresh_data.py
+++ b/custom_components/meraki_ha/button/device/mt15_refresh_data.py
@@ -40,10 +40,6 @@ class MerakiMt15RefreshDataButton(MerakiEntity, ButtonEntity):
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information."""
-        return resolve_device_info(self._device, self._config_entry)
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/meraki_ha/button/device/poe_cycle.py
+++ b/custom_components/meraki_ha/button/device/poe_cycle.py
@@ -39,10 +39,6 @@ class MerakiPoECycleButton(MerakiEntity, ButtonEntity):
             icon="mdi:restart",
         )
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        return resolve_device_info(self._device, self._config_entry)
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/meraki_ha/button/reboot.py
+++ b/custom_components/meraki_ha/button/reboot.py
@@ -44,10 +44,6 @@ class MerakiRebootButton(MerakiEntity, ButtonEntity):
         self._config_entry = config_entry
         self._attr_name = "Reboot"
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        return resolve_device_info(self._device, self._config_entry)
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -114,11 +114,6 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         """Return the device data from the coordinator."""
         return self.coordinator.get_device(self._device_serial) or MerakiDevice()
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information."""
-        return resolve_device_info(self.device_data, self.coordinator.config_entry)
-
     async def async_added_to_hass(self) -> None:
         """Handle when entity is added to hass."""
         await super().async_added_to_hass()

--- a/custom_components/meraki_ha/core/utils/naming_utils.py
+++ b/custom_components/meraki_ha/core/utils/naming_utils.py
@@ -37,10 +37,36 @@ def format_device_name(device: dict[str, Any] | Any, config: Mapping[str, Any]) 
         else:
             name = f"{model} {device.get('serial')}"
 
-    # Enforce [Sensor] prefix for MT devices
-    if product_type == "sensor" or model.startswith("MT"):
-        if not str(name).startswith("[Sensor]"):
-            name = f"[Sensor] {name}"
+    # Prefix mapping
+    prefix_map = {
+        "sensor": "Sensor",
+        "camera": "Camera",
+        "switch": "Switch",
+        "wireless": "Wireless",
+        "appliance": "Appliance",
+        "cellularGateway": "Gateway",
+    }
+
+    # Determine prefix
+    prefix = prefix_map.get(product_type)
+    if not prefix:
+        if model.startswith("MT"):
+            prefix = "Sensor"
+        elif model.startswith(("MV", "CS-")):
+            prefix = "Camera"
+        elif model.startswith("MS"):
+            prefix = "Switch"
+        elif model.startswith("MR"):
+            prefix = "Wireless"
+        elif model.startswith("MX"):
+            prefix = "Appliance"
+        elif model.startswith("MG"):
+            prefix = "Gateway"
+
+    if prefix:
+        full_prefix = f"[{prefix}] "
+        if not str(name).startswith(full_prefix):
+            name = f"{full_prefix}{name}"
 
     return standardize_device_name(name)
 

--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
@@ -21,6 +22,18 @@ class MerakiEntity(CoordinatorEntity[T], Generic[T]):
     """Base Cisco Meraki entity."""
 
     _attr_has_entity_name = True
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return consistent device information across all platforms."""
+        from .helpers.device_info_helpers import resolve_device_info
+
+        device_data = self.device_data
+        if device_data:
+            return resolve_device_info(
+                device_data, self.coordinator.config_entry
+            )
+        return getattr(self, "_attr_device_info", None)
 
     @property
     def _serial(self) -> str | None:

--- a/custom_components/meraki_ha/helpers/device_info_helpers.py
+++ b/custom_components/meraki_ha/helpers/device_info_helpers.py
@@ -83,37 +83,20 @@ def _resolve_network_info(data: dict[str, Any]) -> DeviceInfo | None:
     return None
 
 
-def _resolve_physical_device_info(data: dict[str, Any]) -> DeviceInfo | None:
+def _resolve_physical_device_info(
+    data: dict[str, Any], config_entry: ConfigEntry
+) -> DeviceInfo | None:
     """Resolve DeviceInfo for a physical device."""
     device_serial = data.get("serial")
     if device_serial:
-        product_type = str(data.get("productType") or data.get("product_type") or "")
         model = str(data.get("model") or "Unknown")
 
-        # Identify Camera Logic: strictly enforce [Camera] prefix for all camera models
-        is_camera = product_type.lower() == "camera" or model.startswith(("MV", "CS-"))
-        # Identify Sensor Logic: strictly enforce [Sensor] prefix for
-        # all MT sensor models
-        is_sensor = product_type.lower() == "sensor" or model.startswith("MT")
-
-        if is_camera:
-            prefix = "Camera"
-        elif is_sensor:
-            prefix = "Sensor"
-        else:
-            prefix = DEVICE_TYPE_MAPPING.get(product_type, "Device")
-
-        raw_name = data.get("name") or device_serial
-        full_prefix = f"[{prefix}] "
-
-        if raw_name and str(raw_name).startswith(full_prefix):
-            name = raw_name
-        else:
-            name = f"{full_prefix}{raw_name}"
+        # Use the centralized format_device_name to ensure consistency
+        name = format_device_name(data, config_entry.options)
 
         return DeviceInfo(
             identifiers={(DOMAIN, device_serial)},
-            name=standardize_device_name(name),
+            name=name,
             manufacturer="Cisco Meraki",
             model=model,
             sw_version=str(data.get("firmware") or ""),
@@ -163,7 +146,7 @@ def resolve_device_info(
     if info := _resolve_network_info(entity_data):
         return info
 
-    if info := _resolve_physical_device_info(entity_data):
+    if info := _resolve_physical_device_info(entity_data, config_entry):
         return info
 
     # This may happen temporarily during startup or if a device type is unknown

--- a/custom_components/meraki_ha/sensor/device/ap_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/ap_client_count.py
@@ -46,10 +46,6 @@ class MerakiAPClientCountSensor(MerakiSensor):
             name="Client Count",
         )
 
-        self._attr_device_info = resolve_device_info(
-            entity_data=asdict(device_data),
-            config_entry=self._config_entry,
-        )
         self._update_state()
 
     def _get_current_device_data(self) -> MerakiDevice | None:

--- a/custom_components/meraki_ha/sensor/device/connected_clients.py
+++ b/custom_components/meraki_ha/sensor/device/connected_clients.py
@@ -44,10 +44,6 @@ class MerakiDeviceConnectedClientsSensor(MerakiSensor):
             name="Connected Clients",
         )
 
-        self._attr_device_info = resolve_device_info(
-            entity_data=asdict(device_data),
-            config_entry=self.coordinator.config_entry,
-        )
         self._update_state()
 
     def _get_current_device_data(self) -> MerakiDevice | None:

--- a/custom_components/meraki_ha/sensor/device/device_status.py
+++ b/custom_components/meraki_ha/sensor/device/device_status.py
@@ -65,10 +65,6 @@ class MerakiDeviceStatusSensor(MerakiSensor):
         super().__init__(coordinator)
         self._device_serial: str = cast(str, device_data.serial)  # Serial is mandatory
 
-        # Set device info for linking to HA device registry
-        # This uses the initial device_data for static info.
-        self._attr_device_info = resolve_device_info(device_data, config_entry)
-
         # _attr_name is not explicitly set
         self.entity_description = SensorEntityDescription(
             key="device_status",

--- a/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_mt_base.py
@@ -64,10 +64,6 @@ class MerakiMtSensor(MerakiSensor, RestoreSensor):
                 elif isinstance(value, int):
                     self._attr_native_value = float(value)
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return the device info."""
-        return resolve_device_info(self._device, self.coordinator.config_entry)
 
     def _get_readings_list(self) -> list[dict[str, Any]] | None:
         if not self.coordinator.data or not self._serial:

--- a/custom_components/meraki_ha/sensor/device/network_settings.py
+++ b/custom_components/meraki_ha/sensor/device/network_settings.py
@@ -41,11 +41,6 @@ class MerakiDeviceUplinkBaseSensor(MerakiEntity, SensorEntity):
         self._config_entry = config_entry
         self._interface = interface
 
-        self._attr_device_info = resolve_device_info(
-            entity_data=asdict(device_data),
-            config_entry=self._config_entry,
-        )
-
     def _get_uplink_data(self) -> dict[str, Any] | None:
         """Retrieve the latest uplink data from the coordinator."""
         device = self.coordinator.get_device(self._device_serial)

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from custom_components.meraki_ha.const.integration import DOMAIN
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.const import UnitOfPower
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinators import MerakiMainCoordinator
-from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -21,10 +19,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiPoeUsageSensor(
-    CoordinatorEntity,
-    SensorEntity,
-):
+class MerakiPoeUsageSensor(MerakiSensor):
     """
     Representation of a Meraki switch PoE usage sensor.
 
@@ -58,20 +53,6 @@ class MerakiPoeUsageSensor(
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device.serial))},
-            name=format_device_name(
-                self._device,
-                self.coordinator.config_entry.options,
-            ),
-            model=getattr(self._device, "model", None)
-            if not isinstance(self._device, dict)
-            else self._device.get("model"),
-            manufacturer="Cisco Meraki",
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/sensor/device/rtsp_url.py
+++ b/custom_components/meraki_ha/sensor/device/rtsp_url.py
@@ -5,22 +5,20 @@ from __future__ import annotations
 import logging
 from typing import cast
 
-from custom_components.meraki_ha.const.integration import DOMAIN
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.models.device import MerakiDevice
-from ...core.utils.naming_utils import format_device_name
 from ...core.utils.network_utils import construct_rtsp_url
+from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiRtspUrlSensor(CoordinatorEntity, SensorEntity):
+class MerakiRtspUrlSensor(MerakiSensor):
     """
     Representation of an RTSP URL sensor.
 
@@ -85,17 +83,6 @@ class MerakiRtspUrlSensor(CoordinatorEntity, SensorEntity):
 
         self._attr_native_value = "Not available"
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._device_data.serial))},
-            name=format_device_name(self._device_data, self._config_entry.options),
-            model=getattr(self._device_data, "model", None)
-            if not isinstance(self._device_data, dict)
-            else self._device_data.get("model"),
-            manufacturer="Cisco Meraki",
-        )
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/custom_components/meraki_ha/sensor/device/switch_client_count.py
+++ b/custom_components/meraki_ha/sensor/device/switch_client_count.py
@@ -46,10 +46,6 @@ class MerakiSwitchClientCountSensor(MerakiSensor):
             name="Client Count",
         )
 
-        self._attr_device_info = resolve_device_info(
-            entity_data=asdict(device_data),
-            config_entry=self._config_entry,
-        )
         self._update_state()
 
     def _get_current_device_data(self) -> MerakiDevice | None:

--- a/custom_components/meraki_ha/sensor/device/switch_poe.py
+++ b/custom_components/meraki_ha/sensor/device/switch_poe.py
@@ -15,12 +15,12 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ...const.integration import DOMAIN
 from ...coordinators import MerakiSwitchCoordinator
 from ...core.models import MerakiSwitchDevice
+from ...entity import MerakiSensor
 
 
-class MerakiSwitchPoESensor(CoordinatorEntity, SensorEntity):
+class MerakiSwitchPoESensor(MerakiSensor):
     """Representation of a Meraki switch port PoE sensor."""
 
     coordinator: MerakiSwitchCoordinator
@@ -50,26 +50,6 @@ class MerakiSwitchPoESensor(CoordinatorEntity, SensorEntity):
         self._attr_name = f"Port {port_id} PoE"
         self._last_state = None
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info linking this port to its parent hardware."""
-        from ...core.utils.naming_utils import format_device_name
-
-        # Action 3: Robust lookup for correct parent linkage
-        device = self.coordinator.get_device(self._device_serial) or self._device
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_serial)},
-            name=format_device_name(
-                device,
-                self.coordinator.config_entry.options
-                if self.coordinator.config_entry
-                else {},
-            ),
-            manufacturer="Cisco Meraki",
-            model=getattr(device, "model", "Unknown"),
-            sw_version=getattr(device, "firmware", ""),
-        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/sensor/device/switch_port.py
+++ b/custom_components/meraki_ha/sensor/device/switch_port.py
@@ -17,14 +17,14 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from ...const.integration import DOMAIN
 from ...coordinators import MerakiSwitchCoordinator
 from ...core.models.device import MerakiDevice
+from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiSwitchPortBaseSensor(CoordinatorEntity, SensorEntity, ABC):
+class MerakiSwitchPortBaseSensor(MerakiSensor, ABC):
     """Base representation of a Meraki switch port sensor."""
 
     coordinator: MerakiSwitchCoordinator
@@ -55,26 +55,6 @@ class MerakiSwitchPortBaseSensor(CoordinatorEntity, SensorEntity, ABC):
         self._attr_name = f"Port {port_id}{name_suffix}"
         self._last_state = None
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info linking this port to its parent hardware."""
-        from ...core.utils.naming_utils import format_device_name
-
-        # Action 3: Robust lookup for correct parent linkage
-        device = self.coordinator.get_device(self._device_serial) or self._device
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_serial)},
-            name=format_device_name(
-                device,
-                self.coordinator.config_entry.options
-                if self.coordinator.config_entry
-                else {},
-            ),
-            manufacturer="Cisco Meraki",
-            model=getattr(device, "model", "Unknown"),
-            sw_version=getattr(device, "firmware", ""),
-        )
 
     @property
     def available(self) -> bool:

--- a/custom_components/meraki_ha/sensor/device/wireless_radio.py
+++ b/custom_components/meraki_ha/sensor/device/wireless_radio.py
@@ -44,10 +44,6 @@ class MerakiWirelessRadioSensor(MerakiSensor):
         self._band_key = band_key
         self._setting_key = setting_key
 
-        self._attr_device_info = resolve_device_info(
-            entity_data=asdict(device_data),
-            config_entry=self._config_entry,
-        )
         self._update_state()
 
     def _get_current_device_data(self) -> MerakiDevice | None:

--- a/custom_components/meraki_ha/switch/camera_settings.py
+++ b/custom_components/meraki_ha/switch/camera_settings.py
@@ -117,14 +117,3 @@ class MerakiCameraSettingSwitchBase(
         """Update the setting via the Meraki API."""
         raise NotImplementedError
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        return DeviceInfo(
-            identifiers={("meraki_ha", cast(str, self._device_data.serial))},
-            name=standardize_device_name(self._device_data.name),
-            manufacturer="Cisco Meraki",
-            model=getattr(self._device_data, "model", None)
-            if not isinstance(self._device_data, dict)
-            else self._device_data.get("model"),
-        )

--- a/custom_components/meraki_ha/switch/meraki_device_led_switch.py
+++ b/custom_components/meraki_ha/switch/meraki_device_led_switch.py
@@ -41,10 +41,6 @@ class MerakiDeviceLEDSwitch(MerakiEntity, SwitchEntity):
         self._attr_unique_id = f"{self._device_serial}_led_control"
         self._attr_name = "LED Control"
 
-        self._attr_device_info = resolve_device_info(
-            entity_data=asdict(device_data),
-            config_entry=self._config_entry,
-        )
         self._update_state()
 
     @callback

--- a/custom_components/meraki_ha/switch/mt40_power_outlet.py
+++ b/custom_components/meraki_ha/switch/mt40_power_outlet.py
@@ -14,7 +14,6 @@ from ..coordinators import MerakiSensorCoordinator
 from ..core.api import MerakiApiClientProtocol
 from ..core.models.device import MerakiDevice
 from ..entity import MerakiEntity
-from ..helpers.device_info_helpers import resolve_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,10 +59,6 @@ class MerakiMt40PowerOutlet(
         self._attr_name = "Outlet"
         self._attr_is_on: bool | None = None
 
-    @property
-    def device_info(self) -> DeviceInfo | None:
-        """Return device information."""
-        return resolve_device_info(self._device_info, self._config_entry)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/meraki_ha/switch/switch_port.py
+++ b/custom_components/meraki_ha/switch/switch_port.py
@@ -76,26 +76,6 @@ class _MerakiPortSwitchBase(MerakiEntity, SwitchEntity, ABC):
         self._last_state = None
         self._update_internal_state()
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device info linking this port to its parent hardware."""
-        from ..core.utils.naming_utils import format_device_name
-
-        # Robust lookup: Always prefer latest data from coordinator
-        device = self.coordinator.get_device(self._device_serial) or self._device
-
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device_serial)},
-            name=format_device_name(
-                device,
-                self.coordinator.config_entry.options
-                if self.coordinator.config_entry
-                else {},
-            ),
-            manufacturer="Cisco Meraki",
-            model=getattr(device, "model", "Unknown"),
-            sw_version=getattr(device, "firmware", ""),
-        )
 
     @property
     def available(self) -> bool:

--- a/tests/test_naming_standardization.py
+++ b/tests/test_naming_standardization.py
@@ -14,7 +14,7 @@ def test_standardize_device_name():
 
 def test_format_device_name():
     config = {"options": {}}
-    # MT devices (sensors) now get a [Sensor] prefix, which is exempted from the Meraki prefix
+    # MT devices (sensors) now get a [Sensor] prefix
     device = {
         "name": "Kitchen MT14",
         "model": "MT14",
@@ -22,6 +22,33 @@ def test_format_device_name():
         "productType": "sensor",
     }
     assert format_device_name(device, config) == "[Sensor] Kitchen MT14"
+
+    # MS devices (switches) get a [Switch] prefix
+    switch_device = {
+        "name": "Office Switch",
+        "model": "MS120-8LP",
+        "serial": "Q2XX-YYYY-YYYY",
+        "productType": "switch",
+    }
+    assert format_device_name(switch_device, config) == "[Switch] Office Switch"
+
+    # MR devices (wireless) get a [Wireless] prefix
+    wireless_device = {
+        "name": "Living Room AP",
+        "model": "MR33",
+        "serial": "Q2XX-ZZZZ-ZZZZ",
+        "productType": "wireless",
+    }
+    assert format_device_name(wireless_device, config) == "[Wireless] Living Room AP"
+
+    # MX devices (appliance) get a [Appliance] prefix
+    appliance_device = {
+        "name": "Home Gateway",
+        "model": "MX64",
+        "serial": "Q2XX-WWWW-WWWW",
+        "productType": "appliance",
+    }
+    assert format_device_name(appliance_device, config) == "[Appliance] Home Gateway"
 
     device_no_name = {
         "name": None,


### PR DESCRIPTION
This PR standardizes the `device_info` payload across all Meraki entities to prevent naming collisions and "last write wins" registry overwrites in Home Assistant. By centralizing naming logic in a base class and a shared helper, all entities (including base sensors and port sensors) now report the exact same device name (e.g., `[Switch] Office Switch`) to the HA Device Registry.

Fixes #2683

---
*PR created automatically by Jules for task [9201661937235522633](https://jules.google.com/task/9201661937235522633) started by @brewmarsh*