### PR TITLE
Create Custom Meraki VLAN Card

### DIFF
--- a/custom_components/meraki_ha/switch/vlan_dhcp.py
+++ b/custom_components/meraki_ha/switch/vlan_dhcp.py
@@ -20,8 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
     """Representation of a Meraki VLAN's DHCP handling switch."""
 
-    _attr_name = "DHCP"
-
     def __init__(
         self,
         coordinator: MerakiSwitchCoordinator,
@@ -36,10 +34,25 @@ class MerakiVLANDHCPSwitch(MerakiVLANEntity, SwitchEntity):
         vlan_id = self._vlan.id
         if not vlan_id:
             raise ValueError("VLAN ID should not be None here")
+        self._attr_name = f"{vlan.name} DHCP"
         self._attr_unique_id = get_vlan_entity_id(
             self._network_id, vlan_id, "dhcp_handling"
         )
         self._update_internal_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes for the VLAN DHCP switch."""
+        attrs = super().extra_state_attributes
+        attrs.update(
+            {
+                "vlan_id": self._vlan.id,
+                "vlan_name": self._vlan.name,
+                "subnet": self._vlan.subnet,
+                "gateway": self._vlan.appliance_ip,
+            }
+        )
+        return attrs
 
     def _update_internal_state(self) -> None:
         """Update the internal state of the switch."""

--- a/custom_components/meraki_ha/www/meraki-card.js
+++ b/custom_components/meraki_ha/www/meraki-card.js
@@ -3,18 +3,18 @@
  * Copyright 2019 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const $t = globalThis, Qt = $t.ShadowRoot && ($t.ShadyCSS === void 0 || $t.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Zt = Symbol(), ge = /* @__PURE__ */ new WeakMap();
-let Ne = class {
-  constructor(t, e, s) {
-    if (this._$cssResult$ = !0, s !== Zt) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+const xt = globalThis, te = xt.ShadowRoot && (xt.ShadyCSS === void 0 || xt.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, ee = Symbol(), ve = /* @__PURE__ */ new WeakMap();
+let Le = class {
+  constructor(t, e, i) {
+    if (this._$cssResult$ = !0, i !== ee) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const e = this.t;
-    if (Qt && t === void 0) {
-      const s = e !== void 0 && e.length === 1;
-      s && (t = ge.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), s && ge.set(e, t));
+    if (te && t === void 0) {
+      const i = e !== void 0 && e.length === 1;
+      i && (t = ve.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), i && ve.set(e, t));
     }
     return t;
   }
@@ -22,33 +22,33 @@ let Ne = class {
     return this.cssText;
   }
 };
-const Xe = (n) => new Ne(typeof n == "string" ? n : n + "", void 0, Zt), F = (n, ...t) => {
-  const e = n.length === 1 ? n[0] : t.reduce((s, i, r) => s + ((o) => {
+const ns = (n) => new Le(typeof n == "string" ? n : n + "", void 0, ee), D = (n, ...t) => {
+  const e = n.length === 1 ? n[0] : t.reduce((i, s, r) => i + ((o) => {
     if (o._$cssResult$ === !0) return o.cssText;
     if (typeof o == "number") return o;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + o + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(i) + n[r + 1], n[0]);
-  return new Ne(e, n, Zt);
-}, ti = (n, t) => {
-  if (Qt) n.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  })(s) + n[r + 1], n[0]);
+  return new Le(e, n, ee);
+}, rs = (n, t) => {
+  if (te) n.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
   else for (const e of t) {
-    const s = document.createElement("style"), i = $t.litNonce;
-    i !== void 0 && s.setAttribute("nonce", i), s.textContent = e.cssText, n.appendChild(s);
+    const i = document.createElement("style"), s = xt.litNonce;
+    s !== void 0 && i.setAttribute("nonce", s), i.textContent = e.cssText, n.appendChild(i);
   }
-}, pe = Qt ? (n) => n : (n) => n instanceof CSSStyleSheet ? ((t) => {
+}, be = te ? (n) => n : (n) => n instanceof CSSStyleSheet ? ((t) => {
   let e = "";
-  for (const s of t.cssRules) e += s.cssText;
-  return Xe(e);
+  for (const i of t.cssRules) e += i.cssText;
+  return ns(e);
 })(n) : n;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const { is: ei, defineProperty: ii, getOwnPropertyDescriptor: si, getOwnPropertyNames: ni, getOwnPropertySymbols: ri, getPrototypeOf: oi } = Object, G = globalThis, me = G.trustedTypes, ai = me ? me.emptyScript : "", Ut = G.reactiveElementPolyfillSupport, dt = (n, t) => n, St = { toAttribute(n, t) {
+const { is: os, defineProperty: as, getOwnPropertyDescriptor: cs, getOwnPropertyNames: ls, getOwnPropertySymbols: ds, getPrototypeOf: hs } = Object, G = globalThis, Ee = G.trustedTypes, us = Ee ? Ee.emptyScript : "", zt = G.reactiveElementPolyfillSupport, ut = (n, t) => n, Mt = { toAttribute(n, t) {
   switch (t) {
     case Boolean:
-      n = n ? ai : null;
+      n = n ? us : null;
       break;
     case Object:
     case Array:
@@ -73,69 +73,69 @@ const { is: ei, defineProperty: ii, getOwnPropertyDescriptor: si, getOwnProperty
       }
   }
   return e;
-} }, Xt = (n, t) => !ei(n, t), _e = { attribute: !0, type: String, converter: St, reflect: !1, useDefault: !1, hasChanged: Xt };
+} }, se = (n, t) => !os(n, t), Ce = { attribute: !0, type: String, converter: Mt, reflect: !1, useDefault: !1, hasChanged: se };
 Symbol.metadata ?? (Symbol.metadata = Symbol("metadata")), G.litPropertyMetadata ?? (G.litPropertyMetadata = /* @__PURE__ */ new WeakMap());
-let tt = class extends HTMLElement {
+let et = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ?? (this.l = [])).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = _e) {
+  static createProperty(t, e = Ce) {
     if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
-      const s = Symbol(), i = this.getPropertyDescriptor(t, s, e);
-      i !== void 0 && ii(this.prototype, t, i);
+      const i = Symbol(), s = this.getPropertyDescriptor(t, i, e);
+      s !== void 0 && as(this.prototype, t, s);
     }
   }
-  static getPropertyDescriptor(t, e, s) {
-    const { get: i, set: r } = si(this.prototype, t) ?? { get() {
+  static getPropertyDescriptor(t, e, i) {
+    const { get: s, set: r } = cs(this.prototype, t) ?? { get() {
       return this[e];
     }, set(o) {
       this[e] = o;
     } };
-    return { get: i, set(o) {
-      const a = i == null ? void 0 : i.call(this);
-      r == null || r.call(this, o), this.requestUpdate(t, a, s);
+    return { get: s, set(o) {
+      const a = s == null ? void 0 : s.call(this);
+      r == null || r.call(this, o), this.requestUpdate(t, a, i);
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? _e;
+    return this.elementProperties.get(t) ?? Ce;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(dt("elementProperties"))) return;
-    const t = oi(this);
+    if (this.hasOwnProperty(ut("elementProperties"))) return;
+    const t = hs(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(dt("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(dt("properties"))) {
-      const e = this.properties, s = [...ni(e), ...ri(e)];
-      for (const i of s) this.createProperty(i, e[i]);
+    if (this.hasOwnProperty(ut("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(ut("properties"))) {
+      const e = this.properties, i = [...ls(e), ...ds(e)];
+      for (const s of i) this.createProperty(s, e[s]);
     }
     const t = this[Symbol.metadata];
     if (t !== null) {
       const e = litPropertyMetadata.get(t);
-      if (e !== void 0) for (const [s, i] of e) this.elementProperties.set(s, i);
+      if (e !== void 0) for (const [i, s] of e) this.elementProperties.set(i, s);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [e, s] of this.elementProperties) {
-      const i = this._$Eu(e, s);
-      i !== void 0 && this._$Eh.set(i, e);
+    for (const [e, i] of this.elementProperties) {
+      const s = this._$Eu(e, i);
+      s !== void 0 && this._$Eh.set(s, e);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
   static finalizeStyles(t) {
     const e = [];
     if (Array.isArray(t)) {
-      const s = new Set(t.flat(1 / 0).reverse());
-      for (const i of s) e.unshift(pe(i));
-    } else t !== void 0 && e.push(pe(t));
+      const i = new Set(t.flat(1 / 0).reverse());
+      for (const s of i) e.unshift(be(s));
+    } else t !== void 0 && e.push(be(t));
     return e;
   }
   static _$Eu(t, e) {
-    const s = e.attribute;
-    return s === !1 ? void 0 : typeof s == "string" ? s : typeof t == "string" ? t.toLowerCase() : void 0;
+    const i = e.attribute;
+    return i === !1 ? void 0 : typeof i == "string" ? i : typeof t == "string" ? t.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
@@ -154,18 +154,18 @@ let tt = class extends HTMLElement {
   }
   _$E_() {
     const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
-    for (const s of e.keys()) this.hasOwnProperty(s) && (t.set(s, this[s]), delete this[s]);
+    for (const i of e.keys()) this.hasOwnProperty(i) && (t.set(i, this[i]), delete this[i]);
     t.size > 0 && (this._$Ep = t);
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return ti(t, this.constructor.elementStyles), t;
+    return rs(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     var t;
     this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this.enableUpdating(!0), (t = this._$EO) == null || t.forEach((e) => {
-      var s;
-      return (s = e.hostConnected) == null ? void 0 : s.call(e);
+      var i;
+      return (i = e.hostConnected) == null ? void 0 : i.call(e);
     });
   }
   enableUpdating(t) {
@@ -173,42 +173,42 @@ let tt = class extends HTMLElement {
   disconnectedCallback() {
     var t;
     (t = this._$EO) == null || t.forEach((e) => {
-      var s;
-      return (s = e.hostDisconnected) == null ? void 0 : s.call(e);
+      var i;
+      return (i = e.hostDisconnected) == null ? void 0 : i.call(e);
     });
   }
-  attributeChangedCallback(t, e, s) {
-    this._$AK(t, s);
+  attributeChangedCallback(t, e, i) {
+    this._$AK(t, i);
   }
   _$ET(t, e) {
     var r;
-    const s = this.constructor.elementProperties.get(t), i = this.constructor._$Eu(t, s);
-    if (i !== void 0 && s.reflect === !0) {
-      const o = (((r = s.converter) == null ? void 0 : r.toAttribute) !== void 0 ? s.converter : St).toAttribute(e, s.type);
-      this._$Em = t, o == null ? this.removeAttribute(i) : this.setAttribute(i, o), this._$Em = null;
+    const i = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, i);
+    if (s !== void 0 && i.reflect === !0) {
+      const o = (((r = i.converter) == null ? void 0 : r.toAttribute) !== void 0 ? i.converter : Mt).toAttribute(e, i.type);
+      this._$Em = t, o == null ? this.removeAttribute(s) : this.setAttribute(s, o), this._$Em = null;
     }
   }
   _$AK(t, e) {
     var r, o;
-    const s = this.constructor, i = s._$Eh.get(t);
-    if (i !== void 0 && this._$Em !== i) {
-      const a = s.getPropertyOptions(i), c = typeof a.converter == "function" ? { fromAttribute: a.converter } : ((r = a.converter) == null ? void 0 : r.fromAttribute) !== void 0 ? a.converter : St;
-      this._$Em = i;
+    const i = this.constructor, s = i._$Eh.get(t);
+    if (s !== void 0 && this._$Em !== s) {
+      const a = i.getPropertyOptions(s), c = typeof a.converter == "function" ? { fromAttribute: a.converter } : ((r = a.converter) == null ? void 0 : r.fromAttribute) !== void 0 ? a.converter : Mt;
+      this._$Em = s;
       const l = c.fromAttribute(e, a.type);
-      this[i] = l ?? ((o = this._$Ej) == null ? void 0 : o.get(i)) ?? l, this._$Em = null;
+      this[s] = l ?? ((o = this._$Ej) == null ? void 0 : o.get(s)) ?? l, this._$Em = null;
     }
   }
-  requestUpdate(t, e, s, i = !1, r) {
+  requestUpdate(t, e, i, s = !1, r) {
     var o;
     if (t !== void 0) {
       const a = this.constructor;
-      if (i === !1 && (r = this[t]), s ?? (s = a.getPropertyOptions(t)), !((s.hasChanged ?? Xt)(r, e) || s.useDefault && s.reflect && r === ((o = this._$Ej) == null ? void 0 : o.get(t)) && !this.hasAttribute(a._$Eu(t, s)))) return;
-      this.C(t, e, s);
+      if (s === !1 && (r = this[t]), i ?? (i = a.getPropertyOptions(t)), !((i.hasChanged ?? se)(r, e) || i.useDefault && i.reflect && r === ((o = this._$Ej) == null ? void 0 : o.get(t)) && !this.hasAttribute(a._$Eu(t, i)))) return;
+      this.C(t, e, i);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(t, e, { useDefault: s, reflect: i, wrapped: r }, o) {
-    s && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t) && (this._$Ej.set(t, o ?? e ?? this[t]), r !== !0 || o !== void 0) || (this._$AL.has(t) || (this.hasUpdated || s || (e = void 0), this._$AL.set(t, e)), i === !0 && this._$Em !== t && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t));
+  C(t, e, { useDefault: i, reflect: s, wrapped: r }, o) {
+    i && !(this._$Ej ?? (this._$Ej = /* @__PURE__ */ new Map())).has(t) && (this._$Ej.set(t, o ?? e ?? this[t]), r !== !0 || o !== void 0) || (this._$AL.has(t) || (this.hasUpdated || i || (e = void 0), this._$AL.set(t, e)), s === !0 && this._$Em !== t && (this._$Eq ?? (this._$Eq = /* @__PURE__ */ new Set())).add(t));
   }
   async _$EP() {
     this.isUpdatePending = !0;
@@ -224,15 +224,15 @@ let tt = class extends HTMLElement {
     return this.performUpdate();
   }
   performUpdate() {
-    var s;
+    var i;
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ?? (this.renderRoot = this.createRenderRoot()), this._$Ep) {
         for (const [r, o] of this._$Ep) this[r] = o;
         this._$Ep = void 0;
       }
-      const i = this.constructor.elementProperties;
-      if (i.size > 0) for (const [r, o] of i) {
+      const s = this.constructor.elementProperties;
+      if (s.size > 0) for (const [r, o] of s) {
         const { wrapped: a } = o, c = this[r];
         a !== !0 || this._$AL.has(r) || c === void 0 || this.C(r, void 0, o, c);
       }
@@ -240,12 +240,12 @@ let tt = class extends HTMLElement {
     let t = !1;
     const e = this._$AL;
     try {
-      t = this.shouldUpdate(e), t ? (this.willUpdate(e), (s = this._$EO) == null || s.forEach((i) => {
+      t = this.shouldUpdate(e), t ? (this.willUpdate(e), (i = this._$EO) == null || i.forEach((s) => {
         var r;
-        return (r = i.hostUpdate) == null ? void 0 : r.call(i);
+        return (r = s.hostUpdate) == null ? void 0 : r.call(s);
       }), this.update(e)) : this._$EM();
-    } catch (i) {
-      throw t = !1, this._$EM(), i;
+    } catch (s) {
+      throw t = !1, this._$EM(), s;
     }
     t && this._$AE(e);
   }
@@ -253,9 +253,9 @@ let tt = class extends HTMLElement {
   }
   _$AE(t) {
     var e;
-    (e = this._$EO) == null || e.forEach((s) => {
-      var i;
-      return (i = s.hostUpdated) == null ? void 0 : i.call(s);
+    (e = this._$EO) == null || e.forEach((i) => {
+      var s;
+      return (s = i.hostUpdated) == null ? void 0 : s.call(i);
     }), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
   }
   _$EM() {
@@ -278,76 +278,76 @@ let tt = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-tt.elementStyles = [], tt.shadowRootOptions = { mode: "open" }, tt[dt("elementProperties")] = /* @__PURE__ */ new Map(), tt[dt("finalized")] = /* @__PURE__ */ new Map(), Ut == null || Ut({ ReactiveElement: tt }), (G.reactiveElementVersions ?? (G.reactiveElementVersions = [])).push("2.1.2");
+et.elementStyles = [], et.shadowRootOptions = { mode: "open" }, et[ut("elementProperties")] = /* @__PURE__ */ new Map(), et[ut("finalized")] = /* @__PURE__ */ new Map(), zt == null || zt({ ReactiveElement: et }), (G.reactiveElementVersions ?? (G.reactiveElementVersions = [])).push("2.1.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const ht = globalThis, ye = (n) => n, kt = ht.trustedTypes, we = kt ? kt.createPolicy("lit-html", { createHTML: (n) => n }) : void 0, Te = "$lit$", j = `lit$${Math.random().toFixed(9).slice(2)}$`, Me = "?" + j, ci = `<${Me}>`, Z = document, ft = () => Z.createComment(""), gt = (n) => n === null || typeof n != "object" && typeof n != "function", te = Array.isArray, li = (n) => te(n) || typeof (n == null ? void 0 : n[Symbol.iterator]) == "function", Ot = `[ 	
-\f\r]`, lt = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ve = /-->/g, be = />/g, J = RegExp(`>|${Ot}(?:([^\\s"'>=/]+)(${Ot}*=${Ot}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), Ee = /'/g, Ce = /"/g, Ie = /^(?:script|style|textarea|title)$/i, di = (n) => (t, ...e) => ({ _$litType$: n, strings: t, values: e }), b = di(1), et = Symbol.for("lit-noChange"), $ = Symbol.for("lit-nothing"), Ae = /* @__PURE__ */ new WeakMap(), Y = Z.createTreeWalker(Z, 129);
-function xe(n, t) {
-  if (!te(n) || !n.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return we !== void 0 ? we.createHTML(t) : t;
+const ft = globalThis, $e = (n) => n, Tt = ft.trustedTypes, Ae = Tt ? Tt.createPolicy("lit-html", { createHTML: (n) => n }) : void 0, Be = "$lit$", j = `lit$${Math.random().toFixed(9).slice(2)}$`, Re = "?" + j, fs = `<${Re}>`, Z = document, pt = () => Z.createComment(""), mt = (n) => n === null || typeof n != "object" && typeof n != "function", ie = Array.isArray, gs = (n) => ie(n) || typeof (n == null ? void 0 : n[Symbol.iterator]) == "function", Ft = `[
+\f\r]`, ht = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ke = /-->/g, Se = />/g, J = RegExp(`>|${Ft}(?:([^\\s"'>=/]+)(${Ft}*=${Ft}*(?:[^
+\f\r"'\`<>=]|("|')|))|$)`, "g"), Pe = /'/g, Ne = /"/g, Ue = /^(?:script|style|textarea|title)$/i, ps = (n) => (t, ...e) => ({ _$litType$: n, strings: t, values: e }), b = ps(1), st = Symbol.for("lit-noChange"), A = Symbol.for("lit-nothing"), xe = /* @__PURE__ */ new WeakMap(), Y = Z.createTreeWalker(Z, 129);
+function Oe(n, t) {
+  if (!ie(n) || !n.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return Ae !== void 0 ? Ae.createHTML(t) : t;
 }
-const hi = (n, t) => {
-  const e = n.length - 1, s = [];
-  let i, r = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = lt;
+const ms = (n, t) => {
+  const e = n.length - 1, i = [];
+  let s, r = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = ht;
   for (let a = 0; a < e; a++) {
     const c = n[a];
     let l, d, h = -1, u = 0;
-    for (; u < c.length && (o.lastIndex = u, d = o.exec(c), d !== null); ) u = o.lastIndex, o === lt ? d[1] === "!--" ? o = ve : d[1] !== void 0 ? o = be : d[2] !== void 0 ? (Ie.test(d[2]) && (i = RegExp("</" + d[2], "g")), o = J) : d[3] !== void 0 && (o = J) : o === J ? d[0] === ">" ? (o = i ?? lt, h = -1) : d[1] === void 0 ? h = -2 : (h = o.lastIndex - d[2].length, l = d[1], o = d[3] === void 0 ? J : d[3] === '"' ? Ce : Ee) : o === Ce || o === Ee ? o = J : o === ve || o === be ? o = lt : (o = J, i = void 0);
+    for (; u < c.length && (o.lastIndex = u, d = o.exec(c), d !== null); ) u = o.lastIndex, o === ht ? d[1] === "!--" ? o = ke : d[1] !== void 0 ? o = Se : d[2] !== void 0 ? (Ue.test(d[2]) && (s = RegExp("</" + d[2], "g")), o = J) : d[3] !== void 0 && (o = J) : o === J ? d[0] === ">" ? (o = s ?? ht, h = -1) : d[1] === void 0 ? h = -2 : (h = o.lastIndex - d[2].length, l = d[1], o = d[3] === void 0 ? J : d[3] === '"' ? Ne : Pe) : o === Ne || o === Pe ? o = J : o === ke || o === Se ? o = ht : (o = J, s = void 0);
     const f = o === J && n[a + 1].startsWith("/>") ? " " : "";
-    r += o === lt ? c + ci : h >= 0 ? (s.push(l), c.slice(0, h) + Te + c.slice(h) + j + f) : c + j + (h === -2 ? a : f);
+    r += o === ht ? c + fs : h >= 0 ? (i.push(l), c.slice(0, h) + Be + c.slice(h) + j + f) : c + j + (h === -2 ? a : f);
   }
-  return [xe(n, r + (n[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), s];
+  return [Oe(n, r + (n[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), i];
 };
-class pt {
-  constructor({ strings: t, _$litType$: e }, s) {
-    let i;
+class _t {
+  constructor({ strings: t, _$litType$: e }, i) {
+    let s;
     this.parts = [];
     let r = 0, o = 0;
-    const a = t.length - 1, c = this.parts, [l, d] = hi(t, e);
-    if (this.el = pt.createElement(l, s), Y.currentNode = this.el.content, e === 2 || e === 3) {
+    const a = t.length - 1, c = this.parts, [l, d] = ms(t, e);
+    if (this.el = _t.createElement(l, i), Y.currentNode = this.el.content, e === 2 || e === 3) {
       const h = this.el.content.firstChild;
       h.replaceWith(...h.childNodes);
     }
-    for (; (i = Y.nextNode()) !== null && c.length < a; ) {
-      if (i.nodeType === 1) {
-        if (i.hasAttributes()) for (const h of i.getAttributeNames()) if (h.endsWith(Te)) {
-          const u = d[o++], f = i.getAttribute(h).split(j), g = /([.?@])?(.*)/.exec(u);
-          c.push({ type: 1, index: r, name: g[2], strings: f, ctor: g[1] === "." ? fi : g[1] === "?" ? gi : g[1] === "@" ? pi : Tt }), i.removeAttribute(h);
-        } else h.startsWith(j) && (c.push({ type: 6, index: r }), i.removeAttribute(h));
-        if (Ie.test(i.tagName)) {
-          const h = i.textContent.split(j), u = h.length - 1;
+    for (; (s = Y.nextNode()) !== null && c.length < a; ) {
+      if (s.nodeType === 1) {
+        if (s.hasAttributes()) for (const h of s.getAttributeNames()) if (h.endsWith(Be)) {
+          const u = d[o++], f = s.getAttribute(h).split(j), g = /([.?@])?(.*)/.exec(u);
+          c.push({ type: 1, index: r, name: g[2], strings: f, ctor: g[1] === "." ? ys : g[1] === "?" ? ws : g[1] === "@" ? vs : Lt }), s.removeAttribute(h);
+        } else h.startsWith(j) && (c.push({ type: 6, index: r }), s.removeAttribute(h));
+        if (Ue.test(s.tagName)) {
+          const h = s.textContent.split(j), u = h.length - 1;
           if (u > 0) {
-            i.textContent = kt ? kt.emptyScript : "";
-            for (let f = 0; f < u; f++) i.append(h[f], ft()), Y.nextNode(), c.push({ type: 2, index: ++r });
-            i.append(h[u], ft());
+            s.textContent = Tt ? Tt.emptyScript : "";
+            for (let f = 0; f < u; f++) s.append(h[f], pt()), Y.nextNode(), c.push({ type: 2, index: ++r });
+            s.append(h[u], pt());
           }
         }
-      } else if (i.nodeType === 8) if (i.data === Me) c.push({ type: 2, index: r });
+      } else if (s.nodeType === 8) if (s.data === Re) c.push({ type: 2, index: r });
       else {
         let h = -1;
-        for (; (h = i.data.indexOf(j, h + 1)) !== -1; ) c.push({ type: 7, index: r }), h += j.length - 1;
+        for (; (h = s.data.indexOf(j, h + 1)) !== -1; ) c.push({ type: 7, index: r }), h += j.length - 1;
       }
       r++;
     }
   }
   static createElement(t, e) {
-    const s = Z.createElement("template");
-    return s.innerHTML = t, s;
+    const i = Z.createElement("template");
+    return i.innerHTML = t, i;
   }
 }
-function it(n, t, e = n, s) {
+function it(n, t, e = n, i) {
   var o, a;
-  if (t === et) return t;
-  let i = s !== void 0 ? (o = e._$Co) == null ? void 0 : o[s] : e._$Cl;
-  const r = gt(t) ? void 0 : t._$litDirective$;
-  return (i == null ? void 0 : i.constructor) !== r && ((a = i == null ? void 0 : i._$AO) == null || a.call(i, !1), r === void 0 ? i = void 0 : (i = new r(n), i._$AT(n, e, s)), s !== void 0 ? (e._$Co ?? (e._$Co = []))[s] = i : e._$Cl = i), i !== void 0 && (t = it(n, i._$AS(n, t.values), i, s)), t;
+  if (t === st) return t;
+  let s = i !== void 0 ? (o = e._$Co) == null ? void 0 : o[i] : e._$Cl;
+  const r = mt(t) ? void 0 : t._$litDirective$;
+  return (s == null ? void 0 : s.constructor) !== r && ((a = s == null ? void 0 : s._$AO) == null || a.call(s, !1), r === void 0 ? s = void 0 : (s = new r(n), s._$AT(n, e, i)), i !== void 0 ? (e._$Co ?? (e._$Co = []))[i] = s : e._$Cl = s), s !== void 0 && (t = it(n, s._$AS(n, t.values), s, i)), t;
 }
-class ui {
+class _s {
   constructor(t, e) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
   }
@@ -358,30 +358,30 @@ class ui {
     return this._$AM._$AU;
   }
   u(t) {
-    const { el: { content: e }, parts: s } = this._$AD, i = ((t == null ? void 0 : t.creationScope) ?? Z).importNode(e, !0);
-    Y.currentNode = i;
-    let r = Y.nextNode(), o = 0, a = 0, c = s[0];
+    const { el: { content: e }, parts: i } = this._$AD, s = ((t == null ? void 0 : t.creationScope) ?? Z).importNode(e, !0);
+    Y.currentNode = s;
+    let r = Y.nextNode(), o = 0, a = 0, c = i[0];
     for (; c !== void 0; ) {
       if (o === c.index) {
         let l;
-        c.type === 2 ? l = new vt(r, r.nextSibling, this, t) : c.type === 1 ? l = new c.ctor(r, c.name, c.strings, this, t) : c.type === 6 && (l = new mi(r, this, t)), this._$AV.push(l), c = s[++a];
+        c.type === 2 ? l = new Ct(r, r.nextSibling, this, t) : c.type === 1 ? l = new c.ctor(r, c.name, c.strings, this, t) : c.type === 6 && (l = new bs(r, this, t)), this._$AV.push(l), c = i[++a];
       }
       o !== (c == null ? void 0 : c.index) && (r = Y.nextNode(), o++);
     }
-    return Y.currentNode = Z, i;
+    return Y.currentNode = Z, s;
   }
   p(t) {
     let e = 0;
-    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(t, s, e), e += s.strings.length - 2) : s._$AI(t[e])), e++;
+    for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(t, i, e), e += i.strings.length - 2) : i._$AI(t[e])), e++;
   }
 }
-class vt {
+class Ct {
   get _$AU() {
     var t;
     return ((t = this._$AM) == null ? void 0 : t._$AU) ?? this._$Cv;
   }
-  constructor(t, e, s, i) {
-    this.type = 2, this._$AH = $, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = s, this.options = i, this._$Cv = (i == null ? void 0 : i.isConnected) ?? !0;
+  constructor(t, e, i, s) {
+    this.type = 2, this._$AH = A, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = i, this.options = s, this._$Cv = (s == null ? void 0 : s.isConnected) ?? !0;
   }
   get parentNode() {
     let t = this._$AA.parentNode;
@@ -395,7 +395,7 @@ class vt {
     return this._$AB;
   }
   _$AI(t, e = this) {
-    t = it(this, t, e), gt(t) ? t === $ || t == null || t === "" ? (this._$AH !== $ && this._$AR(), this._$AH = $) : t !== this._$AH && t !== et && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : li(t) ? this.k(t) : this._(t);
+    t = it(this, t, e), mt(t) ? t === A || t == null || t === "" ? (this._$AH !== A && this._$AR(), this._$AH = A) : t !== this._$AH && t !== st && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : gs(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -404,33 +404,33 @@ class vt {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== $ && gt(this._$AH) ? this._$AA.nextSibling.data = t : this.T(Z.createTextNode(t)), this._$AH = t;
+    this._$AH !== A && mt(this._$AH) ? this._$AA.nextSibling.data = t : this.T(Z.createTextNode(t)), this._$AH = t;
   }
   $(t) {
     var r;
-    const { values: e, _$litType$: s } = t, i = typeof s == "number" ? this._$AC(t) : (s.el === void 0 && (s.el = pt.createElement(xe(s.h, s.h[0]), this.options)), s);
-    if (((r = this._$AH) == null ? void 0 : r._$AD) === i) this._$AH.p(e);
+    const { values: e, _$litType$: i } = t, s = typeof i == "number" ? this._$AC(t) : (i.el === void 0 && (i.el = _t.createElement(Oe(i.h, i.h[0]), this.options)), i);
+    if (((r = this._$AH) == null ? void 0 : r._$AD) === s) this._$AH.p(e);
     else {
-      const o = new ui(i, this), a = o.u(this.options);
+      const o = new _s(s, this), a = o.u(this.options);
       o.p(e), this.T(a), this._$AH = o;
     }
   }
   _$AC(t) {
-    let e = Ae.get(t.strings);
-    return e === void 0 && Ae.set(t.strings, e = new pt(t)), e;
+    let e = xe.get(t.strings);
+    return e === void 0 && xe.set(t.strings, e = new _t(t)), e;
   }
   k(t) {
-    te(this._$AH) || (this._$AH = [], this._$AR());
+    ie(this._$AH) || (this._$AH = [], this._$AR());
     const e = this._$AH;
-    let s, i = 0;
-    for (const r of t) i === e.length ? e.push(s = new vt(this.O(ft()), this.O(ft()), this, this.options)) : s = e[i], s._$AI(r), i++;
-    i < e.length && (this._$AR(s && s._$AB.nextSibling, i), e.length = i);
+    let i, s = 0;
+    for (const r of t) s === e.length ? e.push(i = new Ct(this.O(pt()), this.O(pt()), this, this.options)) : i = e[s], i._$AI(r), s++;
+    s < e.length && (this._$AR(i && i._$AB.nextSibling, s), e.length = s);
   }
   _$AR(t = this._$AA.nextSibling, e) {
-    var s;
-    for ((s = this._$AP) == null ? void 0 : s.call(this, !1, !0, e); t !== this._$AB; ) {
-      const i = ye(t).nextSibling;
-      ye(t).remove(), t = i;
+    var i;
+    for ((i = this._$AP) == null ? void 0 : i.call(this, !1, !0, e); t !== this._$AB; ) {
+      const s = $e(t).nextSibling;
+      $e(t).remove(), t = s;
     }
   }
   setConnected(t) {
@@ -438,64 +438,64 @@ class vt {
     this._$AM === void 0 && (this._$Cv = t, (e = this._$AP) == null || e.call(this, t));
   }
 }
-class Tt {
+class Lt {
   get tagName() {
     return this.element.tagName;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(t, e, s, i, r) {
-    this.type = 1, this._$AH = $, this._$AN = void 0, this.element = t, this.name = e, this._$AM = i, this.options = r, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = $;
+  constructor(t, e, i, s, r) {
+    this.type = 1, this._$AH = A, this._$AN = void 0, this.element = t, this.name = e, this._$AM = s, this.options = r, i.length > 2 || i[0] !== "" || i[1] !== "" ? (this._$AH = Array(i.length - 1).fill(new String()), this.strings = i) : this._$AH = A;
   }
-  _$AI(t, e = this, s, i) {
+  _$AI(t, e = this, i, s) {
     const r = this.strings;
     let o = !1;
-    if (r === void 0) t = it(this, t, e, 0), o = !gt(t) || t !== this._$AH && t !== et, o && (this._$AH = t);
+    if (r === void 0) t = it(this, t, e, 0), o = !mt(t) || t !== this._$AH && t !== st, o && (this._$AH = t);
     else {
       const a = t;
       let c, l;
-      for (t = r[0], c = 0; c < r.length - 1; c++) l = it(this, a[s + c], e, c), l === et && (l = this._$AH[c]), o || (o = !gt(l) || l !== this._$AH[c]), l === $ ? t = $ : t !== $ && (t += (l ?? "") + r[c + 1]), this._$AH[c] = l;
+      for (t = r[0], c = 0; c < r.length - 1; c++) l = it(this, a[i + c], e, c), l === st && (l = this._$AH[c]), o || (o = !mt(l) || l !== this._$AH[c]), l === A ? t = A : t !== A && (t += (l ?? "") + r[c + 1]), this._$AH[c] = l;
     }
-    o && !i && this.j(t);
+    o && !s && this.j(t);
   }
   j(t) {
-    t === $ ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+    t === A ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class fi extends Tt {
+class ys extends Lt {
   constructor() {
     super(...arguments), this.type = 3;
   }
   j(t) {
-    this.element[this.name] = t === $ ? void 0 : t;
+    this.element[this.name] = t === A ? void 0 : t;
   }
 }
-class gi extends Tt {
+class ws extends Lt {
   constructor() {
     super(...arguments), this.type = 4;
   }
   j(t) {
-    this.element.toggleAttribute(this.name, !!t && t !== $);
+    this.element.toggleAttribute(this.name, !!t && t !== A);
   }
 }
-class pi extends Tt {
-  constructor(t, e, s, i, r) {
-    super(t, e, s, i, r), this.type = 5;
+class vs extends Lt {
+  constructor(t, e, i, s, r) {
+    super(t, e, i, s, r), this.type = 5;
   }
   _$AI(t, e = this) {
-    if ((t = it(this, t, e, 0) ?? $) === et) return;
-    const s = this._$AH, i = t === $ && s !== $ || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive, r = t !== $ && (s === $ || i);
-    i && this.element.removeEventListener(this.name, this, s), r && this.element.addEventListener(this.name, this, t), this._$AH = t;
+    if ((t = it(this, t, e, 0) ?? A) === st) return;
+    const i = this._$AH, s = t === A && i !== A || t.capture !== i.capture || t.once !== i.once || t.passive !== i.passive, r = t !== A && (i === A || s);
+    s && this.element.removeEventListener(this.name, this, i), r && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
   handleEvent(t) {
     var e;
     typeof this._$AH == "function" ? this._$AH.call(((e = this.options) == null ? void 0 : e.host) ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class mi {
-  constructor(t, e, s) {
-    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = s;
+class bs {
+  constructor(t, e, i) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = i;
   }
   get _$AU() {
     return this._$AM._$AU;
@@ -504,16 +504,16 @@ class mi {
     it(this, t);
   }
 }
-const Ht = ht.litHtmlPolyfillSupport;
-Ht == null || Ht(pt, vt), (ht.litHtmlVersions ?? (ht.litHtmlVersions = [])).push("3.3.2");
-const _i = (n, t, e) => {
-  const s = (e == null ? void 0 : e.renderBefore) ?? t;
-  let i = s._$litPart$;
-  if (i === void 0) {
+const Vt = ft.litHtmlPolyfillSupport;
+Vt == null || Vt(_t, Ct), (ft.litHtmlVersions ?? (ft.litHtmlVersions = [])).push("3.3.2");
+const Es = (n, t, e) => {
+  const i = (e == null ? void 0 : e.renderBefore) ?? t;
+  let s = i._$litPart$;
+  if (s === void 0) {
     const r = (e == null ? void 0 : e.renderBefore) ?? null;
-    s._$litPart$ = i = new vt(t.insertBefore(ft(), r), r, void 0, e ?? {});
+    i._$litPart$ = s = new Ct(t.insertBefore(pt(), r), r, void 0, e ?? {});
   }
-  return i._$AI(n), i;
+  return s._$AI(n), s;
 };
 /**
  * @license
@@ -521,7 +521,7 @@ const _i = (n, t, e) => {
  * SPDX-License-Identifier: BSD-3-Clause
  */
 const Q = globalThis;
-class M extends tt {
+class P extends et {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -532,7 +532,7 @@ class M extends tt {
   }
   update(t) {
     const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = _i(e, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Es(e, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     var t;
@@ -543,23 +543,23 @@ class M extends tt {
     super.disconnectedCallback(), (t = this._$Do) == null || t.setConnected(!1);
   }
   render() {
-    return et;
+    return st;
   }
 }
-var Pe;
-M._$litElement$ = !0, M.finalized = !0, (Pe = Q.litElementHydrateSupport) == null || Pe.call(Q, { LitElement: M });
-const Ft = Q.litElementPolyfillSupport;
-Ft == null || Ft({ LitElement: M });
+var De;
+P._$litElement$ = !0, P.finalized = !0, (De = Q.litElementHydrateSupport) == null || De.call(Q, { LitElement: P });
+const jt = Q.litElementPolyfillSupport;
+jt == null || jt({ LitElement: P });
 (Q.litElementVersions ?? (Q.litElementVersions = [])).push("4.2.2");
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const yi = { attribute: !0, type: String, converter: St, reflect: !1, hasChanged: Xt }, wi = (n = yi, t, e) => {
-  const { kind: s, metadata: i } = e;
-  let r = globalThis.litPropertyMetadata.get(i);
-  if (r === void 0 && globalThis.litPropertyMetadata.set(i, r = /* @__PURE__ */ new Map()), s === "setter" && ((n = Object.create(n)).wrapped = !0), r.set(e.name, n), s === "accessor") {
+const Cs = { attribute: !0, type: String, converter: Mt, reflect: !1, hasChanged: se }, $s = (n = Cs, t, e) => {
+  const { kind: i, metadata: s } = e;
+  let r = globalThis.litPropertyMetadata.get(s);
+  if (r === void 0 && globalThis.litPropertyMetadata.set(s, r = /* @__PURE__ */ new Map()), i === "setter" && ((n = Object.create(n)).wrapped = !0), r.set(e.name, n), i === "accessor") {
     const { name: o } = e;
     return { set(a) {
       const c = t.get.call(this);
@@ -568,19 +568,19 @@ const yi = { attribute: !0, type: String, converter: St, reflect: !1, hasChanged
       return a !== void 0 && this.C(o, void 0, n, a), a;
     } };
   }
-  if (s === "setter") {
+  if (i === "setter") {
     const { name: o } = e;
     return function(a) {
       const c = this[o];
       t.call(this, a), this.requestUpdate(o, c, n, !0, a);
     };
   }
-  throw Error("Unsupported decorator location: " + s);
+  throw Error("Unsupported decorator location: " + i);
 };
-function z(n) {
-  return (t, e) => typeof e == "object" ? wi(n, t, e) : ((s, i, r) => {
-    const o = i.hasOwnProperty(r);
-    return i.constructor.createProperty(r, s), o ? Object.getOwnPropertyDescriptor(i, r) : void 0;
+function L(n) {
+  return (t, e) => typeof e == "object" ? $s(n, t, e) : ((i, s, r) => {
+    const o = s.hasOwnProperty(r);
+    return s.constructor.createProperty(r, i), o ? Object.getOwnPropertyDescriptor(s, r) : void 0;
   })(n, t, e);
 }
 /**
@@ -588,10 +588,10 @@ function z(n) {
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-function v(n) {
-  return z({ ...n, state: !0, attribute: !1 });
+function y(n) {
+  return L({ ...n, state: !0, attribute: !1 });
 }
-const De = (n, t, e) => b`
+const ne = (n, t, e) => b`
   <ha-card class="status-card warning">
     <div class="card-content flex-col align-center p-8">
       <ha-icon icon="mdi:alert-circle" style="--mdc-icon-size: 48px; margin-bottom: 16px;"></ha-icon>
@@ -600,7 +600,7 @@ const De = (n, t, e) => b`
     </div>
     ${b`<div class="version">v${e}</div>`}
   </ha-card>
-`, Mt = (n, t, e) => b`
+`, $t = (n, t, e) => b`
   <ha-card class="status-card loading">
     <div class="card-content flex-col align-center p-8">
       <h1 class="status-title">${n}</h1>
@@ -609,7 +609,7 @@ const De = (n, t, e) => b`
     </div>
     <div class="version">v${e}</div>
   </ha-card>
-`, It = F`
+`, At = D`
   ha-card.status-card {
     --ha-card-background: var(--warning-color, #ffeb3b);
     background-color: var(--warning-color, #ffeb3b) !important;
@@ -710,8 +710,8 @@ const De = (n, t, e) => b`
     gap: 12px;
   }
 `;
-var Be = /* @__PURE__ */ ((n) => (n.GET_CONFIG = "meraki_ha/get_config", n.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", n.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", n.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", n.GET_VERSION = "meraki_ha/get_version", n.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", n.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", n.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", n.GET_GUEST_KEYS = "meraki_ha/ipsk/get", n.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", n.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", n))(Be || {});
-const vi = async (n, t) => {
+var He = /* @__PURE__ */ ((n) => (n.GET_CONFIG = "meraki_ha/get_config", n.SUBSCRIBE_MERAKI_DATA = "meraki_ha/subscribe_meraki_data", n.GET_CAMERA_STREAM_URL = "meraki_ha/get_camera_stream_url", n.GET_CAMERA_SNAPSHOT = "meraki_ha/get_camera_snapshot", n.GET_VERSION = "meraki_ha/get_version", n.GET_NETWORK_EVENTS = "meraki_ha/get_network_events", n.UPDATE_ENABLED_NETWORKS = "meraki_ha/update_enabled_networks", n.CREATE_GUEST_KEY = "meraki_ha/ipsk/create", n.GET_GUEST_KEYS = "meraki_ha/ipsk/get", n.REVOKE_GUEST_KEY = "meraki_ha/ipsk/revoke", n.TIMED_ACCESS_GET_POLICIES = "meraki_ha/timed_access/get_policies", n))(He || {});
+const As = async (n, t) => {
   if (!n)
     throw new Error("Home Assistant object is not available.");
   try {
@@ -724,7 +724,7 @@ const vi = async (n, t) => {
     throw console.error(`Cisco Meraki HA: WebSocket error [${t.type}]:`, e), e;
   }
 };
-class L {
+class R {
   /**
    * Fetches wireless networks, SSIDs, and group policies directly from the integration's backend cache.
    */
@@ -733,19 +733,19 @@ class L {
       const e = await t.callWS({
         type: "config_entries/get",
         domain: "meraki_ha"
-      }), s = e.length > 0 ? e[0].entry_id : null;
-      if (!s)
+      }), i = e.length > 0 ? e[0].entry_id : null;
+      if (!i)
         return { networks: [], ssids: [], groupPolicies: [], entryId: null };
-      const i = await vi(t, {
-        type: Be.GET_CONFIG,
-        config_entry_id: s
-      }), r = (Array.isArray(i.networks) ? i.networks : []).filter((c) => {
+      const s = await As(t, {
+        type: He.GET_CONFIG,
+        config_entry_id: i
+      }), r = (Array.isArray(s.networks) ? s.networks : []).filter((c) => {
         var l;
         return (l = c.productTypes) == null ? void 0 : l.includes("wireless");
-      }), o = Array.isArray(i.ssids) ? i.ssids : [], a = [];
-      if (i.group_policies && typeof i.group_policies == "object")
+      }), o = Array.isArray(s.ssids) ? s.ssids : [], a = [];
+      if (s.group_policies && typeof s.group_policies == "object")
         for (const [c, l] of Object.entries(
-          i.group_policies
+          s.group_policies
         ))
           Array.isArray(l) && l.forEach((d) => {
             a.push({
@@ -754,7 +754,7 @@ class L {
               name: d.name
             });
           });
-      return { networks: r, ssids: o, groupPolicies: a, entryId: s };
+      return { networks: r, ssids: o, groupPolicies: a, entryId: i };
     } catch (e) {
       return console.error("Failed to fetch Meraki data via WS:", e), { networks: [], ssids: [], groupPolicies: [], entryId: null };
     }
@@ -766,23 +766,23 @@ class L {
    * @param maxRetries Maximum number of polling attempts (default: 12 attempts / ~1 minute)
    * @param delayMs Delay between attempts in milliseconds (default: 5000ms)
    */
-  static async pollConfig(t, e, s = 12, i = 5e3) {
-    for (let r = 0; r < s; r++) {
+  static async pollConfig(t, e, i = 12, s = 5e3) {
+    for (let r = 0; r < i; r++) {
       try {
         const o = await this.fetchConfig(t);
         if (o.networks.length > 0)
           return e("", !1), o;
         e(
-          `Waiting for integration to sync... (Attempt ${r + 1}/${s})`,
+          `Waiting for integration to sync... (Attempt ${r + 1}/${i})`,
           !0
         );
       } catch {
         e(
-          `Error connecting to backend. Retrying... (Attempt ${r + 1}/${s})`,
+          `Error connecting to backend. Retrying... (Attempt ${r + 1}/${i})`,
           !0
         );
       }
-      await new Promise((o) => setTimeout(o, i));
+      await new Promise((o) => setTimeout(o, s));
     }
     return e(
       "Integration failed to initialize after 1 minute. Please check backend logs.",
@@ -793,16 +793,16 @@ class L {
    * Formats networks for an ha-form dropdown.
    */
   static getNetworkOptions(t, e = !1) {
-    const s = t.map((i) => ({ value: i.id, label: i.name }));
-    return e ? [{ value: "", label: "All Networks" }, ...s] : s;
+    const i = t.map((s) => ({ value: s.id, label: s.name }));
+    return e ? [{ value: "", label: "All Networks" }, ...i] : i;
   }
   /**
    * Formats SSIDs for an ha-form dropdown.
    * @param valueType Determines if the dropdown returns the SSID's string name (for QR codes) or integer number (for Guest API calls).
    */
-  static getSsidOptions(t, e, s = "name") {
+  static getSsidOptions(t, e, i = "name") {
     return (e ? t.filter((r) => r.networkId === e) : t).map((r) => ({
-      value: s === "number" ? String(r.number) : r.name,
+      value: i === "number" ? String(r.number) : r.name,
       label: `${r.name} (SSID ${r.number})`
     }));
   }
@@ -810,22 +810,22 @@ class L {
    * Formats Group Policies for an ha-form dropdown.
    */
   static getGroupPolicyOptions(t, e) {
-    const i = (e ? t.filter((r) => r.networkId === e) : t).map((r) => ({
+    const s = (e ? t.filter((r) => r.networkId === e) : t).map((r) => ({
       value: r.groupPolicyId,
       label: r.name
     }));
     return [
       { value: "CREATE", label: "Create 'Home Assistant Guest' Policy" },
       { value: "NONE", label: "None (Network Default)" },
-      ...i
+      ...s
     ];
   }
 }
-var bt = {}, bi = function() {
+var kt = {}, ks = function() {
   return typeof Promise == "function" && Promise.prototype && Promise.prototype.then;
-}, Re = {}, P = {};
-let ee;
-const Ei = [
+}, ze = {}, N = {};
+let re;
+const Ss = [
   0,
   // Not used
   26,
@@ -869,32 +869,32 @@ const Ei = [
   3532,
   3706
 ];
-P.getSymbolSize = function(t) {
+N.getSymbolSize = function(t) {
   if (!t) throw new Error('"version" cannot be null or undefined');
   if (t < 1 || t > 40) throw new Error('"version" should be in range from 1 to 40');
   return t * 4 + 17;
 };
-P.getSymbolTotalCodewords = function(t) {
-  return Ei[t];
+N.getSymbolTotalCodewords = function(t) {
+  return Ss[t];
 };
-P.getBCHDigit = function(n) {
+N.getBCHDigit = function(n) {
   let t = 0;
   for (; n !== 0; )
     t++, n >>>= 1;
   return t;
 };
-P.setToSJISFunction = function(t) {
+N.setToSJISFunction = function(t) {
   if (typeof t != "function")
     throw new Error('"toSJISFunc" is not a valid function.');
-  ee = t;
+  re = t;
 };
-P.isKanjiModeEnabled = function() {
-  return typeof ee < "u";
+N.isKanjiModeEnabled = function() {
+  return typeof re < "u";
 };
-P.toSJIS = function(t) {
-  return ee(t);
+N.toSJIS = function(t) {
+  return re(t);
 };
-var xt = {};
+var Bt = {};
 (function(n) {
   n.L = { bit: 1 }, n.M = { bit: 0 }, n.Q = { bit: 3 }, n.H = { bit: 2 };
   function t(e) {
@@ -917,22 +917,22 @@ var xt = {};
         throw new Error("Unknown EC Level: " + e);
     }
   }
-  n.isValid = function(s) {
-    return s && typeof s.bit < "u" && s.bit >= 0 && s.bit < 4;
-  }, n.from = function(s, i) {
-    if (n.isValid(s))
-      return s;
-    try {
-      return t(s);
-    } catch {
+  n.isValid = function(i) {
+    return i && typeof i.bit < "u" && i.bit >= 0 && i.bit < 4;
+  }, n.from = function(i, s) {
+    if (n.isValid(i))
       return i;
+    try {
+      return t(i);
+    } catch {
+      return s;
     }
   };
-})(xt);
-function Le() {
+})(Bt);
+function Fe() {
   this.buffer = [], this.length = 0;
 }
-Le.prototype = {
+Fe.prototype = {
   get: function(n) {
     const t = Math.floor(n / 8);
     return (this.buffer[t] >>> 7 - n % 8 & 1) === 1;
@@ -949,58 +949,58 @@ Le.prototype = {
     this.buffer.length <= t && this.buffer.push(0), n && (this.buffer[t] |= 128 >>> this.length % 8), this.length++;
   }
 };
-var Ci = Le;
-function Et(n) {
+var Ps = Fe;
+function St(n) {
   if (!n || n < 1)
     throw new Error("BitMatrix size must be defined and greater than 0");
   this.size = n, this.data = new Uint8Array(n * n), this.reservedBit = new Uint8Array(n * n);
 }
-Et.prototype.set = function(n, t, e, s) {
-  const i = n * this.size + t;
-  this.data[i] = e, s && (this.reservedBit[i] = !0);
+St.prototype.set = function(n, t, e, i) {
+  const s = n * this.size + t;
+  this.data[s] = e, i && (this.reservedBit[s] = !0);
 };
-Et.prototype.get = function(n, t) {
+St.prototype.get = function(n, t) {
   return this.data[n * this.size + t];
 };
-Et.prototype.xor = function(n, t, e) {
+St.prototype.xor = function(n, t, e) {
   this.data[n * this.size + t] ^= e;
 };
-Et.prototype.isReserved = function(n, t) {
+St.prototype.isReserved = function(n, t) {
   return this.reservedBit[n * this.size + t];
 };
-var Ai = Et, Ue = {};
+var Ns = St, Ve = {};
 (function(n) {
-  const t = P.getSymbolSize;
-  n.getRowColCoords = function(s) {
-    if (s === 1) return [];
-    const i = Math.floor(s / 7) + 2, r = t(s), o = r === 145 ? 26 : Math.ceil((r - 13) / (2 * i - 2)) * 2, a = [r - 7];
-    for (let c = 1; c < i - 1; c++)
+  const t = N.getSymbolSize;
+  n.getRowColCoords = function(i) {
+    if (i === 1) return [];
+    const s = Math.floor(i / 7) + 2, r = t(i), o = r === 145 ? 26 : Math.ceil((r - 13) / (2 * s - 2)) * 2, a = [r - 7];
+    for (let c = 1; c < s - 1; c++)
       a[c] = a[c - 1] - o;
     return a.push(6), a.reverse();
-  }, n.getPositions = function(s) {
-    const i = [], r = n.getRowColCoords(s), o = r.length;
+  }, n.getPositions = function(i) {
+    const s = [], r = n.getRowColCoords(i), o = r.length;
     for (let a = 0; a < o; a++)
       for (let c = 0; c < o; c++)
         a === 0 && c === 0 || // top-left
         a === 0 && c === o - 1 || // bottom-left
-        a === o - 1 && c === 0 || i.push([r[a], r[c]]);
-    return i;
+        a === o - 1 && c === 0 || s.push([r[a], r[c]]);
+    return s;
   };
-})(Ue);
-var Oe = {};
-const $i = P.getSymbolSize, $e = 7;
-Oe.getPositions = function(t) {
-  const e = $i(t);
+})(Ve);
+var je = {};
+const xs = N.getSymbolSize, Me = 7;
+je.getPositions = function(t) {
+  const e = xs(t);
   return [
     // top-left
     [0, 0],
     // top-right
-    [e - $e, 0],
+    [e - Me, 0],
     // bottom-left
-    [0, e - $e]
+    [0, e - Me]
   ];
 };
-var He = {};
+var qe = {};
 (function(n) {
   n.Patterns = {
     PATTERN000: 0,
@@ -1018,86 +1018,86 @@ var He = {};
     N3: 40,
     N4: 10
   };
-  n.isValid = function(i) {
-    return i != null && i !== "" && !isNaN(i) && i >= 0 && i <= 7;
-  }, n.from = function(i) {
-    return n.isValid(i) ? parseInt(i, 10) : void 0;
-  }, n.getPenaltyN1 = function(i) {
-    const r = i.size;
+  n.isValid = function(s) {
+    return s != null && s !== "" && !isNaN(s) && s >= 0 && s <= 7;
+  }, n.from = function(s) {
+    return n.isValid(s) ? parseInt(s, 10) : void 0;
+  }, n.getPenaltyN1 = function(s) {
+    const r = s.size;
     let o = 0, a = 0, c = 0, l = null, d = null;
     for (let h = 0; h < r; h++) {
       a = c = 0, l = d = null;
       for (let u = 0; u < r; u++) {
-        let f = i.get(h, u);
-        f === l ? a++ : (a >= 5 && (o += t.N1 + (a - 5)), l = f, a = 1), f = i.get(u, h), f === d ? c++ : (c >= 5 && (o += t.N1 + (c - 5)), d = f, c = 1);
+        let f = s.get(h, u);
+        f === l ? a++ : (a >= 5 && (o += t.N1 + (a - 5)), l = f, a = 1), f = s.get(u, h), f === d ? c++ : (c >= 5 && (o += t.N1 + (c - 5)), d = f, c = 1);
       }
       a >= 5 && (o += t.N1 + (a - 5)), c >= 5 && (o += t.N1 + (c - 5));
     }
     return o;
-  }, n.getPenaltyN2 = function(i) {
-    const r = i.size;
+  }, n.getPenaltyN2 = function(s) {
+    const r = s.size;
     let o = 0;
     for (let a = 0; a < r - 1; a++)
       for (let c = 0; c < r - 1; c++) {
-        const l = i.get(a, c) + i.get(a, c + 1) + i.get(a + 1, c) + i.get(a + 1, c + 1);
+        const l = s.get(a, c) + s.get(a, c + 1) + s.get(a + 1, c) + s.get(a + 1, c + 1);
         (l === 4 || l === 0) && o++;
       }
     return o * t.N2;
-  }, n.getPenaltyN3 = function(i) {
-    const r = i.size;
+  }, n.getPenaltyN3 = function(s) {
+    const r = s.size;
     let o = 0, a = 0, c = 0;
     for (let l = 0; l < r; l++) {
       a = c = 0;
       for (let d = 0; d < r; d++)
-        a = a << 1 & 2047 | i.get(l, d), d >= 10 && (a === 1488 || a === 93) && o++, c = c << 1 & 2047 | i.get(d, l), d >= 10 && (c === 1488 || c === 93) && o++;
+        a = a << 1 & 2047 | s.get(l, d), d >= 10 && (a === 1488 || a === 93) && o++, c = c << 1 & 2047 | s.get(d, l), d >= 10 && (c === 1488 || c === 93) && o++;
     }
     return o * t.N3;
-  }, n.getPenaltyN4 = function(i) {
+  }, n.getPenaltyN4 = function(s) {
     let r = 0;
-    const o = i.data.length;
-    for (let c = 0; c < o; c++) r += i.data[c];
+    const o = s.data.length;
+    for (let c = 0; c < o; c++) r += s.data[c];
     return Math.abs(Math.ceil(r * 100 / o / 5) - 10) * t.N4;
   };
-  function e(s, i, r) {
-    switch (s) {
+  function e(i, s, r) {
+    switch (i) {
       case n.Patterns.PATTERN000:
-        return (i + r) % 2 === 0;
+        return (s + r) % 2 === 0;
       case n.Patterns.PATTERN001:
-        return i % 2 === 0;
+        return s % 2 === 0;
       case n.Patterns.PATTERN010:
         return r % 3 === 0;
       case n.Patterns.PATTERN011:
-        return (i + r) % 3 === 0;
+        return (s + r) % 3 === 0;
       case n.Patterns.PATTERN100:
-        return (Math.floor(i / 2) + Math.floor(r / 3)) % 2 === 0;
+        return (Math.floor(s / 2) + Math.floor(r / 3)) % 2 === 0;
       case n.Patterns.PATTERN101:
-        return i * r % 2 + i * r % 3 === 0;
+        return s * r % 2 + s * r % 3 === 0;
       case n.Patterns.PATTERN110:
-        return (i * r % 2 + i * r % 3) % 2 === 0;
+        return (s * r % 2 + s * r % 3) % 2 === 0;
       case n.Patterns.PATTERN111:
-        return (i * r % 3 + (i + r) % 2) % 2 === 0;
+        return (s * r % 3 + (s + r) % 2) % 2 === 0;
       default:
-        throw new Error("bad maskPattern:" + s);
+        throw new Error("bad maskPattern:" + i);
     }
   }
-  n.applyMask = function(i, r) {
+  n.applyMask = function(s, r) {
     const o = r.size;
     for (let a = 0; a < o; a++)
       for (let c = 0; c < o; c++)
-        r.isReserved(c, a) || r.xor(c, a, e(i, c, a));
-  }, n.getBestMask = function(i, r) {
+        r.isReserved(c, a) || r.xor(c, a, e(s, c, a));
+  }, n.getBestMask = function(s, r) {
     const o = Object.keys(n.Patterns).length;
     let a = 0, c = 1 / 0;
     for (let l = 0; l < o; l++) {
-      r(l), n.applyMask(l, i);
-      const d = n.getPenaltyN1(i) + n.getPenaltyN2(i) + n.getPenaltyN3(i) + n.getPenaltyN4(i);
-      n.applyMask(l, i), d < c && (c = d, a = l);
+      r(l), n.applyMask(l, s);
+      const d = n.getPenaltyN1(s) + n.getPenaltyN2(s) + n.getPenaltyN3(s) + n.getPenaltyN4(s);
+      n.applyMask(l, s), d < c && (c = d, a = l);
     }
     return a;
   };
-})(He);
-var Dt = {};
-const q = xt, Ct = [
+})(qe);
+var Rt = {};
+const q = Bt, Pt = [
   // L  M  Q  H
   1,
   1,
@@ -1259,7 +1259,7 @@ const q = xt, Ct = [
   49,
   68,
   81
-], At = [
+], Nt = [
   // L  M  Q  H
   7,
   10,
@@ -1422,125 +1422,125 @@ const q = xt, Ct = [
   2040,
   2430
 ];
-Dt.getBlocksCount = function(t, e) {
+Rt.getBlocksCount = function(t, e) {
   switch (e) {
     case q.L:
-      return Ct[(t - 1) * 4 + 0];
+      return Pt[(t - 1) * 4 + 0];
     case q.M:
-      return Ct[(t - 1) * 4 + 1];
+      return Pt[(t - 1) * 4 + 1];
     case q.Q:
-      return Ct[(t - 1) * 4 + 2];
+      return Pt[(t - 1) * 4 + 2];
     case q.H:
-      return Ct[(t - 1) * 4 + 3];
+      return Pt[(t - 1) * 4 + 3];
     default:
       return;
   }
 };
-Dt.getTotalCodewordsCount = function(t, e) {
+Rt.getTotalCodewordsCount = function(t, e) {
   switch (e) {
     case q.L:
-      return At[(t - 1) * 4 + 0];
+      return Nt[(t - 1) * 4 + 0];
     case q.M:
-      return At[(t - 1) * 4 + 1];
+      return Nt[(t - 1) * 4 + 1];
     case q.Q:
-      return At[(t - 1) * 4 + 2];
+      return Nt[(t - 1) * 4 + 2];
     case q.H:
-      return At[(t - 1) * 4 + 3];
+      return Nt[(t - 1) * 4 + 3];
     default:
       return;
   }
 };
-var Fe = {}, Bt = {};
-const ut = new Uint8Array(512), Pt = new Uint8Array(256);
+var Ge = {}, Ut = {};
+const gt = new Uint8Array(512), It = new Uint8Array(256);
 (function() {
   let t = 1;
   for (let e = 0; e < 255; e++)
-    ut[e] = t, Pt[t] = e, t <<= 1, t & 256 && (t ^= 285);
+    gt[e] = t, It[t] = e, t <<= 1, t & 256 && (t ^= 285);
   for (let e = 255; e < 512; e++)
-    ut[e] = ut[e - 255];
+    gt[e] = gt[e - 255];
 })();
-Bt.log = function(t) {
+Ut.log = function(t) {
   if (t < 1) throw new Error("log(" + t + ")");
-  return Pt[t];
+  return It[t];
 };
-Bt.exp = function(t) {
-  return ut[t];
+Ut.exp = function(t) {
+  return gt[t];
 };
-Bt.mul = function(t, e) {
-  return t === 0 || e === 0 ? 0 : ut[Pt[t] + Pt[e]];
+Ut.mul = function(t, e) {
+  return t === 0 || e === 0 ? 0 : gt[It[t] + It[e]];
 };
 (function(n) {
-  const t = Bt;
-  n.mul = function(s, i) {
-    const r = new Uint8Array(s.length + i.length - 1);
-    for (let o = 0; o < s.length; o++)
-      for (let a = 0; a < i.length; a++)
-        r[o + a] ^= t.mul(s[o], i[a]);
+  const t = Ut;
+  n.mul = function(i, s) {
+    const r = new Uint8Array(i.length + s.length - 1);
+    for (let o = 0; o < i.length; o++)
+      for (let a = 0; a < s.length; a++)
+        r[o + a] ^= t.mul(i[o], s[a]);
     return r;
-  }, n.mod = function(s, i) {
-    let r = new Uint8Array(s);
-    for (; r.length - i.length >= 0; ) {
+  }, n.mod = function(i, s) {
+    let r = new Uint8Array(i);
+    for (; r.length - s.length >= 0; ) {
       const o = r[0];
-      for (let c = 0; c < i.length; c++)
-        r[c] ^= t.mul(i[c], o);
+      for (let c = 0; c < s.length; c++)
+        r[c] ^= t.mul(s[c], o);
       let a = 0;
       for (; a < r.length && r[a] === 0; ) a++;
       r = r.slice(a);
     }
     return r;
-  }, n.generateECPolynomial = function(s) {
-    let i = new Uint8Array([1]);
-    for (let r = 0; r < s; r++)
-      i = n.mul(i, new Uint8Array([1, t.exp(r)]));
-    return i;
+  }, n.generateECPolynomial = function(i) {
+    let s = new Uint8Array([1]);
+    for (let r = 0; r < i; r++)
+      s = n.mul(s, new Uint8Array([1, t.exp(r)]));
+    return s;
   };
-})(Fe);
-const ze = Fe;
-function ie(n) {
+})(Ge);
+const Ke = Ge;
+function oe(n) {
   this.genPoly = void 0, this.degree = n, this.degree && this.initialize(this.degree);
 }
-ie.prototype.initialize = function(t) {
-  this.degree = t, this.genPoly = ze.generateECPolynomial(this.degree);
+oe.prototype.initialize = function(t) {
+  this.degree = t, this.genPoly = Ke.generateECPolynomial(this.degree);
 };
-ie.prototype.encode = function(t) {
+oe.prototype.encode = function(t) {
   if (!this.genPoly)
     throw new Error("Encoder not initialized");
   const e = new Uint8Array(t.length + this.degree);
   e.set(t);
-  const s = ze.mod(e, this.genPoly), i = this.degree - s.length;
-  if (i > 0) {
+  const i = Ke.mod(e, this.genPoly), s = this.degree - i.length;
+  if (s > 0) {
     const r = new Uint8Array(this.degree);
-    return r.set(s, i), r;
+    return r.set(i, s), r;
   }
-  return s;
+  return i;
 };
-var Si = ie, Ve = {}, K = {}, se = {};
-se.isValid = function(t) {
+var Ms = oe, We = {}, K = {}, ae = {};
+ae.isValid = function(t) {
   return !isNaN(t) && t >= 1 && t <= 40;
 };
-var B = {};
-const je = "[0-9]+", ki = "[A-Z $%*+\\-./:]+";
-let mt = "(?:[u3000-u303F]|[u3040-u309F]|[u30A0-u30FF]|[uFF00-uFFEF]|[u4E00-u9FAF]|[u2605-u2606]|[u2190-u2195]|u203B|[u2010u2015u2018u2019u2025u2026u201Cu201Du2225u2260]|[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+";
-mt = mt.replace(/u/g, "\\u");
-const Pi = "(?:(?![A-Z0-9 $%*+\\-./:]|" + mt + `)(?:.|[\r
+var U = {};
+const Je = "[0-9]+", Ts = "[A-Z $%*+\\-./:]+";
+let yt = "(?:[u3000-u303F]|[u3040-u309F]|[u30A0-u30FF]|[uFF00-uFFEF]|[u4E00-u9FAF]|[u2605-u2606]|[u2190-u2195]|u203B|[u2010u2015u2018u2019u2025u2026u201Cu201Du2225u2260]|[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+";
+yt = yt.replace(/u/g, "\\u");
+const Is = "(?:(?![A-Z0-9 $%*+\\-./:]|" + yt + `)(?:.|[\r
 ]))+`;
-B.KANJI = new RegExp(mt, "g");
-B.BYTE_KANJI = new RegExp("[^A-Z0-9 $%*+\\-./:]+", "g");
-B.BYTE = new RegExp(Pi, "g");
-B.NUMERIC = new RegExp(je, "g");
-B.ALPHANUMERIC = new RegExp(ki, "g");
-const Ni = new RegExp("^" + mt + "$"), Ti = new RegExp("^" + je + "$"), Mi = new RegExp("^[A-Z0-9 $%*+\\-./:]+$");
-B.testKanji = function(t) {
-  return Ni.test(t);
+U.KANJI = new RegExp(yt, "g");
+U.BYTE_KANJI = new RegExp("[^A-Z0-9 $%*+\\-./:]+", "g");
+U.BYTE = new RegExp(Is, "g");
+U.NUMERIC = new RegExp(Je, "g");
+U.ALPHANUMERIC = new RegExp(Ts, "g");
+const Ds = new RegExp("^" + yt + "$"), Ls = new RegExp("^" + Je + "$"), Bs = new RegExp("^[A-Z0-9 $%*+\\-./:]+$");
+U.testKanji = function(t) {
+  return Ds.test(t);
 };
-B.testNumeric = function(t) {
-  return Ti.test(t);
+U.testNumeric = function(t) {
+  return Ls.test(t);
 };
-B.testAlphanumeric = function(t) {
-  return Mi.test(t);
+U.testAlphanumeric = function(t) {
+  return Bs.test(t);
 };
 (function(n) {
-  const t = se, e = B;
+  const t = ae, e = U;
   n.NUMERIC = {
     id: "Numeric",
     bit: 1,
@@ -1572,10 +1572,10 @@ B.testAlphanumeric = function(t) {
   }, n.isValid = function(r) {
     return r && r.bit && r.ccBits;
   };
-  function s(i) {
-    if (typeof i != "string")
+  function i(s) {
+    if (typeof s != "string")
       throw new Error("Param is not a string");
-    switch (i.toLowerCase()) {
+    switch (s.toLowerCase()) {
       case "numeric":
         return n.NUMERIC;
       case "alphanumeric":
@@ -1585,73 +1585,73 @@ B.testAlphanumeric = function(t) {
       case "byte":
         return n.BYTE;
       default:
-        throw new Error("Unknown mode: " + i);
+        throw new Error("Unknown mode: " + s);
     }
   }
   n.from = function(r, o) {
     if (n.isValid(r))
       return r;
     try {
-      return s(r);
+      return i(r);
     } catch {
       return o;
     }
   };
 })(K);
 (function(n) {
-  const t = P, e = Dt, s = xt, i = K, r = se, o = 7973, a = t.getBCHDigit(o);
+  const t = N, e = Rt, i = Bt, s = K, r = ae, o = 7973, a = t.getBCHDigit(o);
   function c(u, f, g) {
-    for (let y = 1; y <= 40; y++)
-      if (f <= n.getCapacity(y, g, u))
-        return y;
+    for (let w = 1; w <= 40; w++)
+      if (f <= n.getCapacity(w, g, u))
+        return w;
   }
   function l(u, f) {
-    return i.getCharCountIndicator(u, f) + 4;
+    return s.getCharCountIndicator(u, f) + 4;
   }
   function d(u, f) {
     let g = 0;
-    return u.forEach(function(y) {
-      const S = l(y.mode, f);
-      g += S + y.getBitsLength();
+    return u.forEach(function(w) {
+      const k = l(w.mode, f);
+      g += k + w.getBitsLength();
     }), g;
   }
   function h(u, f) {
     for (let g = 1; g <= 40; g++)
-      if (d(u, g) <= n.getCapacity(g, f, i.MIXED))
+      if (d(u, g) <= n.getCapacity(g, f, s.MIXED))
         return g;
   }
   n.from = function(f, g) {
     return r.isValid(f) ? parseInt(f, 10) : g;
-  }, n.getCapacity = function(f, g, y) {
+  }, n.getCapacity = function(f, g, w) {
     if (!r.isValid(f))
       throw new Error("Invalid QR Code version");
-    typeof y > "u" && (y = i.BYTE);
-    const S = t.getSymbolTotalCodewords(f), _ = e.getTotalCodewordsCount(f, g), w = (S - _) * 8;
-    if (y === i.MIXED) return w;
-    const m = w - l(y, f);
-    switch (y) {
-      case i.NUMERIC:
+    typeof w > "u" && (w = s.BYTE);
+    const k = t.getSymbolTotalCodewords(f), _ = e.getTotalCodewordsCount(f, g), v = (k - _) * 8;
+    if (w === s.MIXED) return v;
+    const m = v - l(w, f);
+    switch (w) {
+      case s.NUMERIC:
         return Math.floor(m / 10 * 3);
-      case i.ALPHANUMERIC:
+      case s.ALPHANUMERIC:
         return Math.floor(m / 11 * 2);
-      case i.KANJI:
+      case s.KANJI:
         return Math.floor(m / 13);
-      case i.BYTE:
+      case s.BYTE:
       default:
         return Math.floor(m / 8);
     }
   }, n.getBestVersionForData = function(f, g) {
-    let y;
-    const S = s.from(g, s.M);
+    let w;
+    const k = i.from(g, i.M);
     if (Array.isArray(f)) {
       if (f.length > 1)
-        return h(f, S);
+        return h(f, k);
       if (f.length === 0)
         return 1;
-      y = f[0];
+      w = f[0];
     } else
-      y = f;
-    return c(y.mode, y.getLength(), S);
+      w = f;
+    return c(w.mode, w.getLength(), k);
   }, n.getEncodedBits = function(f) {
     if (!r.isValid(f) || f < 7)
       throw new Error("Invalid QR Code version");
@@ -1660,39 +1660,39 @@ B.testAlphanumeric = function(t) {
       g ^= o << t.getBCHDigit(g) - a;
     return f << 12 | g;
   };
-})(Ve);
-var qe = {};
-const Kt = P, Ge = 1335, Ii = 21522, Se = Kt.getBCHDigit(Ge);
-qe.getEncodedBits = function(t, e) {
-  const s = t.bit << 3 | e;
-  let i = s << 10;
-  for (; Kt.getBCHDigit(i) - Se >= 0; )
-    i ^= Ge << Kt.getBCHDigit(i) - Se;
-  return (s << 10 | i) ^ Ii;
+})(We);
+var Ye = {};
+const Yt = N, Qe = 1335, Rs = 21522, Te = Yt.getBCHDigit(Qe);
+Ye.getEncodedBits = function(t, e) {
+  const i = t.bit << 3 | e;
+  let s = i << 10;
+  for (; Yt.getBCHDigit(s) - Te >= 0; )
+    s ^= Qe << Yt.getBCHDigit(s) - Te;
+  return (i << 10 | s) ^ Rs;
 };
-var Ke = {};
-const xi = K;
-function st(n) {
-  this.mode = xi.NUMERIC, this.data = n.toString();
+var Ze = {};
+const Us = K;
+function nt(n) {
+  this.mode = Us.NUMERIC, this.data = n.toString();
 }
-st.getBitsLength = function(t) {
+nt.getBitsLength = function(t) {
   return 10 * Math.floor(t / 3) + (t % 3 ? t % 3 * 3 + 1 : 0);
 };
-st.prototype.getLength = function() {
+nt.prototype.getLength = function() {
   return this.data.length;
 };
-st.prototype.getBitsLength = function() {
-  return st.getBitsLength(this.data.length);
+nt.prototype.getBitsLength = function() {
+  return nt.getBitsLength(this.data.length);
 };
-st.prototype.write = function(t) {
-  let e, s, i;
+nt.prototype.write = function(t) {
+  let e, i, s;
   for (e = 0; e + 3 <= this.data.length; e += 3)
-    s = this.data.substr(e, 3), i = parseInt(s, 10), t.put(i, 10);
+    i = this.data.substr(e, 3), s = parseInt(i, 10), t.put(s, 10);
   const r = this.data.length - e;
-  r > 0 && (s = this.data.substr(e), i = parseInt(s, 10), t.put(i, r * 3 + 1));
+  r > 0 && (i = this.data.substr(e), s = parseInt(i, 10), t.put(s, r * 3 + 1));
 };
-var Di = st;
-const Bi = K, zt = [
+var Os = nt;
+const Hs = K, qt = [
   "0",
   "1",
   "2",
@@ -1739,33 +1739,11 @@ const Bi = K, zt = [
   "/",
   ":"
 ];
-function nt(n) {
-  this.mode = Bi.ALPHANUMERIC, this.data = n;
-}
-nt.getBitsLength = function(t) {
-  return 11 * Math.floor(t / 2) + 6 * (t % 2);
-};
-nt.prototype.getLength = function() {
-  return this.data.length;
-};
-nt.prototype.getBitsLength = function() {
-  return nt.getBitsLength(this.data.length);
-};
-nt.prototype.write = function(t) {
-  let e;
-  for (e = 0; e + 2 <= this.data.length; e += 2) {
-    let s = zt.indexOf(this.data[e]) * 45;
-    s += zt.indexOf(this.data[e + 1]), t.put(s, 11);
-  }
-  this.data.length % 2 && t.put(zt.indexOf(this.data[e]), 6);
-};
-var Ri = nt;
-const Li = K;
 function rt(n) {
-  this.mode = Li.BYTE, typeof n == "string" ? this.data = new TextEncoder().encode(n) : this.data = new Uint8Array(n);
+  this.mode = Hs.ALPHANUMERIC, this.data = n;
 }
 rt.getBitsLength = function(t) {
-  return t * 8;
+  return 11 * Math.floor(t / 2) + 6 * (t % 2);
 };
 rt.prototype.getLength = function() {
   return this.data.length;
@@ -1773,17 +1751,21 @@ rt.prototype.getLength = function() {
 rt.prototype.getBitsLength = function() {
   return rt.getBitsLength(this.data.length);
 };
-rt.prototype.write = function(n) {
-  for (let t = 0, e = this.data.length; t < e; t++)
-    n.put(this.data[t], 8);
+rt.prototype.write = function(t) {
+  let e;
+  for (e = 0; e + 2 <= this.data.length; e += 2) {
+    let i = qt.indexOf(this.data[e]) * 45;
+    i += qt.indexOf(this.data[e + 1]), t.put(i, 11);
+  }
+  this.data.length % 2 && t.put(qt.indexOf(this.data[e]), 6);
 };
-var Ui = rt;
-const Oi = K, Hi = P;
+var zs = rt;
+const Fs = K;
 function ot(n) {
-  this.mode = Oi.KANJI, this.data = n;
+  this.mode = Fs.BYTE, typeof n == "string" ? this.data = new TextEncoder().encode(n) : this.data = new Uint8Array(n);
 }
 ot.getBitsLength = function(t) {
-  return t * 13;
+  return t * 8;
 };
 ot.prototype.getLength = function() {
   return this.data.length;
@@ -1792,9 +1774,27 @@ ot.prototype.getBitsLength = function() {
   return ot.getBitsLength(this.data.length);
 };
 ot.prototype.write = function(n) {
+  for (let t = 0, e = this.data.length; t < e; t++)
+    n.put(this.data[t], 8);
+};
+var Vs = ot;
+const js = K, qs = N;
+function at(n) {
+  this.mode = js.KANJI, this.data = n;
+}
+at.getBitsLength = function(t) {
+  return t * 13;
+};
+at.prototype.getLength = function() {
+  return this.data.length;
+};
+at.prototype.getBitsLength = function() {
+  return at.getBitsLength(this.data.length);
+};
+at.prototype.write = function(n) {
   let t;
   for (t = 0; t < this.data.length; t++) {
-    let e = Hi.toSJIS(this.data[t]);
+    let e = qs.toSJIS(this.data[t]);
     if (e >= 33088 && e <= 40956)
       e -= 33088;
     else if (e >= 57408 && e <= 60351)
@@ -1807,35 +1807,35 @@ Make sure your charset is UTF-8`
     e = (e >>> 8 & 255) * 192 + (e & 255), n.put(e, 13);
   }
 };
-var Fi = ot, We = { exports: {} };
+var Gs = at, Xe = { exports: {} };
 (function(n) {
   var t = {
-    single_source_shortest_paths: function(e, s, i) {
+    single_source_shortest_paths: function(e, i, s) {
       var r = {}, o = {};
-      o[s] = 0;
+      o[i] = 0;
       var a = t.PriorityQueue.make();
-      a.push(s, 0);
-      for (var c, l, d, h, u, f, g, y, S; !a.empty(); ) {
+      a.push(i, 0);
+      for (var c, l, d, h, u, f, g, w, k; !a.empty(); ) {
         c = a.pop(), l = c.value, h = c.cost, u = e[l] || {};
         for (d in u)
-          u.hasOwnProperty(d) && (f = u[d], g = h + f, y = o[d], S = typeof o[d] > "u", (S || y > g) && (o[d] = g, a.push(d, g), r[d] = l));
+          u.hasOwnProperty(d) && (f = u[d], g = h + f, w = o[d], k = typeof o[d] > "u", (k || w > g) && (o[d] = g, a.push(d, g), r[d] = l));
       }
-      if (typeof i < "u" && typeof o[i] > "u") {
-        var _ = ["Could not find a path from ", s, " to ", i, "."].join("");
+      if (typeof s < "u" && typeof o[s] > "u") {
+        var _ = ["Could not find a path from ", i, " to ", s, "."].join("");
         throw new Error(_);
       }
       return r;
     },
-    extract_shortest_path_from_predecessor_list: function(e, s) {
-      for (var i = [], r = s; r; )
-        i.push(r), e[r], r = e[r];
-      return i.reverse(), i;
+    extract_shortest_path_from_predecessor_list: function(e, i) {
+      for (var s = [], r = i; r; )
+        s.push(r), e[r], r = e[r];
+      return s.reverse(), s;
     },
-    find_path: function(e, s, i) {
-      var r = t.single_source_shortest_paths(e, s, i);
+    find_path: function(e, i, s) {
+      var r = t.single_source_shortest_paths(e, i, s);
       return t.extract_shortest_path_from_predecessor_list(
         r,
-        i
+        s
       );
     },
     /**
@@ -1843,22 +1843,22 @@ var Fi = ot, We = { exports: {} };
      */
     PriorityQueue: {
       make: function(e) {
-        var s = t.PriorityQueue, i = {}, r;
+        var i = t.PriorityQueue, s = {}, r;
         e = e || {};
-        for (r in s)
-          s.hasOwnProperty(r) && (i[r] = s[r]);
-        return i.queue = [], i.sorter = e.sorter || s.default_sorter, i;
+        for (r in i)
+          i.hasOwnProperty(r) && (s[r] = i[r]);
+        return s.queue = [], s.sorter = e.sorter || i.default_sorter, s;
       },
-      default_sorter: function(e, s) {
-        return e.cost - s.cost;
+      default_sorter: function(e, i) {
+        return e.cost - i.cost;
       },
       /**
        * Add a new item to the queue and ensure the highest priority element
        * is at the front of the queue.
        */
-      push: function(e, s) {
-        var i = { value: e, cost: s };
-        this.queue.push(i), this.queue.sort(this.sorter);
+      push: function(e, i) {
+        var s = { value: e, cost: i };
+        this.queue.push(s), this.queue.sort(this.sorter);
       },
       /**
        * Return the highest priority element in the queue.
@@ -1872,242 +1872,242 @@ var Fi = ot, We = { exports: {} };
     }
   };
   n.exports = t;
-})(We);
-var zi = We.exports;
+})(Xe);
+var Ks = Xe.exports;
 (function(n) {
-  const t = K, e = Di, s = Ri, i = Ui, r = Fi, o = B, a = P, c = zi;
+  const t = K, e = Os, i = zs, s = Vs, r = Gs, o = U, a = N, c = Ks;
   function l(_) {
     return unescape(encodeURIComponent(_)).length;
   }
-  function d(_, w, m) {
+  function d(_, v, m) {
     const p = [];
     let E;
     for (; (E = _.exec(m)) !== null; )
       p.push({
         data: E[0],
         index: E.index,
-        mode: w,
+        mode: v,
         length: E[0].length
       });
     return p;
   }
   function h(_) {
-    const w = d(o.NUMERIC, t.NUMERIC, _), m = d(o.ALPHANUMERIC, t.ALPHANUMERIC, _);
+    const v = d(o.NUMERIC, t.NUMERIC, _), m = d(o.ALPHANUMERIC, t.ALPHANUMERIC, _);
     let p, E;
-    return a.isKanjiModeEnabled() ? (p = d(o.BYTE, t.BYTE, _), E = d(o.KANJI, t.KANJI, _)) : (p = d(o.BYTE_KANJI, t.BYTE, _), E = []), w.concat(m, p, E).sort(function(A, x) {
-      return A.index - x.index;
-    }).map(function(A) {
+    return a.isKanjiModeEnabled() ? (p = d(o.BYTE, t.BYTE, _), E = d(o.KANJI, t.KANJI, _)) : (p = d(o.BYTE_KANJI, t.BYTE, _), E = []), v.concat(m, p, E).sort(function($, I) {
+      return $.index - I.index;
+    }).map(function($) {
       return {
-        data: A.data,
-        mode: A.mode,
-        length: A.length
+        data: $.data,
+        mode: $.mode,
+        length: $.length
       };
     });
   }
-  function u(_, w) {
-    switch (w) {
+  function u(_, v) {
+    switch (v) {
       case t.NUMERIC:
         return e.getBitsLength(_);
       case t.ALPHANUMERIC:
-        return s.getBitsLength(_);
+        return i.getBitsLength(_);
       case t.KANJI:
         return r.getBitsLength(_);
       case t.BYTE:
-        return i.getBitsLength(_);
+        return s.getBitsLength(_);
     }
   }
   function f(_) {
-    return _.reduce(function(w, m) {
-      const p = w.length - 1 >= 0 ? w[w.length - 1] : null;
-      return p && p.mode === m.mode ? (w[w.length - 1].data += m.data, w) : (w.push(m), w);
+    return _.reduce(function(v, m) {
+      const p = v.length - 1 >= 0 ? v[v.length - 1] : null;
+      return p && p.mode === m.mode ? (v[v.length - 1].data += m.data, v) : (v.push(m), v);
     }, []);
   }
   function g(_) {
-    const w = [];
+    const v = [];
     for (let m = 0; m < _.length; m++) {
       const p = _[m];
       switch (p.mode) {
         case t.NUMERIC:
-          w.push([
+          v.push([
             p,
             { data: p.data, mode: t.ALPHANUMERIC, length: p.length },
             { data: p.data, mode: t.BYTE, length: p.length }
           ]);
           break;
         case t.ALPHANUMERIC:
-          w.push([
+          v.push([
             p,
             { data: p.data, mode: t.BYTE, length: p.length }
           ]);
           break;
         case t.KANJI:
-          w.push([
+          v.push([
             p,
             { data: p.data, mode: t.BYTE, length: l(p.data) }
           ]);
           break;
         case t.BYTE:
-          w.push([
+          v.push([
             { data: p.data, mode: t.BYTE, length: l(p.data) }
           ]);
       }
     }
-    return w;
+    return v;
   }
-  function y(_, w) {
+  function w(_, v) {
     const m = {}, p = { start: {} };
     let E = ["start"];
     for (let C = 0; C < _.length; C++) {
-      const A = _[C], x = [];
-      for (let V = 0; V < A.length; V++) {
-        const D = A[V], ct = "" + C + V;
-        x.push(ct), m[ct] = { node: D, lastCount: 0 }, p[ct] = {};
-        for (let Lt = 0; Lt < E.length; Lt++) {
-          const R = E[Lt];
-          m[R] && m[R].node.mode === D.mode ? (p[R][ct] = u(m[R].lastCount + D.length, D.mode) - u(m[R].lastCount, D.mode), m[R].lastCount += D.length) : (m[R] && (m[R].lastCount = D.length), p[R][ct] = u(D.length, D.mode) + 4 + t.getCharCountIndicator(D.mode, w));
+      const $ = _[C], I = [];
+      for (let V = 0; V < $.length; V++) {
+        const B = $[V], dt = "" + C + V;
+        I.push(dt), m[dt] = { node: B, lastCount: 0 }, p[dt] = {};
+        for (let Ht = 0; Ht < E.length; Ht++) {
+          const O = E[Ht];
+          m[O] && m[O].node.mode === B.mode ? (p[O][dt] = u(m[O].lastCount + B.length, B.mode) - u(m[O].lastCount, B.mode), m[O].lastCount += B.length) : (m[O] && (m[O].lastCount = B.length), p[O][dt] = u(B.length, B.mode) + 4 + t.getCharCountIndicator(B.mode, v));
         }
       }
-      E = x;
+      E = I;
     }
     for (let C = 0; C < E.length; C++)
       p[E[C]].end = 0;
     return { map: p, table: m };
   }
-  function S(_, w) {
+  function k(_, v) {
     let m;
     const p = t.getBestModeForData(_);
-    if (m = t.from(w, p), m !== t.BYTE && m.bit < p.bit)
+    if (m = t.from(v, p), m !== t.BYTE && m.bit < p.bit)
       throw new Error('"' + _ + '" cannot be encoded with mode ' + t.toString(m) + `.
  Suggested mode is: ` + t.toString(p));
     switch (m === t.KANJI && !a.isKanjiModeEnabled() && (m = t.BYTE), m) {
       case t.NUMERIC:
         return new e(_);
       case t.ALPHANUMERIC:
-        return new s(_);
+        return new i(_);
       case t.KANJI:
         return new r(_);
       case t.BYTE:
-        return new i(_);
+        return new s(_);
     }
   }
-  n.fromArray = function(w) {
-    return w.reduce(function(m, p) {
-      return typeof p == "string" ? m.push(S(p, null)) : p.data && m.push(S(p.data, p.mode)), m;
+  n.fromArray = function(v) {
+    return v.reduce(function(m, p) {
+      return typeof p == "string" ? m.push(k(p, null)) : p.data && m.push(k(p.data, p.mode)), m;
     }, []);
-  }, n.fromString = function(w, m) {
-    const p = h(w, a.isKanjiModeEnabled()), E = g(p), C = y(E, m), A = c.find_path(C.map, "start", "end"), x = [];
-    for (let V = 1; V < A.length - 1; V++)
-      x.push(C.table[A[V]].node);
-    return n.fromArray(f(x));
-  }, n.rawSplit = function(w) {
+  }, n.fromString = function(v, m) {
+    const p = h(v, a.isKanjiModeEnabled()), E = g(p), C = w(E, m), $ = c.find_path(C.map, "start", "end"), I = [];
+    for (let V = 1; V < $.length - 1; V++)
+      I.push(C.table[$[V]].node);
+    return n.fromArray(f(I));
+  }, n.rawSplit = function(v) {
     return n.fromArray(
-      h(w, a.isKanjiModeEnabled())
+      h(v, a.isKanjiModeEnabled())
     );
   };
-})(Ke);
-const Rt = P, Vt = xt, Vi = Ci, ji = Ai, qi = Ue, Gi = Oe, Wt = He, Jt = Dt, Ki = Si, Nt = Ve, Wi = qe, Ji = K, jt = Ke;
-function Yi(n, t) {
-  const e = n.size, s = Gi.getPositions(t);
-  for (let i = 0; i < s.length; i++) {
-    const r = s[i][0], o = s[i][1];
+})(Ze);
+const Ot = N, Gt = Bt, Ws = Ps, Js = Ns, Ys = Ve, Qs = je, Qt = qe, Zt = Rt, Zs = Ms, Dt = We, Xs = Ye, ti = K, Kt = Ze;
+function ei(n, t) {
+  const e = n.size, i = Qs.getPositions(t);
+  for (let s = 0; s < i.length; s++) {
+    const r = i[s][0], o = i[s][1];
     for (let a = -1; a <= 7; a++)
       if (!(r + a <= -1 || e <= r + a))
         for (let c = -1; c <= 7; c++)
           o + c <= -1 || e <= o + c || (a >= 0 && a <= 6 && (c === 0 || c === 6) || c >= 0 && c <= 6 && (a === 0 || a === 6) || a >= 2 && a <= 4 && c >= 2 && c <= 4 ? n.set(r + a, o + c, !0, !0) : n.set(r + a, o + c, !1, !0));
   }
 }
-function Qi(n) {
+function si(n) {
   const t = n.size;
   for (let e = 8; e < t - 8; e++) {
-    const s = e % 2 === 0;
-    n.set(e, 6, s, !0), n.set(6, e, s, !0);
+    const i = e % 2 === 0;
+    n.set(e, 6, i, !0), n.set(6, e, i, !0);
   }
 }
-function Zi(n, t) {
-  const e = qi.getPositions(t);
-  for (let s = 0; s < e.length; s++) {
-    const i = e[s][0], r = e[s][1];
+function ii(n, t) {
+  const e = Ys.getPositions(t);
+  for (let i = 0; i < e.length; i++) {
+    const s = e[i][0], r = e[i][1];
     for (let o = -2; o <= 2; o++)
       for (let a = -2; a <= 2; a++)
-        o === -2 || o === 2 || a === -2 || a === 2 || o === 0 && a === 0 ? n.set(i + o, r + a, !0, !0) : n.set(i + o, r + a, !1, !0);
+        o === -2 || o === 2 || a === -2 || a === 2 || o === 0 && a === 0 ? n.set(s + o, r + a, !0, !0) : n.set(s + o, r + a, !1, !0);
   }
 }
-function Xi(n, t) {
-  const e = n.size, s = Nt.getEncodedBits(t);
-  let i, r, o;
+function ni(n, t) {
+  const e = n.size, i = Dt.getEncodedBits(t);
+  let s, r, o;
   for (let a = 0; a < 18; a++)
-    i = Math.floor(a / 3), r = a % 3 + e - 8 - 3, o = (s >> a & 1) === 1, n.set(i, r, o, !0), n.set(r, i, o, !0);
+    s = Math.floor(a / 3), r = a % 3 + e - 8 - 3, o = (i >> a & 1) === 1, n.set(s, r, o, !0), n.set(r, s, o, !0);
 }
-function qt(n, t, e) {
-  const s = n.size, i = Wi.getEncodedBits(t, e);
+function Wt(n, t, e) {
+  const i = n.size, s = Xs.getEncodedBits(t, e);
   let r, o;
   for (r = 0; r < 15; r++)
-    o = (i >> r & 1) === 1, r < 6 ? n.set(r, 8, o, !0) : r < 8 ? n.set(r + 1, 8, o, !0) : n.set(s - 15 + r, 8, o, !0), r < 8 ? n.set(8, s - r - 1, o, !0) : r < 9 ? n.set(8, 15 - r - 1 + 1, o, !0) : n.set(8, 15 - r - 1, o, !0);
-  n.set(s - 8, 8, 1, !0);
+    o = (s >> r & 1) === 1, r < 6 ? n.set(r, 8, o, !0) : r < 8 ? n.set(r + 1, 8, o, !0) : n.set(i - 15 + r, 8, o, !0), r < 8 ? n.set(8, i - r - 1, o, !0) : r < 9 ? n.set(8, 15 - r - 1 + 1, o, !0) : n.set(8, 15 - r - 1, o, !0);
+  n.set(i - 8, 8, 1, !0);
 }
-function ts(n, t) {
+function ri(n, t) {
   const e = n.size;
-  let s = -1, i = e - 1, r = 7, o = 0;
+  let i = -1, s = e - 1, r = 7, o = 0;
   for (let a = e - 1; a > 0; a -= 2)
     for (a === 6 && a--; ; ) {
       for (let c = 0; c < 2; c++)
-        if (!n.isReserved(i, a - c)) {
+        if (!n.isReserved(s, a - c)) {
           let l = !1;
-          o < t.length && (l = (t[o] >>> r & 1) === 1), n.set(i, a - c, l), r--, r === -1 && (o++, r = 7);
+          o < t.length && (l = (t[o] >>> r & 1) === 1), n.set(s, a - c, l), r--, r === -1 && (o++, r = 7);
         }
-      if (i += s, i < 0 || e <= i) {
-        i -= s, s = -s;
+      if (s += i, s < 0 || e <= s) {
+        s -= i, i = -i;
         break;
       }
     }
 }
-function es(n, t, e) {
-  const s = new Vi();
+function oi(n, t, e) {
+  const i = new Ws();
   e.forEach(function(c) {
-    s.put(c.mode.bit, 4), s.put(c.getLength(), Ji.getCharCountIndicator(c.mode, n)), c.write(s);
+    i.put(c.mode.bit, 4), i.put(c.getLength(), ti.getCharCountIndicator(c.mode, n)), c.write(i);
   });
-  const i = Rt.getSymbolTotalCodewords(n), r = Jt.getTotalCodewordsCount(n, t), o = (i - r) * 8;
-  for (s.getLengthInBits() + 4 <= o && s.put(0, 4); s.getLengthInBits() % 8 !== 0; )
-    s.putBit(0);
-  const a = (o - s.getLengthInBits()) / 8;
+  const s = Ot.getSymbolTotalCodewords(n), r = Zt.getTotalCodewordsCount(n, t), o = (s - r) * 8;
+  for (i.getLengthInBits() + 4 <= o && i.put(0, 4); i.getLengthInBits() % 8 !== 0; )
+    i.putBit(0);
+  const a = (o - i.getLengthInBits()) / 8;
   for (let c = 0; c < a; c++)
-    s.put(c % 2 ? 17 : 236, 8);
-  return is(s, n, t);
+    i.put(c % 2 ? 17 : 236, 8);
+  return ai(i, n, t);
 }
-function is(n, t, e) {
-  const s = Rt.getSymbolTotalCodewords(t), i = Jt.getTotalCodewordsCount(t, e), r = s - i, o = Jt.getBlocksCount(t, e), a = s % o, c = o - a, l = Math.floor(s / o), d = Math.floor(r / o), h = d + 1, u = l - d, f = new Ki(u);
+function ai(n, t, e) {
+  const i = Ot.getSymbolTotalCodewords(t), s = Zt.getTotalCodewordsCount(t, e), r = i - s, o = Zt.getBlocksCount(t, e), a = i % o, c = o - a, l = Math.floor(i / o), d = Math.floor(r / o), h = d + 1, u = l - d, f = new Zs(u);
   let g = 0;
-  const y = new Array(o), S = new Array(o);
+  const w = new Array(o), k = new Array(o);
   let _ = 0;
-  const w = new Uint8Array(n.buffer);
-  for (let A = 0; A < o; A++) {
-    const x = A < c ? d : h;
-    y[A] = w.slice(g, g + x), S[A] = f.encode(y[A]), g += x, _ = Math.max(_, x);
+  const v = new Uint8Array(n.buffer);
+  for (let $ = 0; $ < o; $++) {
+    const I = $ < c ? d : h;
+    w[$] = v.slice(g, g + I), k[$] = f.encode(w[$]), g += I, _ = Math.max(_, I);
   }
-  const m = new Uint8Array(s);
+  const m = new Uint8Array(i);
   let p = 0, E, C;
   for (E = 0; E < _; E++)
     for (C = 0; C < o; C++)
-      E < y[C].length && (m[p++] = y[C][E]);
+      E < w[C].length && (m[p++] = w[C][E]);
   for (E = 0; E < u; E++)
     for (C = 0; C < o; C++)
-      m[p++] = S[C][E];
+      m[p++] = k[C][E];
   return m;
 }
-function ss(n, t, e, s) {
-  let i;
+function ci(n, t, e, i) {
+  let s;
   if (Array.isArray(n))
-    i = jt.fromArray(n);
+    s = Kt.fromArray(n);
   else if (typeof n == "string") {
     let l = t;
     if (!l) {
-      const d = jt.rawSplit(n);
-      l = Nt.getBestVersionForData(d, e);
+      const d = Kt.rawSplit(n);
+      l = Dt.getBestVersionForData(d, e);
     }
-    i = jt.fromString(n, l || 40);
+    s = Kt.fromString(n, l || 40);
   } else
     throw new Error("Invalid data");
-  const r = Nt.getBestVersionForData(i, e);
+  const r = Dt.getBestVersionForData(s, e);
   if (!r)
     throw new Error("The amount of data is too big to be stored in a QR Code");
   if (!t)
@@ -2119,82 +2119,82 @@ The chosen QR Code version cannot contain this amount of data.
 Minimum version required to store current data is: ` + r + `.
 `
     );
-  const o = es(t, e, i), a = Rt.getSymbolSize(t), c = new ji(a);
-  return Yi(c, t), Qi(c), Zi(c, t), qt(c, e, 0), t >= 7 && Xi(c, t), ts(c, o), isNaN(s) && (s = Wt.getBestMask(
+  const o = oi(t, e, s), a = Ot.getSymbolSize(t), c = new Js(a);
+  return ei(c, t), si(c), ii(c, t), Wt(c, e, 0), t >= 7 && ni(c, t), ri(c, o), isNaN(i) && (i = Qt.getBestMask(
     c,
-    qt.bind(null, c, e)
-  )), Wt.applyMask(s, c), qt(c, e, s), {
+    Wt.bind(null, c, e)
+  )), Qt.applyMask(i, c), Wt(c, e, i), {
     modules: c,
     version: t,
     errorCorrectionLevel: e,
-    maskPattern: s,
-    segments: i
+    maskPattern: i,
+    segments: s
   };
 }
-Re.create = function(t, e) {
+ze.create = function(t, e) {
   if (typeof t > "u" || t === "")
     throw new Error("No input text");
-  let s = Vt.M, i, r;
-  return typeof e < "u" && (s = Vt.from(e.errorCorrectionLevel, Vt.M), i = Nt.from(e.version), r = Wt.from(e.maskPattern), e.toSJISFunc && Rt.setToSJISFunction(e.toSJISFunc)), ss(t, i, s, r);
+  let i = Gt.M, s, r;
+  return typeof e < "u" && (i = Gt.from(e.errorCorrectionLevel, Gt.M), s = Dt.from(e.version), r = Qt.from(e.maskPattern), e.toSJISFunc && Ot.setToSJISFunction(e.toSJISFunc)), ci(t, s, i, r);
 };
-var Je = {}, ne = {};
+var ts = {}, ce = {};
 (function(n) {
   function t(e) {
     if (typeof e == "number" && (e = e.toString()), typeof e != "string")
       throw new Error("Color should be defined as hex string");
-    let s = e.slice().replace("#", "").split("");
-    if (s.length < 3 || s.length === 5 || s.length > 8)
+    let i = e.slice().replace("#", "").split("");
+    if (i.length < 3 || i.length === 5 || i.length > 8)
       throw new Error("Invalid hex color: " + e);
-    (s.length === 3 || s.length === 4) && (s = Array.prototype.concat.apply([], s.map(function(r) {
+    (i.length === 3 || i.length === 4) && (i = Array.prototype.concat.apply([], i.map(function(r) {
       return [r, r];
-    }))), s.length === 6 && s.push("F", "F");
-    const i = parseInt(s.join(""), 16);
+    }))), i.length === 6 && i.push("F", "F");
+    const s = parseInt(i.join(""), 16);
     return {
-      r: i >> 24 & 255,
-      g: i >> 16 & 255,
-      b: i >> 8 & 255,
-      a: i & 255,
-      hex: "#" + s.slice(0, 6).join("")
+      r: s >> 24 & 255,
+      g: s >> 16 & 255,
+      b: s >> 8 & 255,
+      a: s & 255,
+      hex: "#" + i.slice(0, 6).join("")
     };
   }
-  n.getOptions = function(s) {
-    s || (s = {}), s.color || (s.color = {});
-    const i = typeof s.margin > "u" || s.margin === null || s.margin < 0 ? 4 : s.margin, r = s.width && s.width >= 21 ? s.width : void 0, o = s.scale || 4;
+  n.getOptions = function(i) {
+    i || (i = {}), i.color || (i.color = {});
+    const s = typeof i.margin > "u" || i.margin === null || i.margin < 0 ? 4 : i.margin, r = i.width && i.width >= 21 ? i.width : void 0, o = i.scale || 4;
     return {
       width: r,
       scale: r ? 4 : o,
-      margin: i,
+      margin: s,
       color: {
-        dark: t(s.color.dark || "#000000ff"),
-        light: t(s.color.light || "#ffffffff")
+        dark: t(i.color.dark || "#000000ff"),
+        light: t(i.color.light || "#ffffffff")
       },
-      type: s.type,
-      rendererOpts: s.rendererOpts || {}
+      type: i.type,
+      rendererOpts: i.rendererOpts || {}
     };
-  }, n.getScale = function(s, i) {
-    return i.width && i.width >= s + i.margin * 2 ? i.width / (s + i.margin * 2) : i.scale;
-  }, n.getImageWidth = function(s, i) {
-    const r = n.getScale(s, i);
-    return Math.floor((s + i.margin * 2) * r);
-  }, n.qrToImageData = function(s, i, r) {
-    const o = i.modules.size, a = i.modules.data, c = n.getScale(o, r), l = Math.floor((o + r.margin * 2) * c), d = r.margin * c, h = [r.color.light, r.color.dark];
+  }, n.getScale = function(i, s) {
+    return s.width && s.width >= i + s.margin * 2 ? s.width / (i + s.margin * 2) : s.scale;
+  }, n.getImageWidth = function(i, s) {
+    const r = n.getScale(i, s);
+    return Math.floor((i + s.margin * 2) * r);
+  }, n.qrToImageData = function(i, s, r) {
+    const o = s.modules.size, a = s.modules.data, c = n.getScale(o, r), l = Math.floor((o + r.margin * 2) * c), d = r.margin * c, h = [r.color.light, r.color.dark];
     for (let u = 0; u < l; u++)
       for (let f = 0; f < l; f++) {
-        let g = (u * l + f) * 4, y = r.color.light;
+        let g = (u * l + f) * 4, w = r.color.light;
         if (u >= d && f >= d && u < l - d && f < l - d) {
-          const S = Math.floor((u - d) / c), _ = Math.floor((f - d) / c);
-          y = h[a[S * o + _] ? 1 : 0];
+          const k = Math.floor((u - d) / c), _ = Math.floor((f - d) / c);
+          w = h[a[k * o + _] ? 1 : 0];
         }
-        s[g++] = y.r, s[g++] = y.g, s[g++] = y.b, s[g] = y.a;
+        i[g++] = w.r, i[g++] = w.g, i[g++] = w.b, i[g] = w.a;
       }
   };
-})(ne);
+})(ce);
 (function(n) {
-  const t = ne;
-  function e(i, r, o) {
-    i.clearRect(0, 0, r.width, r.height), r.style || (r.style = {}), r.height = o, r.width = o, r.style.height = o + "px", r.style.width = o + "px";
+  const t = ce;
+  function e(s, r, o) {
+    s.clearRect(0, 0, r.width, r.height), r.style || (r.style = {}), r.height = o, r.width = o, r.style.height = o + "px", r.style.width = o + "px";
   }
-  function s() {
+  function i() {
     try {
       return document.createElement("canvas");
     } catch {
@@ -2203,7 +2203,7 @@ var Je = {}, ne = {};
   }
   n.render = function(r, o, a) {
     let c = a, l = o;
-    typeof c > "u" && (!o || !o.getContext) && (c = o, o = void 0), o || (l = s()), c = t.getOptions(c);
+    typeof c > "u" && (!o || !o.getContext) && (c = o, o = void 0), o || (l = i()), c = t.getOptions(c);
     const d = t.getImageWidth(r.modules.size, c), h = l.getContext("2d"), u = h.createImageData(d, d);
     return t.qrToImageData(u.data, r, c), e(h, l, d), h.putImageData(u, 0, 0), l;
   }, n.renderToDataURL = function(r, o, a) {
@@ -2212,65 +2212,65 @@ var Je = {}, ne = {};
     const l = n.render(r, o, c), d = c.type || "image/png", h = c.rendererOpts || {};
     return l.toDataURL(d, h.quality);
   };
-})(Je);
-var Ye = {};
-const ns = ne;
-function ke(n, t) {
-  const e = n.a / 255, s = t + '="' + n.hex + '"';
-  return e < 1 ? s + " " + t + '-opacity="' + e.toFixed(2).slice(1) + '"' : s;
+})(ts);
+var es = {};
+const li = ce;
+function Ie(n, t) {
+  const e = n.a / 255, i = t + '="' + n.hex + '"';
+  return e < 1 ? i + " " + t + '-opacity="' + e.toFixed(2).slice(1) + '"' : i;
 }
-function Gt(n, t, e) {
-  let s = n + t;
-  return typeof e < "u" && (s += " " + e), s;
+function Jt(n, t, e) {
+  let i = n + t;
+  return typeof e < "u" && (i += " " + e), i;
 }
-function rs(n, t, e) {
-  let s = "", i = 0, r = !1, o = 0;
+function di(n, t, e) {
+  let i = "", s = 0, r = !1, o = 0;
   for (let a = 0; a < n.length; a++) {
     const c = Math.floor(a % t), l = Math.floor(a / t);
-    !c && !r && (r = !0), n[a] ? (o++, a > 0 && c > 0 && n[a - 1] || (s += r ? Gt("M", c + e, 0.5 + l + e) : Gt("m", i, 0), i = 0, r = !1), c + 1 < t && n[a + 1] || (s += Gt("h", o), o = 0)) : i++;
+    !c && !r && (r = !0), n[a] ? (o++, a > 0 && c > 0 && n[a - 1] || (i += r ? Jt("M", c + e, 0.5 + l + e) : Jt("m", s, 0), s = 0, r = !1), c + 1 < t && n[a + 1] || (i += Jt("h", o), o = 0)) : s++;
   }
-  return s;
+  return i;
 }
-Ye.render = function(t, e, s) {
-  const i = ns.getOptions(e), r = t.modules.size, o = t.modules.data, a = r + i.margin * 2, c = i.color.light.a ? "<path " + ke(i.color.light, "fill") + ' d="M0 0h' + a + "v" + a + 'H0z"/>' : "", l = "<path " + ke(i.color.dark, "stroke") + ' d="' + rs(o, r, i.margin) + '"/>', d = 'viewBox="0 0 ' + a + " " + a + '"', u = '<svg xmlns="http://www.w3.org/2000/svg" ' + (i.width ? 'width="' + i.width + '" height="' + i.width + '" ' : "") + d + ' shape-rendering="crispEdges">' + c + l + `</svg>
+es.render = function(t, e, i) {
+  const s = li.getOptions(e), r = t.modules.size, o = t.modules.data, a = r + s.margin * 2, c = s.color.light.a ? "<path " + Ie(s.color.light, "fill") + ' d="M0 0h' + a + "v" + a + 'H0z"/>' : "", l = "<path " + Ie(s.color.dark, "stroke") + ' d="' + di(o, r, s.margin) + '"/>', d = 'viewBox="0 0 ' + a + " " + a + '"', u = '<svg xmlns="http://www.w3.org/2000/svg" ' + (s.width ? 'width="' + s.width + '" height="' + s.width + '" ' : "") + d + ' shape-rendering="crispEdges">' + c + l + `</svg>
 `;
-  return typeof s == "function" && s(null, u), u;
+  return typeof i == "function" && i(null, u), u;
 };
-const os = bi, Yt = Re, Qe = Je, as = Ye;
-function re(n, t, e, s, i) {
+const hi = ks, Xt = ze, ss = ts, ui = es;
+function le(n, t, e, i, s) {
   const r = [].slice.call(arguments, 1), o = r.length, a = typeof r[o - 1] == "function";
-  if (!a && !os())
+  if (!a && !hi())
     throw new Error("Callback required as last argument");
   if (a) {
     if (o < 2)
       throw new Error("Too few arguments provided");
-    o === 2 ? (i = e, e = t, t = s = void 0) : o === 3 && (t.getContext && typeof i > "u" ? (i = s, s = void 0) : (i = s, s = e, e = t, t = void 0));
+    o === 2 ? (s = e, e = t, t = i = void 0) : o === 3 && (t.getContext && typeof s > "u" ? (s = i, i = void 0) : (s = i, i = e, e = t, t = void 0));
   } else {
     if (o < 1)
       throw new Error("Too few arguments provided");
-    return o === 1 ? (e = t, t = s = void 0) : o === 2 && !t.getContext && (s = e, e = t, t = void 0), new Promise(function(c, l) {
+    return o === 1 ? (e = t, t = i = void 0) : o === 2 && !t.getContext && (i = e, e = t, t = void 0), new Promise(function(c, l) {
       try {
-        const d = Yt.create(e, s);
-        c(n(d, t, s));
+        const d = Xt.create(e, i);
+        c(n(d, t, i));
       } catch (d) {
         l(d);
       }
     });
   }
   try {
-    const c = Yt.create(e, s);
-    i(null, n(c, t, s));
+    const c = Xt.create(e, i);
+    s(null, n(c, t, i));
   } catch (c) {
-    i(c);
+    s(c);
   }
 }
-bt.create = Yt.create;
-bt.toCanvas = re.bind(null, Qe.render);
-bt.toDataURL = re.bind(null, Qe.renderToDataURL);
-bt.toString = re.bind(null, function(n, t, e) {
-  return as.render(n, e);
+kt.create = Xt.create;
+kt.toCanvas = le.bind(null, ss.render);
+kt.toDataURL = le.bind(null, ss.renderToDataURL);
+kt.toString = le.bind(null, function(n, t, e) {
+  return ui.render(n, e);
 });
-class T {
+class M {
   /**
    * Resolves a value that might be an entity ID or a raw string.
    */
@@ -2280,14 +2280,14 @@ class T {
   /**
    * Discovers a Wi-Fi password using manual overrides, entity IDs, or smart attribute mapping.
    */
-  static getPasswordForSsid(t, e, s, i, r) {
+  static getPasswordForSsid(t, e, i, s, r) {
     if (!t) return "";
     if (r && r !== "password123")
       return this.getValue(t, r);
-    if (!s) return "";
-    const o = parseInt(s, 10), a = e.find((d) => {
-      const h = !i || d.networkId === i;
-      return isNaN(o) ? d.name === s && h : d.number === o && h;
+    if (!i) return "";
+    const o = parseInt(i, 10), a = e.find((d) => {
+      const h = !s || d.networkId === s;
+      return isNaN(o) ? d.name === i && h : d.number === o && h;
     });
     if (a)
       for (const d in t.states) {
@@ -2299,7 +2299,7 @@ class T {
             return h.state;
         }
       }
-    const l = (a ? a.name : s).toLowerCase().replace(/[^a-z0-9]/g, "_");
+    const l = (a ? a.name : i).toLowerCase().replace(/[^a-z0-9]/g, "_");
     for (const d in t.states)
       if (d.includes(l) && (d.includes("password") || d.includes("psk"))) {
         const h = t.states[d];
@@ -2318,15 +2318,15 @@ class T {
    * Generates a standard Wi-Fi QR string.
    */
   static generateWifiQrString(t, e) {
-    const s = this.escapeWifiString(t), i = e ? this.escapeWifiString(e) : "";
-    return i ? `WIFI:T:WPA;S:${s};P:${i};;` : `WIFI:T:nopass;S:${s};P:;;`;
+    const i = this.escapeWifiString(t), s = e ? this.escapeWifiString(e) : "";
+    return s ? `WIFI:T:WPA;S:${i};P:${s};;` : `WIFI:T:nopass;S:${i};P:;;`;
   }
   /**
    * Generates an SVG QR code from a string.
    */
   static async generateQrSvg(t, e = 1) {
     try {
-      return await bt.toString(t, {
+      return await kt.toString(t, {
         type: "svg",
         margin: e,
         color: {
@@ -2334,8 +2334,8 @@ class T {
           light: "#ffffff"
         }
       });
-    } catch (s) {
-      return console.error("Failed to generate QR code SVG:", s), '<div style="text-align:center; padding: 24px;">QR Code Unavailable</div>';
+    } catch (i) {
+      return console.error("Failed to generate QR code SVG:", i), '<div style="text-align:center; padding: 24px;">QR Code Unavailable</div>';
     }
   }
   /**
@@ -2394,16 +2394,16 @@ class T {
       "sky",
       "earth",
       "sun"
-    ], s = (i) => i[Math.floor(Math.random() * i.length)];
-    return `${s(t)}-${s(e)}-${Math.floor(Math.random() * 1e3)}`;
+    ], i = (s) => s[Math.floor(Math.random() * s.length)];
+    return `${i(t)}-${i(e)}-${Math.floor(Math.random() * 1e3)}`;
   }
 }
-var cs = Object.defineProperty, W = (n, t, e, s) => {
-  for (var i = void 0, r = n.length - 1, o; r >= 0; r--)
-    (o = n[r]) && (i = o(t, e, i) || i);
-  return i && cs(t, e, i), i;
+var fi = Object.defineProperty, W = (n, t, e, i) => {
+  for (var s = void 0, r = n.length - 1, o; r >= 0; r--)
+    (o = n[r]) && (s = o(t, e, s) || s);
+  return s && fi(t, e, s), s;
 };
-const oe = class oe extends M {
+const de = class de extends P {
   constructor() {
     super(...arguments), this._optimisticProfile = null, this._isUpdating = !1, this._isLoading = !0, this._loadingMessage = "Connecting...";
   }
@@ -2419,7 +2419,7 @@ const oe = class oe extends M {
     super.firstUpdated(t), this._loadCentralizedData();
   }
   async _loadCentralizedData() {
-    this.hass && await L.pollConfig(
+    this.hass && await R.pollConfig(
       this.hass,
       (t, e) => {
         this._loadingMessage = t, this._isLoading = e;
@@ -2429,10 +2429,10 @@ const oe = class oe extends M {
   _discoverEntity() {
     if (this.hass)
       return Object.keys(this.hass.states).find((t) => {
-        var i;
+        var s;
         if (!t.startsWith("select.")) return !1;
-        const s = ((i = this.hass.states[t].attributes.friendly_name) == null ? void 0 : i.toLowerCase()) || "";
-        return t.includes("content_filter") || s.includes("content filter") || t.includes("meraki");
+        const i = ((s = this.hass.states[t].attributes.friendly_name) == null ? void 0 : s.toLowerCase()) || "";
+        return t.includes("content_filter") || i.includes("content filter") || t.includes("meraki");
       });
   }
   static getStubConfig() {
@@ -2445,14 +2445,14 @@ const oe = class oe extends M {
     var l, d, h;
     if (!this.hass || !this._config) return b``;
     if (this._isLoading)
-      return Mt(
+      return $t(
         ((l = this._config) == null ? void 0 : l.name) || "Cisco Meraki Content Filter",
         this._loadingMessage,
         "2.3.0-beta.3530"
       );
-    const t = this._config.entity || this._discoverEntity(), e = t ? this.hass.states[t] : void 0, s = this._config.entity ? this.hass.states[this._config.entity] : void 0, i = ((d = s == null ? void 0 : s.attributes) == null ? void 0 : d.friendly_name) || "Cisco Meraki", r = this._config.name || (this._config.entity ? `${i} Content Filter` : "Cisco Meraki Content Filter");
+    const t = this._config.entity || this._discoverEntity(), e = t ? this.hass.states[t] : void 0, i = this._config.entity ? this.hass.states[this._config.entity] : void 0, s = ((d = i == null ? void 0 : i.attributes) == null ? void 0 : d.friendly_name) || "Cisco Meraki", r = this._config.name || (this._config.entity ? `${s} Content Filter` : "Cisco Meraki Content Filter");
     if (!t || !e)
-      return De(
+      return ne(
         "Entity Missing",
         "No content filter entity was found. Please check your configuration.",
         "2.3.0-beta.3530"
@@ -2490,15 +2490,15 @@ const oe = class oe extends M {
         }), setTimeout(() => {
           this._optimisticProfile = null, this._isUpdating = !1;
         }, 8e3);
-      } catch (s) {
-        console.error("Failed to call select_option service:", s), this._optimisticProfile = null, this._isUpdating = !1;
+      } catch (i) {
+        console.error("Failed to call select_option service:", i), this._optimisticProfile = null, this._isUpdating = !1;
       }
     }
   }
 };
-oe.styles = [
-  It,
-  F`
+de.styles = [
+  At,
+  D`
       :host { display: block; }
       ha-card {
         height: 100%;
@@ -2550,26 +2550,26 @@ oe.styles = [
       }
     `
 ];
-let U = oe;
+let H = de;
 W([
-  z({ attribute: !1 })
-], U.prototype, "hass");
+  L({ attribute: !1 })
+], H.prototype, "hass");
 W([
-  v()
-], U.prototype, "_config");
+  y()
+], H.prototype, "_config");
 W([
-  v()
-], U.prototype, "_optimisticProfile");
+  y()
+], H.prototype, "_optimisticProfile");
 W([
-  v()
-], U.prototype, "_isUpdating");
+  y()
+], H.prototype, "_isUpdating");
 W([
-  v()
-], U.prototype, "_isLoading");
+  y()
+], H.prototype, "_isLoading");
 W([
-  v()
-], U.prototype, "_loadingMessage");
-const ae = class ae extends M {
+  y()
+], H.prototype, "_loadingMessage");
+const he = class he extends P {
   constructor() {
     super(...arguments), this._schema = [
       {
@@ -2608,18 +2608,18 @@ const ae = class ae extends M {
     }));
   }
 };
-ae.styles = F`
+he.styles = D`
     .editor-container { padding: 16px; }
   `;
-let _t = ae;
+let wt = he;
 W([
-  z({ attribute: !1 })
-], _t.prototype, "hass");
+  L({ attribute: !1 })
+], wt.prototype, "hass");
 W([
-  v()
-], _t.prototype, "_config");
-customElements.get("meraki-content-filter-card") || customElements.define("meraki-content-filter-card", U);
-customElements.get("meraki-content-filter-card-editor") || customElements.define("meraki-content-filter-card-editor", _t);
+  y()
+], wt.prototype, "_config");
+customElements.get("meraki-content-filter-card") || customElements.define("meraki-content-filter-card", H);
+customElements.get("meraki-content-filter-card-editor") || customElements.define("meraki-content-filter-card-editor", wt);
 window.customCards = window.customCards || [];
 window.customCards.some((n) => n.type === "meraki-content-filter-card") || window.customCards.push({
   type: "meraki-content-filter-card",
@@ -2627,12 +2627,12 @@ window.customCards.some((n) => n.type === "meraki-content-filter-card") || windo
   description: "Control Cisco Meraki Content Filtering profiles.",
   preview: !0
 });
-var ls = Object.defineProperty, I = (n, t, e, s) => {
-  for (var i = void 0, r = n.length - 1, o; r >= 0; r--)
-    (o = n[r]) && (i = o(t, e, i) || i);
-  return i && ls(t, e, i), i;
+var gi = Object.defineProperty, T = (n, t, e, i) => {
+  for (var s = void 0, r = n.length - 1, o; r >= 0; r--)
+    (o = n[r]) && (s = o(t, e, s) || s);
+  return s && gi(t, e, s), s;
 };
-const ce = class ce extends M {
+const ue = class ue extends P {
   constructor() {
     super(...arguments), this._networks = [], this._ssids = [], this._isLoading = !0, this._loadingMessage = "Connecting...", this._computeLabel = (t) => t.name === "networkId" ? "Network (Optional filter)" : t.name === "ssid" ? "SSID (Required)" : t.name === "password" ? "Password (Optional override or Entity ID)" : t.name === "name" ? "Card Title (Optional)" : t.name;
   }
@@ -2644,20 +2644,20 @@ const ce = class ce extends M {
   }
   async _loadCentralizedData() {
     if (!this.hass) return;
-    const { networks: t, ssids: e } = await L.pollConfig(
+    const { networks: t, ssids: e } = await R.pollConfig(
       this.hass,
-      (s, i) => {
-        this._loadingMessage = s, this._isLoading = i;
+      (i, s) => {
+        this._loadingMessage = i, this._isLoading = s;
       }
     );
     this._networks = t, this._ssids = e;
   }
   _valueChanged(t) {
     if (!this._config) return;
-    const e = t.detail.value, s = { ...this._config, ...e };
-    this._config.networkId !== e.networkId && (s.ssid = ""), Object.keys(s).forEach((i) => {
-      s[i] === "" && delete s[i];
-    }), this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: s }, bubbles: !0, composed: !0 }));
+    const e = t.detail.value, i = { ...this._config, ...e };
+    this._config.networkId !== e.networkId && (i.ssid = ""), Object.keys(i).forEach((s) => {
+      i[s] === "" && delete i[s];
+    }), this.dispatchEvent(new CustomEvent("config-changed", { detail: { config: i }, bubbles: !0, composed: !0 }));
   }
   render() {
     if (!this.hass || !this._config) return b``;
@@ -2670,7 +2670,7 @@ const ce = class ce extends M {
           </div>
         </div>
       `;
-    const t = L.getNetworkOptions(this._networks, !0), e = L.getSsidOptions(this._ssids, this._config.networkId, "name"), s = [
+    const t = R.getNetworkOptions(this._networks, !0), e = R.getSsidOptions(this._ssids, this._config.networkId, "name"), i = [
       { name: "networkId", selector: { select: { options: t, mode: "dropdown" } } },
       { name: "ssid", selector: { select: { options: e, custom_value: !0, mode: "dropdown" } } },
       { name: "password", selector: { text: {} } },
@@ -2681,7 +2681,7 @@ const ce = class ce extends M {
         <ha-form
           .hass=${this.hass}
           .data=${this._config}
-          .schema=${s}
+          .schema=${i}
           .computeLabel=${this._computeLabel}
           @value-changed=${this._valueChanged}
         ></ha-form>
@@ -2689,27 +2689,27 @@ const ce = class ce extends M {
     `;
   }
 };
-ce.styles = F`.editor-container { padding: 16px; }`;
-let O = ce;
-I([
-  z({ attribute: !1 })
-], O.prototype, "hass");
-I([
-  v()
-], O.prototype, "_config");
-I([
-  v()
-], O.prototype, "_networks");
-I([
-  v()
-], O.prototype, "_ssids");
-I([
-  v()
-], O.prototype, "_isLoading");
-I([
-  v()
-], O.prototype, "_loadingMessage");
-const le = class le extends M {
+ue.styles = D`.editor-container { padding: 16px; }`;
+let z = ue;
+T([
+  L({ attribute: !1 })
+], z.prototype, "hass");
+T([
+  y()
+], z.prototype, "_config");
+T([
+  y()
+], z.prototype, "_networks");
+T([
+  y()
+], z.prototype, "_ssids");
+T([
+  y()
+], z.prototype, "_isLoading");
+T([
+  y()
+], z.prototype, "_loadingMessage");
+const fe = class fe extends P {
   constructor() {
     super(...arguments), this._qrSvg = "", this._isLoading = !0, this._loadingMessage = "Connecting...", this._ssids = [];
   }
@@ -2732,10 +2732,10 @@ const le = class le extends M {
   }
   async _loadCentralizedData() {
     if (!this.hass) return;
-    const { ssids: t } = await L.pollConfig(
+    const { ssids: t } = await R.pollConfig(
       this.hass,
-      (e, s) => {
-        this._loadingMessage = e, this._isLoading = s;
+      (e, i) => {
+        this._loadingMessage = e, this._isLoading = i;
       }
     );
     this._ssids = t, this._generateQR();
@@ -2745,7 +2745,7 @@ const le = class le extends M {
   }
   async _generateQR() {
     if (!this._config) return;
-    const t = T.getValue(this.hass, this._config.ssid), e = T.getPasswordForSsid(
+    const t = M.getValue(this.hass, this._config.ssid), e = M.getPasswordForSsid(
       this.hass,
       this._ssids,
       t,
@@ -2756,19 +2756,19 @@ const le = class le extends M {
       this._qrSvg = "";
       return;
     }
-    const s = T.generateWifiQrString(t, e);
-    this._qrSvg = await T.generateQrSvg(s, 2);
+    const i = M.generateWifiQrString(t, e);
+    this._qrSvg = await M.generateQrSvg(i, 2);
   }
   render() {
-    var s;
+    var i;
     if (!this._config || !this.hass) return b``;
     if (this._isLoading)
-      return Mt(
-        ((s = this._config) == null ? void 0 : s.name) || "Wi-Fi Access",
+      return $t(
+        ((i = this._config) == null ? void 0 : i.name) || "Wi-Fi Access",
         this._loadingMessage,
         "2.3.0-beta.3530"
       );
-    const t = T.getValue(this.hass, this._config.ssid), e = T.getPasswordForSsid(
+    const t = M.getValue(this.hass, this._config.ssid), e = M.getPasswordForSsid(
       this.hass,
       this._ssids,
       t,
@@ -2787,36 +2787,36 @@ const le = class le extends M {
     `;
   }
 };
-le.styles = [
-  It,
-  F`
+fe.styles = [
+  At,
+  D`
       :host { display: block; }
       .card-content { padding: 16px; gap: 16px; }
       .ssid-display { font-size: 1.5em; font-weight: bold; color: var(--primary-text-color); text-align: center; }
       .password-display { color: var(--secondary-text-color); text-align: center; }
     `
 ];
-let H = le;
-I([
-  z({ attribute: !1 })
-], H.prototype, "hass");
-I([
-  v()
-], H.prototype, "_config");
-I([
-  v()
-], H.prototype, "_qrSvg");
-I([
-  v()
-], H.prototype, "_isLoading");
-I([
-  v()
-], H.prototype, "_loadingMessage");
-I([
-  v()
-], H.prototype, "_ssids");
-customElements.get("meraki-wifi-qr-card") || customElements.define("meraki-wifi-qr-card", H);
-customElements.get("meraki-wifi-qr-card-editor") || customElements.define("meraki-wifi-qr-card-editor", O);
+let F = fe;
+T([
+  L({ attribute: !1 })
+], F.prototype, "hass");
+T([
+  y()
+], F.prototype, "_config");
+T([
+  y()
+], F.prototype, "_qrSvg");
+T([
+  y()
+], F.prototype, "_isLoading");
+T([
+  y()
+], F.prototype, "_loadingMessage");
+T([
+  y()
+], F.prototype, "_ssids");
+customElements.get("meraki-wifi-qr-card") || customElements.define("meraki-wifi-qr-card", F);
+customElements.get("meraki-wifi-qr-card-editor") || customElements.define("meraki-wifi-qr-card-editor", z);
 window.customCards = window.customCards || [];
 window.customCards.some((n) => n.type === "meraki-wifi-qr-card") || window.customCards.push({
   type: "meraki-wifi-qr-card",
@@ -2824,12 +2824,12 @@ window.customCards.some((n) => n.type === "meraki-wifi-qr-card") || window.custo
   description: "Display a scannable Wi-Fi QR code for guests.",
   preview: !0
 });
-var ds = Object.defineProperty, at = (n, t, e, s) => {
-  for (var i = void 0, r = n.length - 1, o; r >= 0; r--)
-    (o = n[r]) && (i = o(t, e, i) || i);
-  return i && ds(t, e, i), i;
+var pi = Object.defineProperty, ct = (n, t, e, i) => {
+  for (var s = void 0, r = n.length - 1, o; r >= 0; r--)
+    (o = n[r]) && (s = o(t, e, s) || s);
+  return s && pi(t, e, s), s;
 };
-const de = class de extends M {
+const ge = class ge extends P {
   constructor() {
     super(...arguments), this._isLoading = !0, this._loadingMessage = "Connecting...";
   }
@@ -2850,7 +2850,7 @@ const de = class de extends M {
     super.firstUpdated(t), this._loadCentralizedData();
   }
   async _loadCentralizedData() {
-    this.hass && await L.pollConfig(
+    this.hass && await R.pollConfig(
       this.hass,
       (t, e) => {
         this._loadingMessage = t, this._isLoading = e;
@@ -2872,23 +2872,23 @@ const de = class de extends M {
   _handleEntityClick(t, e) {
     if (!(!t || !e))
       if (e.action === "navigate" && e.navigation_path) {
-        const s = new CustomEvent("navigate", {
+        const i = new CustomEvent("navigate", {
           detail: { path: e.navigation_path },
           bubbles: !0,
           composed: !0
         });
-        this.dispatchEvent(s);
+        this.dispatchEvent(i);
       } else {
-        const s = new CustomEvent("hass-more-info", {
+        const i = new CustomEvent("hass-more-info", {
           detail: { entityId: t },
           bubbles: !0,
           composed: !0
         });
-        this.dispatchEvent(s);
+        this.dispatchEvent(i);
       }
   }
-  _renderStatusDot(t, e, s) {
-    const i = !!t && !!this.hass.states[t];
+  _renderStatusDot(t, e, i) {
+    const s = !!t && !!this.hass.states[t];
     if (!t || !this.hass.states[t])
       return b`
         <div class="status-item">
@@ -2907,10 +2907,10 @@ const de = class de extends M {
     let a = "var(--disabled-text-color)";
     return o === "ok" || o === "online" || o === "connected" ? a = "var(--success-color)" : o === "warning" ? a = "var(--warning-color)" : (o === "error" || o === "offline" || o === "failed") && (a = "var(--error-color)"), b`
       <div
-        class="status-item ${i ? "clickable" : ""}"
-        @click="${() => i ? this._handleEntityClick(t, s) : null}"
-        role="${i ? "button" : "presentation"}"
-        tabindex="${i ? "0" : "-1"}"
+        class="status-item ${s ? "clickable" : ""}"
+        @click="${() => s ? this._handleEntityClick(t, i) : null}"
+        role="${s ? "button" : "presentation"}"
+        tabindex="${s ? "0" : "-1"}"
       >
         <ha-state-icon
           .hass=${this.hass}
@@ -2925,12 +2925,12 @@ const de = class de extends M {
     `;
   }
   render() {
-    var i, r;
+    var s, r;
     if (!this._config || !this.hass)
       return b``;
     if (this._isLoading)
-      return Mt(
-        ((i = this._config) == null ? void 0 : i.name) || "Cisco Meraki Network Vitals",
+      return $t(
+        ((s = this._config) == null ? void 0 : s.name) || "Cisco Meraki Network Vitals",
         this._loadingMessage,
         "2.3.0-beta.3530"
       );
@@ -2939,7 +2939,7 @@ const de = class de extends M {
       "MERAKI CARD DIAGNOSTIC - Throughput Raw Entity State:",
       this.hass.states[t]
     );
-    const e = t ? this.hass.states[t] : void 0, s = e ? (e.state || "0") + " " + (((r = e.attributes) == null ? void 0 : r.unit_of_measurement) || "") : "N/A";
+    const e = t ? this.hass.states[t] : void 0, i = e ? (e.state || "0") + " " + (((r = e.attributes) == null ? void 0 : r.unit_of_measurement) || "") : "N/A";
     return b`
       <ha-card>
         <div class="card-content">
@@ -2963,7 +2963,7 @@ const de = class de extends M {
             </div>
             <div class="throughput-container">
               <ha-icon icon="mdi:swap-vertical"></ha-icon>
-              <span class="throughput-value">${s}</span>
+              <span class="throughput-value">${i}</span>
             </div>
           </div>
         </div>
@@ -2972,9 +2972,9 @@ const de = class de extends M {
     `;
   }
 };
-de.styles = [
-  It,
-  F`
+ge.styles = [
+  At,
+  D`
       :host {
         display: block;
       }
@@ -3031,25 +3031,25 @@ de.styles = [
       }
     `
 ];
-let X = de;
-at([
-  z({ attribute: !1 })
+let X = ge;
+ct([
+  L({ attribute: !1 })
 ], X.prototype, "hass");
-at([
-  v()
+ct([
+  y()
 ], X.prototype, "_config");
-at([
-  v()
+ct([
+  y()
 ], X.prototype, "_isLoading");
-at([
-  v()
+ct([
+  y()
 ], X.prototype, "_loadingMessage");
-const he = class he extends M {
+const pe = class pe extends P {
   setConfig(t) {
     this._config = t;
   }
   render() {
-    var t, e, s;
+    var t, e, i;
     return !this.hass || !this._config ? b`` : b`
       <div class="card-config">
         <ha-textfield
@@ -3100,7 +3100,7 @@ const he = class he extends M {
         ></ha-textfield>
         <ha-textfield
           label="AP Tap Action"
-          .value=${((s = this._config.ap_tap_action) == null ? void 0 : s.action) || "more-info"}
+          .value=${((i = this._config.ap_tap_action) == null ? void 0 : i.action) || "more-info"}
           .configValue=${"ap_tap_action"}
           @input=${this._valueChanged}
         ></ha-textfield>
@@ -3110,10 +3110,10 @@ const he = class he extends M {
   _valueChanged(t) {
     var o;
     if (!this._config) return;
-    const e = t.target, s = e.configValue;
-    let i = ((o = t.detail) == null ? void 0 : o.value) ?? e.value;
-    s && s.endsWith("_tap_action") && (i.startsWith("/") ? i = { action: "navigate", navigation_path: i } : i = { action: i });
-    const r = { ...this._config, [s]: i };
+    const e = t.target, i = e.configValue;
+    let s = ((o = t.detail) == null ? void 0 : o.value) ?? e.value;
+    i && i.endsWith("_tap_action") && (s.startsWith("/") ? s = { action: "navigate", navigation_path: s } : s = { action: s });
+    const r = { ...this._config, [i]: s };
     this.dispatchEvent(
       new CustomEvent("config-changed", {
         detail: { config: r },
@@ -3123,7 +3123,7 @@ const he = class he extends M {
     );
   }
 };
-he.styles = F`
+pe.styles = D`
     ha-textfield,
     ha-entity-picker {
       display: block;
@@ -3131,17 +3131,17 @@ he.styles = F`
       width: 100%;
     }
   `;
-let yt = he;
-at([
-  z({ attribute: !1 })
-], yt.prototype, "hass");
-at([
-  v()
-], yt.prototype, "_config");
+let vt = pe;
+ct([
+  L({ attribute: !1 })
+], vt.prototype, "hass");
+ct([
+  y()
+], vt.prototype, "_config");
 customElements.get("meraki-network-vitals-card") || customElements.define("meraki-network-vitals-card", X);
 customElements.get("meraki-network-vitals-card-editor") || customElements.define(
   "meraki-network-vitals-card-editor",
-  yt
+  vt
 );
 window.customCards = window.customCards || [];
 window.customCards.some(
@@ -3152,12 +3152,244 @@ window.customCards.some(
   description: "Compact horizontal health header.",
   preview: !0
 });
-var hs = Object.defineProperty, Ze = (n, t, e, s) => {
-  for (var i = void 0, r = n.length - 1, o; r >= 0; r--)
-    (o = n[r]) && (i = o(t, e, i) || i);
-  return i && hs(t, e, i), i;
+var mi = Object.defineProperty, lt = (n, t, e, i) => {
+  for (var s = void 0, r = n.length - 1, o; r >= 0; r--)
+    (o = n[r]) && (s = o(t, e, s) || s);
+  return s && mi(t, e, s), s;
 };
-const ue = class ue extends M {
+const me = class me extends P {
+  constructor() {
+    super(...arguments), this._isLoading = !0, this._loadingMessage = "Connecting...";
+  }
+  static async getConfigElement() {
+    return document.createElement("meraki-vlan-card-editor");
+  }
+  setConfig(t) {
+    if (!t)
+      throw new Error("Invalid configuration");
+    this._config = { ...t };
+  }
+  firstUpdated(t) {
+    super.firstUpdated(t), this._loadCentralizedData();
+  }
+  async _loadCentralizedData() {
+    this.hass && await R.pollConfig(
+      this.hass,
+      (t, e) => {
+        this._loadingMessage = t, this._isLoading = e;
+      }
+    );
+  }
+  static getStubConfig() {
+    return {
+      name: "Meraki VLANs"
+    };
+  }
+  _getVlanEntities() {
+    return this.hass ? Object.keys(this.hass.states).filter((t) => {
+      if (!t.startsWith("switch.")) return !1;
+      const e = this.hass.states[t];
+      return e.attributes.vlan_id !== void 0 && e.attributes.subnet !== void 0;
+    }).map((t) => {
+      var i;
+      const e = this.hass.states[t];
+      return {
+        entity_id: t,
+        name: e.attributes.vlan_name || ((i = e.attributes.friendly_name) == null ? void 0 : i.replace(" DHCP", "")) || "Unknown VLAN",
+        subnet: e.attributes.subnet,
+        gateway: e.attributes.gateway,
+        state: e.state
+      };
+    }).sort((t, e) => t.name.localeCompare(e.name)) : [];
+  }
+  render() {
+    var e;
+    if (!this.hass || !this._config) return b``;
+    if (this._isLoading)
+      return $t(
+        ((e = this._config) == null ? void 0 : e.name) || "Cisco Meraki VLANs",
+        this._loadingMessage,
+        "2.3.0-beta.3530"
+      );
+    const t = this._getVlanEntities();
+    return t.length === 0 ? ne(
+      "No VLANs Found",
+      "No Meraki VLAN DHCP switches were found. Ensure VLAN management is enabled in the integration options.",
+      "2.3.0-beta.3530"
+    ) : b`
+      <ha-card .header="${this._config.name || "Cisco Meraki VLANs"}">
+        <div class="card-content">
+          <div class="vlan-table">
+            <div class="table-header">
+              <div class="col-vlan">VLAN</div>
+              <div class="col-network">Subnet / Gateway</div>
+              <div class="col-dhcp">DHCP</div>
+            </div>
+            ${t.map((i) => b`
+              <div class="table-row">
+                <div class="col-vlan">
+                  <span class="vlan-name">${i.name}</span>
+                </div>
+                <div class="col-network">
+                  <div class="subnet">${i.subnet}</div>
+                  <div class="gateway">${i.gateway}</div>
+                </div>
+                <div class="col-dhcp">
+                  <ha-switch
+                    .checked=${i.state === "on"}
+                    @change=${() => this._toggleDhcp(i.entity_id)}
+                  ></ha-switch>
+                </div>
+              </div>
+            `)}
+          </div>
+        </div>
+        <div class="version">v${"2.3.0-beta.3530"}</div>
+      </ha-card>
+    `;
+  }
+  async _toggleDhcp(t) {
+    if (this.hass)
+      try {
+        await this.hass.callService("switch", "toggle", {
+          entity_id: t
+        });
+      } catch (e) {
+        console.error("Failed to toggle DHCP switch:", e);
+      }
+  }
+};
+me.styles = [
+  At,
+  D`
+      :host { display: block; }
+      .card-content { padding: 0 16px 16px 16px; }
+
+      .vlan-table {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+      }
+
+      .table-header {
+        display: flex;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--divider-color);
+        font-weight: bold;
+        color: var(--secondary-text-color);
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      .table-row {
+        display: flex;
+        align-items: center;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--divider-color);
+      }
+
+      .table-row:last-child {
+        border-bottom: none;
+      }
+
+      .col-vlan { flex: 2; display: flex; align-items: center; }
+      .col-network { flex: 3; }
+      .col-dhcp { flex: 1; display: flex; justify-content: flex-end; }
+
+      .vlan-name {
+        font-weight: 500;
+        color: var(--primary-text-color);
+      }
+
+      .subnet {
+        font-size: 14px;
+        color: var(--primary-text-color);
+      }
+
+      .gateway {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+
+      ha-switch {
+        --switch-checked-button-color: var(--success-color, #4caf50);
+        --switch-checked-track-color: var(--success-color, #4caf50);
+      }
+    `
+];
+let tt = me;
+lt([
+  L({ attribute: !1 })
+], tt.prototype, "hass");
+lt([
+  y()
+], tt.prototype, "_config");
+lt([
+  y()
+], tt.prototype, "_isLoading");
+lt([
+  y()
+], tt.prototype, "_loadingMessage");
+const _e = class _e extends P {
+  constructor() {
+    super(...arguments), this._schema = [
+      {
+        name: "name",
+        selector: { text: {} }
+      }
+    ], this._computeLabel = (t) => t.name === "name" ? "Display Name (Optional)" : t.name;
+  }
+  setConfig(t) {
+    this._config = t;
+  }
+  render() {
+    return !this.hass || !this._config ? b`` : b`
+      <div class="editor-container">
+        <ha-form
+          .hass=${this.hass}
+          .data=${this._config}
+          .schema=${this._schema}
+          .computeLabel=${this._computeLabel}
+          @value-changed=${this._valueChanged}
+        ></ha-form>
+      </div>
+    `;
+  }
+  _valueChanged(t) {
+    if (!this._config) return;
+    const e = { ...this._config, ...t.detail.value };
+    this.dispatchEvent(new CustomEvent("config-changed", {
+      detail: { config: e },
+      bubbles: !0,
+      composed: !0
+    }));
+  }
+};
+_e.styles = D`
+    .editor-container { padding: 16px; }
+  `;
+let bt = _e;
+lt([
+  L({ attribute: !1 })
+], bt.prototype, "hass");
+lt([
+  y()
+], bt.prototype, "_config");
+customElements.get("meraki-vlan-card") || customElements.define("meraki-vlan-card", tt);
+customElements.get("meraki-vlan-card-editor") || customElements.define("meraki-vlan-card-editor", bt);
+window.customCards = window.customCards || [];
+window.customCards.some((n) => n.type === "meraki-vlan-card") || window.customCards.push({
+  type: "meraki-vlan-card",
+  name: "Cisco Meraki VLAN Card",
+  description: "Overview and management of configured VLANs.",
+  preview: !0
+});
+var _i = Object.defineProperty, is = (n, t, e, i) => {
+  for (var s = void 0, r = n.length - 1, o; r >= 0; r--)
+    (o = n[r]) && (s = o(t, e, s) || s);
+  return s && _i(t, e, s), s;
+};
+const ye = class ye extends P {
   constructor() {
     super(...arguments), this._computeLabel = (t) => t.name === "name" ? "Title (Optional)" : t.name === "config_entry_id" ? "Config Entry ID (Optional override)" : t.name;
   }
@@ -3192,23 +3424,23 @@ const ue = class ue extends M {
     }));
   }
 };
-ue.styles = F`
+ye.styles = D`
     .editor-container { padding: 16px; }
   `;
-let wt = ue;
-Ze([
-  z({ attribute: !1 })
-], wt.prototype, "hass");
-Ze([
-  v()
-], wt.prototype, "_config");
-customElements.get("meraki-guest-access-card-editor") || customElements.define("meraki-guest-access-card-editor", wt);
-var us = Object.defineProperty, N = (n, t, e, s) => {
-  for (var i = void 0, r = n.length - 1, o; r >= 0; r--)
-    (o = n[r]) && (i = o(t, e, i) || i);
-  return i && us(t, e, i), i;
+let Et = ye;
+is([
+  L({ attribute: !1 })
+], Et.prototype, "hass");
+is([
+  y()
+], Et.prototype, "_config");
+customElements.get("meraki-guest-access-card-editor") || customElements.define("meraki-guest-access-card-editor", Et);
+var yi = Object.defineProperty, x = (n, t, e, i) => {
+  for (var s = void 0, r = n.length - 1, o; r >= 0; r--)
+    (o = n[r]) && (s = o(t, e, s) || s);
+  return s && yi(t, e, s), s;
 };
-const fe = class fe extends M {
+const we = class we extends P {
   constructor() {
     super(...arguments), this._formData = {
       network: "",
@@ -3234,27 +3466,27 @@ const fe = class fe extends M {
     super.updated(t), t.has("hass") && this.hass && ((e = this.hass.user) != null && e.name) && !this._formData.guestName && (this._formData = { ...this._formData, guestName: this._generateUniqueGuestName() });
   }
   _generateUniqueGuestName() {
-    var s, i;
-    const t = ((i = (s = this.hass) == null ? void 0 : s.user) == null ? void 0 : i.name) || "Home Assistant", e = Math.floor(Math.random() * 1e4).toString().padStart(4, "0");
+    var i, s;
+    const t = ((s = (i = this.hass) == null ? void 0 : i.user) == null ? void 0 : s.name) || "Home Assistant", e = Math.floor(Math.random() * 1e4).toString().padStart(4, "0");
     return `${t} - Guest ${e}`;
   }
   async _loadCentralizedData() {
     var l;
     if (!this.hass) return;
-    const { networks: t, ssids: e, groupPolicies: s, entryId: i } = await L.pollConfig(this.hass, (d, h) => {
+    const { networks: t, ssids: e, groupPolicies: i, entryId: s } = await R.pollConfig(this.hass, (d, h) => {
       this._loadingMessage = d, this._isLoading = h;
     });
     if (t.length === 0) {
       this._isLoading = !1;
       return;
     }
-    this._networks = t, this._ssids = e, this._policies = s, this._configEntryId = ((l = this._config) == null ? void 0 : l.config_entry_id) || i;
+    this._networks = t, this._ssids = e, this._policies = i, this._configEntryId = ((l = this._config) == null ? void 0 : l.config_entry_id) || s;
     let r = this._formData.network, o = this._formData.ssid, a = this._formData.passphrase, c = this._formData.policy;
     if (t.length > 0 && !r && (r = t[0].id), r && !o) {
       const d = e.filter((h) => h.networkId === r);
       d.length > 0 && (o = String(d[0].number));
     }
-    if (r && o && !a && (a = T.getPasswordForSsid(this.hass, this._ssids, o, r), a || (a = T.generateNaturalPassword())), r && !c) {
+    if (r && o && !a && (a = M.getPasswordForSsid(this.hass, this._ssids, o, r), a || (a = M.generateNaturalPassword())), r && !c) {
       const d = this._policies.filter(
         (h) => h.networkId === r
       );
@@ -3271,52 +3503,52 @@ const fe = class fe extends M {
     }, this._isLoading = !1;
   }
   _formValueChanged(t) {
-    const e = t.detail.value, s = this._formData.network;
-    let i = { ...this._formData, ...e };
-    if (i.network !== s) {
-      i.ssid = "", i.passphrase = "", i.policy = "";
+    const e = t.detail.value, i = this._formData.network;
+    let s = { ...this._formData, ...e };
+    if (s.network !== i) {
+      s.ssid = "", s.passphrase = "", s.policy = "";
       const r = this._ssids.filter(
-        (a) => a.networkId === i.network
+        (a) => a.networkId === s.network
       );
-      r.length > 0 && (i.ssid = String(r[0].number));
+      r.length > 0 && (s.ssid = String(r[0].number));
       const o = this._policies.filter(
-        (a) => a.networkId === i.network
+        (a) => a.networkId === s.network
       );
-      o.length > 0 && (i.policy = String(
+      o.length > 0 && (s.policy = String(
         o[0].groupPolicyId || o[0].id
       ));
     }
-    !i.passphrase && i.network && i.ssid && (i.passphrase = T.getPasswordForSsid(
+    !s.passphrase && s.network && s.ssid && (s.passphrase = M.getPasswordForSsid(
       this.hass,
       this._ssids,
-      i.ssid,
-      i.network
-    ) || T.generateNaturalPassword()), this._formData = i;
+      s.ssid,
+      s.network
+    ) || M.generateNaturalPassword()), this._formData = s;
   }
   render() {
     var o, a, c;
     if (this._isLoading)
-      return Mt(
+      return $t(
         ((o = this._config) == null ? void 0 : o.name) || "Cisco Meraki Guest Access",
         this._loadingMessage,
         "2.3.0-beta.3530"
       );
     if (this._networks.length === 0)
-      return De(
+      return ne(
         "No Wireless Networks",
         "No Cisco Meraki wireless networks found. Ensure the integration is configured.",
         "2.3.0-beta.3530"
       );
-    const t = L.getNetworkOptions(
+    const t = R.getNetworkOptions(
       this._networks
-    ), e = L.getSsidOptions(
+    ), e = R.getSsidOptions(
       this._ssids,
       this._formData.network,
       "number"
-    ), s = this._policies.filter((l) => l.networkId === this._formData.network).map((l) => ({
+    ), i = this._policies.filter((l) => l.networkId === this._formData.network).map((l) => ({
       value: String(l.groupPolicyId || l.id),
       label: l.name
-    })), i = [
+    })), s = [
       {
         name: "network",
         selector: { select: { options: t, mode: "dropdown" } }
@@ -3325,11 +3557,11 @@ const fe = class fe extends M {
         name: "ssid",
         selector: { select: { options: e, mode: "dropdown" } }
       },
-      ...s.length > 0 ? [
+      ...i.length > 0 ? [
         {
           name: "policy",
           selector: {
-            select: { options: s, mode: "dropdown" }
+            select: { options: i, mode: "dropdown" }
           }
         }
       ] : [],
@@ -3408,7 +3640,7 @@ const fe = class fe extends M {
             <ha-form
               .hass=${this.hass}
               .data=${this._formData}
-              .schema=${i}
+              .schema=${s}
               .computeLabel=${this._computeLabel}
               @value-changed=${this._formValueChanged}
             ></ha-form>
@@ -3450,10 +3682,10 @@ const fe = class fe extends M {
           "generate_guest_access",
           t
         );
-        const e = parseInt(this._formData.ssid, 10), s = this._ssids.find(
+        const e = parseInt(this._formData.ssid, 10), i = this._ssids.find(
           (a) => a.networkId === this._formData.network && a.number === e
-        ), i = s ? s.name : "Guest WiFi", r = this._formData.passphrase, o = T.generateWifiQrString(i, r);
-        this._qrSvg = await T.generateQrSvg(o), this._success = "Guest access key created successfully!";
+        ), s = i ? i.name : "Guest WiFi", r = this._formData.passphrase, o = M.generateWifiQrString(s, r);
+        this._qrSvg = await M.generateQrSvg(o), this._success = "Guest access key created successfully!";
       } catch (t) {
         this._error = `Failed to create guest key: ${t.message || t}`;
       } finally {
@@ -3462,9 +3694,9 @@ const fe = class fe extends M {
     }
   }
 };
-fe.styles = [
-  It,
-  F`
+we.styles = [
+  At,
+  D`
       .form-container {
         display: flex;
         flex-direction: column;
@@ -3504,47 +3736,47 @@ fe.styles = [
       }
     `
 ];
-let k = fe;
-N([
-  z({ attribute: !1 })
-], k.prototype, "hass");
-N([
-  v()
-], k.prototype, "_config");
-N([
-  v()
-], k.prototype, "_formData");
-N([
-  v()
-], k.prototype, "_networks");
-N([
-  v()
-], k.prototype, "_ssids");
-N([
-  v()
-], k.prototype, "_policies");
-N([
-  v()
-], k.prototype, "_creating");
-N([
-  v()
-], k.prototype, "_error");
-N([
-  v()
-], k.prototype, "_success");
-N([
-  v()
-], k.prototype, "_qrSvg");
-N([
-  v()
-], k.prototype, "_isLoading");
-N([
-  v()
-], k.prototype, "_loadingMessage");
-N([
-  v()
-], k.prototype, "_configEntryId");
-customElements.get("meraki-guest-access-card") || customElements.define("meraki-guest-access-card", k);
+let S = we;
+x([
+  L({ attribute: !1 })
+], S.prototype, "hass");
+x([
+  y()
+], S.prototype, "_config");
+x([
+  y()
+], S.prototype, "_formData");
+x([
+  y()
+], S.prototype, "_networks");
+x([
+  y()
+], S.prototype, "_ssids");
+x([
+  y()
+], S.prototype, "_policies");
+x([
+  y()
+], S.prototype, "_creating");
+x([
+  y()
+], S.prototype, "_error");
+x([
+  y()
+], S.prototype, "_success");
+x([
+  y()
+], S.prototype, "_qrSvg");
+x([
+  y()
+], S.prototype, "_isLoading");
+x([
+  y()
+], S.prototype, "_loadingMessage");
+x([
+  y()
+], S.prototype, "_configEntryId");
+customElements.get("meraki-guest-access-card") || customElements.define("meraki-guest-access-card", S);
 window.customCards = window.customCards || [];
 window.customCards.some(
   (n) => n.type === "meraki-guest-access-card"
@@ -3556,5 +3788,5 @@ window.customCards.some(
   version: "2.3.0-beta.3530"
 });
 export {
-  k as MerakiGuestAccessCard
+  S as MerakiGuestAccessCard
 };

--- a/custom_components/meraki_ha/www/verify.html
+++ b/custom_components/meraki_ha/www/verify.html
@@ -21,10 +21,35 @@
             flex-direction: column;
             gap: 20px;
         }
+        ha-card {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            display: block;
+            padding: 16px;
+        }
+        .card-content {
+            padding: 16px;
+        }
     </style>
+    <script>
+        // Mock HA components
+        class MockElement extends HTMLElement {
+            constructor() { super(); }
+        }
+        customElements.define('ha-card', class extends MockElement {});
+        customElements.define('ha-switch', class extends MockElement {});
+        customElements.define('ha-icon', class extends MockElement {});
+        customElements.define('ha-circular-progress', class extends MockElement {});
+        customElements.define('ha-alert', class extends MockElement {});
+        customElements.define('ha-button', class extends MockElement {});
+    </script>
 </head>
 <body>
     <div class="container">
+        <h2>VLAN Card</h2>
+        <meraki-vlan-card id="vlan-card"></meraki-vlan-card>
+
         <h2>Content Filter Card</h2>
         <meraki-content-filter-card id="filter-card"></meraki-content-filter-card>
 
@@ -32,13 +57,6 @@
         <meraki-guest-access-card id="guest-card"></meraki-guest-access-card>
     </div>
     <script>
-        // Mocking Home Assistant's global components that might be used
-        // Since we are running in a bare browser environment for verification,
-        // some components like ha-card, ha-button, ha-select might not be defined.
-        // But the cards themselves are defined in meraki-card.js.
-        // In a real HA environment, these are provided by HA.
-        // For simple verification, we can see if the cards render their own parts.
-
         const hass = {
             states: {
                 "select.main_office_content_filter": {
@@ -46,6 +64,26 @@
                     attributes: {
                         friendly_name: "Main Office Content Filter",
                         options: ["None", "Security", "Family", "Strict"]
+                    }
+                },
+                "switch.guest_dhcp": {
+                    state: "on",
+                    attributes: {
+                        friendly_name: "Guest DHCP",
+                        vlan_id: "10",
+                        vlan_name: "Guest",
+                        subnet: "192.168.10.0/24",
+                        gateway: "192.168.10.1"
+                    }
+                },
+                "switch.staff_dhcp": {
+                    state: "off",
+                    attributes: {
+                        friendly_name: "Staff DHCP",
+                        vlan_id: "20",
+                        vlan_name: "Staff",
+                        subnet: "192.168.20.0/24",
+                        gateway: "192.168.20.1"
                     }
                 },
                 "sensor.wifi_ap": {
@@ -63,13 +101,17 @@
             user: { name: "Jules" },
             callWS: async (msg) => {
                 if (msg.type === 'config_entries/get') return [{ entry_id: 'test_entry' }];
-                if (msg.type === 'meraki_ha/timed_access/get_policies') return [];
+                if (msg.type === 'meraki_ha/get_config') return { networks: [{ id: 'N_123', name: 'Test Network', productTypes: ['wireless'] }], ssids: [], group_policies: {} };
                 return [];
             },
             callService: async (domain, service, data) => {
                 console.log(`Service Call: ${domain}.${service}`, data);
             }
         };
+
+        const vlanCard = document.getElementById('vlan-card');
+        vlanCard.hass = hass;
+        vlanCard.setConfig({ type: 'meraki-vlan-card', name: 'Meraki VLANs' });
 
         const filterCard = document.getElementById('filter-card');
         filterCard.hass = hass;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.3515",
+  "version": "2.3.0-beta.3530",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.3515",
+      "version": "2.3.0-beta.3530",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/src/meraki-guest-access-card.ts
+++ b/frontend/src/meraki-guest-access-card.ts
@@ -7,6 +7,7 @@ import { WifiHelpers } from './utils/wifi-helpers';
 import './meraki-content-filter-card';
 import './meraki-wifi-qr-card';
 import './meraki-network-vitals-card';
+import './meraki-vlan-card';
 import './meraki-guest-access-card-editor';
 import { Network, SSID } from './types/meraki';
 

--- a/frontend/src/meraki-vlan-card.ts
+++ b/frontend/src/meraki-vlan-card.ts
@@ -1,0 +1,269 @@
+import { LitElement, html, css, PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { HomeAssistant } from './types/ha';
+import { renderWarning, renderLoadingState, sharedStyles } from './shared-ui';
+import { MerakiDataProvider } from './utils/meraki-data';
+
+declare const __VERSION__: string;
+
+interface Config {
+  type: string;
+  name?: string;
+  [key: string]: any;
+}
+
+export class MerakiVlanCard extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() private _config?: Config;
+  @state() private _isLoading: boolean = true;
+  @state() private _loadingMessage: string = "Connecting...";
+
+  public static async getConfigElement() {
+    return document.createElement("meraki-vlan-card-editor");
+  }
+
+  public setConfig(config: Config): void {
+    if (!config) {
+      throw new Error('Invalid configuration');
+    }
+    this._config = { ...config };
+  }
+
+  protected firstUpdated(changedProperties: PropertyValues) {
+    super.firstUpdated(changedProperties);
+    this._loadCentralizedData();
+  }
+
+  private async _loadCentralizedData() {
+    if (!this.hass) return;
+
+    await MerakiDataProvider.pollConfig(
+      this.hass,
+      (msg, isLoading) => {
+        this._loadingMessage = msg;
+        this._isLoading = isLoading;
+      }
+    );
+  }
+
+  public static getStubConfig(): Record<string, unknown> {
+    return {
+      name: 'Meraki VLANs',
+    };
+  }
+
+  private _getVlanEntities() {
+    if (!this.hass) return [];
+
+    return Object.keys(this.hass.states)
+      .filter((entityId) => {
+        if (!entityId.startsWith('switch.')) return false;
+        const stateObj = this.hass.states[entityId];
+        return stateObj.attributes.vlan_id !== undefined && stateObj.attributes.subnet !== undefined;
+      })
+      .map((entityId) => {
+        const stateObj = this.hass.states[entityId];
+        return {
+          entity_id: entityId,
+          name: stateObj.attributes.vlan_name || stateObj.attributes.friendly_name?.replace(' DHCP', '') || 'Unknown VLAN',
+          subnet: stateObj.attributes.subnet,
+          gateway: stateObj.attributes.gateway,
+          state: stateObj.state,
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) return html``;
+
+    if (this._isLoading) {
+      return renderLoadingState(
+        this._config?.name || 'Cisco Meraki VLANs',
+        this._loadingMessage,
+        __VERSION__
+      );
+    }
+
+    const vlanEntities = this._getVlanEntities();
+
+    if (vlanEntities.length === 0) {
+      return renderWarning(
+        "No VLANs Found",
+        "No Meraki VLAN DHCP switches were found. Ensure VLAN management is enabled in the integration options.",
+        __VERSION__
+      );
+    }
+
+    return html`
+      <ha-card .header="${this._config.name || 'Cisco Meraki VLANs'}">
+        <div class="card-content">
+          <div class="vlan-table">
+            <div class="table-header">
+              <div class="col-vlan">VLAN</div>
+              <div class="col-network">Subnet / Gateway</div>
+              <div class="col-dhcp">DHCP</div>
+            </div>
+            ${vlanEntities.map((vlan) => html`
+              <div class="table-row">
+                <div class="col-vlan">
+                  <span class="vlan-name">${vlan.name}</span>
+                </div>
+                <div class="col-network">
+                  <div class="subnet">${vlan.subnet}</div>
+                  <div class="gateway">${vlan.gateway}</div>
+                </div>
+                <div class="col-dhcp">
+                  <ha-switch
+                    .checked=${vlan.state === 'on'}
+                    @change=${() => this._toggleDhcp(vlan.entity_id)}
+                  ></ha-switch>
+                </div>
+              </div>
+            `)}
+          </div>
+        </div>
+        <div class="version">v${__VERSION__}</div>
+      </ha-card>
+    `;
+  }
+
+  private async _toggleDhcp(entityId: string): Promise<void> {
+    if (!this.hass) return;
+    try {
+      await this.hass.callService('switch', 'toggle', {
+        entity_id: entityId,
+      });
+    } catch (err) {
+      console.error("Failed to toggle DHCP switch:", err);
+    }
+  }
+
+  static styles = [
+    sharedStyles,
+    css`
+      :host { display: block; }
+      .card-content { padding: 0 16px 16px 16px; }
+
+      .vlan-table {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+      }
+
+      .table-header {
+        display: flex;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--divider-color);
+        font-weight: bold;
+        color: var(--secondary-text-color);
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      .table-row {
+        display: flex;
+        align-items: center;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--divider-color);
+      }
+
+      .table-row:last-child {
+        border-bottom: none;
+      }
+
+      .col-vlan { flex: 2; display: flex; align-items: center; }
+      .col-network { flex: 3; }
+      .col-dhcp { flex: 1; display: flex; justify-content: flex-end; }
+
+      .vlan-name {
+        font-weight: 500;
+        color: var(--primary-text-color);
+      }
+
+      .subnet {
+        font-size: 14px;
+        color: var(--primary-text-color);
+      }
+
+      .gateway {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+
+      ha-switch {
+        --switch-checked-button-color: var(--success-color, #4caf50);
+        --switch-checked-track-color: var(--success-color, #4caf50);
+      }
+    `
+  ];
+}
+
+export class MerakiVlanCardEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @state() private _config?: Config;
+
+  public setConfig(config: Config): void {
+    this._config = config;
+  }
+
+  private _schema = [
+    {
+      name: "name",
+      selector: { text: {} },
+    },
+  ];
+
+  protected render() {
+    if (!this.hass || !this._config) return html``;
+
+    return html`
+      <div class="editor-container">
+        <ha-form
+          .hass=${this.hass}
+          .data=${this._config}
+          .schema=${this._schema}
+          .computeLabel=${this._computeLabel}
+          @value-changed=${this._valueChanged}
+        ></ha-form>
+      </div>
+    `;
+  }
+
+  private _computeLabel = (schema: any): string => {
+    if (schema.name === "name") return "Display Name (Optional)";
+    return schema.name;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    if (!this._config) return;
+    const config = { ...this._config, ...ev.detail.value };
+    this.dispatchEvent(new CustomEvent("config-changed", {
+      detail: { config },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  static styles = css`
+    .editor-container { padding: 16px; }
+  `;
+}
+
+// Global Registration
+if (!customElements.get('meraki-vlan-card')) {
+  customElements.define('meraki-vlan-card', MerakiVlanCard);
+}
+if (!customElements.get('meraki-vlan-card-editor')) {
+  customElements.define('meraki-vlan-card-editor', MerakiVlanCardEditor);
+}
+
+(window as any).customCards = (window as any).customCards || [];
+if (!(window as any).customCards.some((c: any) => c.type === 'meraki-vlan-card')) {
+  (window as any).customCards.push({
+    type: "meraki-vlan-card",
+    name: "Cisco Meraki VLAN Card",
+    description: "Overview and management of configured VLANs.",
+    preview: true,
+  });
+}

--- a/tests/switch/test_vlan_dhcp.py
+++ b/tests/switch/test_vlan_dhcp.py
@@ -17,6 +17,8 @@ def mock_coordinator_with_vlan_data(mock_coordinator: MagicMock) -> MagicMock:
     vlan1 = MerakiVlan(
         id="1",
         name="VLAN 1",
+        subnet="192.168.1.0/24",
+        appliance_ip="192.168.1.1",
         dhcp_handling="Run a DHCP server",
     )
     network = MerakiNetwork(id="net1", name="Network 1")
@@ -69,8 +71,15 @@ def test_vlan_dhcp_switch_creation(
 
     assert isinstance(switch, MerakiVLANDHCPSwitch)
     assert switch.unique_id == "meraki_vlan_net1_1_dhcp_handling"
-    # assert switch.name == "DHCP" # Can't check name without platform
+    assert switch.name == "VLAN 1 DHCP"
     assert switch.is_on is True
+
+    # Check extra_state_attributes
+    attrs = switch.extra_state_attributes
+    assert attrs["vlan_id"] == "1"
+    assert attrs["vlan_name"] == "VLAN 1"
+    assert attrs["subnet"] == "192.168.1.0/24"
+    assert attrs["gateway"] == "192.168.1.1"
 
 
 def test_vlan_dhcp_switch_off_state(


### PR DESCRIPTION
This PR introduces a bespoke Lovelace card for Cisco Meraki VLAN management. 

Key changes:
- **Backend**: `MerakiVLANDHCPSwitch` now exposes `subnet` and `gateway` (appliance IP) via `extra_state_attributes`. It also uses the VLAN name in its friendly name (e.g., "Main DHCP") to avoid confusion when multiple VLANs have DHCP enabled.
- **Frontend**: A new `meraki-vlan-card` component provides a data table view of all configured VLANs, showing their subnet/gateway info and a toggle for DHCP service.
- **Interactivity**: The card utilizes the native `switch.toggle` service for immediate feedback.
- **Hardening**: The card uses the project's standard `pollConfig` pattern to handle integration startup states gracefully.

Fixes #2693

---
*PR created automatically by Jules for task [12409602827861175613](https://jules.google.com/task/12409602827861175613) started by @brewmarsh*