### PR TITLE
Fix VLAN DHCP switch naming and add network attributes

### DIFF
--- a/custom_components/meraki_ha/switch/vlan_dhcp.py
+++ b/custom_components/meraki_ha/switch/vlan_dhcp.py
@@ -20,8 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
     """Representation of a Meraki VLAN's DHCP handling switch."""
 
-    _attr_name = "DHCP"
-
     def __init__(
         self,
         coordinator: MerakiSwitchCoordinator,
@@ -36,10 +34,28 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
         vlan_id = self._vlan.id
         if not vlan_id:
             raise ValueError("VLAN ID should not be None here")
+
+        # Dynamically include the VLAN context in the name
+        self._attr_name = f"{vlan.name} (VLAN {vlan_id}) DHCP"
+        # Set has_entity_name to False to use the full custom name
+        self._attr_has_entity_name = False
+
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "dhcp_handling"
         )
         self._update_internal_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes for the VLAN DHCP switch."""
+        attrs = super().extra_state_attributes
+        attrs.update(
+            {
+                "subnet": self._vlan.subnet,
+                "gateway": self._vlan.appliance_ip,
+            }
+        )
+        return attrs
 
     def _update_internal_state(self) -> None:
         """Update the internal state of the switch."""

--- a/tests/switch/test_vlan_dhcp.py
+++ b/tests/switch/test_vlan_dhcp.py
@@ -69,8 +69,59 @@ def test_vlan_dhcp_switch_creation(
 
     assert isinstance(switch, MerakiVLANDHCPSwitch)
     assert switch.unique_id == "meraki_vlan_net1_1_dhcp_handling"
-    # assert switch.name == "DHCP" # Can't check name without platform
+    assert switch.name == "VLAN 1 (VLAN 1) DHCP"
     assert switch.is_on is True
+
+    # Check extra state attributes
+    attrs = switch.extra_state_attributes
+    assert attrs["network_id"] == "net1"
+    assert attrs["subnet"] is None  # Not set in fixture
+    assert attrs["gateway"] is None  # Not set in fixture
+
+
+def test_vlan_dhcp_switch_attributes(
+    mock_coordinator: MagicMock,
+    mock_config_entry_with_vlan_management: MagicMock,
+    mock_meraki_client: MagicMock,
+) -> None:
+    """Test the extra state attributes of the VLAN DHCP switch."""
+    vlan = MerakiVlan(
+        id="20",
+        name="Guest",
+        subnet="192.168.20.0/24",
+        appliance_ip="192.168.20.1",
+        dhcp_handling="Run a DHCP server",
+    )
+    network = MerakiNetwork(id="net1", name="Network 1")
+    mock_coordinator.data = {
+        "vlans": {"net1": [vlan]},
+        "networks": [network],
+    }
+
+    def get_network(network_id):
+        if network_id == "net1":
+            return network
+        return None
+
+    mock_coordinator.get_network = MagicMock(side_effect=get_network)
+
+    hass = MagicMock()
+    entities = []
+    async_setup_switches(
+        hass,
+        mock_config_entry_with_vlan_management,
+        mock_coordinator,
+        mock_meraki_client,
+        entities.extend,
+    )
+
+    assert len(entities) == 1
+    switch = entities[0]
+
+    assert switch.name == "Guest (VLAN 20) DHCP"
+    attrs = switch.extra_state_attributes
+    assert attrs["subnet"] == "192.168.20.0/24"
+    assert attrs["gateway"] == "192.168.20.1"
 
 
 def test_vlan_dhcp_switch_off_state(


### PR DESCRIPTION
Identified and fixed the issue where VLAN DHCP switches were identically named "DHCP" in the UI.

Changes:
- Modified `custom_components/meraki_ha/switch/vlan_dhcp.py` to dynamically set `self._attr_name` to `"{vlan_name} (VLAN {vlan_id}) DHCP"`.
- Set `self._attr_has_entity_name = False` to prevent redundant naming in Home Assistant.
- Implemented `extra_state_attributes` in `MerakiVLANDHCPSwitch` to include `subnet` and `gateway` (from `appliance_ip`).
- Updated `tests/switch/test_vlan_dhcp.py` to include assertions for the new naming format and state attributes.
- Verified changes by running the updated test suite.

Fixes #2692

---
*PR created automatically by Jules for task [6596829089770796202](https://jules.google.com/task/6596829089770796202) started by @brewmarsh*