### PR TITLE
Filter expected warnings from staging tests

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -179,8 +179,19 @@ jobs:
           import asyncio
           import aiohttp
           import os
+          import re
           import sys
           from pathlib import Path
+
+          # Action 1: Define a list of IGNORE_PATTERNS (regex)
+          IGNORE_REGEX = [
+              re.compile(r"entity_registry is logging too frequently", re.I),
+              re.compile(
+                  r"(Network traffic analysis|Vlan tracking|Appliance port tracking) is not enabled",
+                  re.I,
+              ),
+              re.compile(r"Meraki API Informational Error.*Status 400", re.I),
+          ]
 
           async def fetch_via_websocket():
               url = os.environ.get("HA_URL", "").replace("http://", "ws://").replace("https://", "wss://") + "/api/websocket"
@@ -256,7 +267,13 @@ jobs:
               # We look for "meraki" and common error/warning indicators
               # HA logs typically look like: 2024-03-14 12:00:00 ERROR (MainThread) [source] message
               for line in logs_content.splitlines():
-                  if "meraki" in line.lower() and any(level in line.upper() for level in ("ERROR", "CRITICAL", "WARNING")):
+                  if "meraki" in line.lower() and any(
+                      level in line.upper() for level in ("ERROR", "CRITICAL", "WARNING")
+                  ):
+                      # Action 2: Filter logs based on IGNORE_PATTERNS
+                      if any(pattern.search(line) for pattern in IGNORE_REGEX):
+                          continue
+
                       # Exclude common false positives if any
                       if "Received unknown command: config/config_entries/get" in line:
                           # We actually WANT to catch this as an error now that we know about it

--- a/scripts/query_logs.py
+++ b/scripts/query_logs.py
@@ -11,10 +11,26 @@ Configuration is provided via environment variables:
 """
 
 import os
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 
 import requests  # type: ignore
+
+# Action 1: Define a list of IGNORE_PATTERNS (regex)
+IGNORE_REGEX = [
+    re.compile(r"entity_registry is logging too frequently", re.I),
+    re.compile(
+        r"(Network traffic analysis|Vlan tracking|Appliance port tracking) is not enabled",
+        re.I,
+    ),
+    re.compile(r"Meraki API Informational Error.*Status 400", re.I),
+]
+
+
+def is_actual_failure(message: str) -> bool:
+    """Check if the log message represents an actual failure."""
+    return not any(pattern.search(message) for pattern in IGNORE_REGEX)
 
 
 def main():
@@ -50,13 +66,25 @@ def main():
         sys.exit(1)
 
     logs = response.json().get("data", [])
-    if logs:
-        print(f"Found {len(logs)} error logs in the last 5 minutes:", file=sys.stderr)
-        for log in logs:
+
+    # Action 2: Filter logs based on IGNORE_PATTERNS
+    actual_errors = []
+    for log in logs:
+        # Better Stack logs usually have a 'message' field
+        message = log.get("message", "")
+        if is_actual_failure(message):
+            actual_errors.append(log)
+
+    if actual_errors:
+        print(
+            f"Found {len(actual_errors)} actual error logs in the last 5 minutes:",
+            file=sys.stderr,
+        )
+        for log in actual_errors:
             print(log, file=sys.stderr)
         sys.exit(1)
 
-    print("No error logs found for meraki_ha in the last 5 minutes.")
+    print("No actual error logs found for meraki_ha in the last 5 minutes.")
     sys.exit(0)
 
 


### PR DESCRIPTION
This change updates the log auditing mechanisms used in CI/CD (specifically staging and smoke tests) to ignore a set of known informational warnings that are not actual failures. 

The following patterns are now filtered using case-insensitive regex:
- `entity_registry is logging too frequently`
- `(Network traffic analysis|Vlan tracking|Appliance port tracking) is not enabled`
- `Meraki API Informational Error.*Status 400`

Changes were applied to:
1. `scripts/query_logs.py`: Added `IGNORE_REGEX` and logic to filter the results returned from the Better Stack API.
2. `.github/workflows/deploy-staging.yaml`: Updated the inline `fetch_logs.py` script with the same `IGNORE_REGEX` and logic to skip matching lines during the log audit phase.

Verification:
- Created and ran a temporary test script `verify_filters.py` to confirm regex accuracy.
- Ran relevant unit tests (`tests/test_friendly_logging.py`, `tests/test_meraki_client_init.py`) to ensure no regressions in core logging logic.
- Verified file changes manually via `read_file`.

Fixes #2699

---
*PR created automatically by Jules for task [17356145735039508610](https://jules.google.com/task/17356145735039508610) started by @brewmarsh*