### PR TITLE
Fix NameError and Harden Camera Device Data Lookup

### DIFF
--- a/custom_components/meraki_ha/camera.py
+++ b/custom_components/meraki_ha/camera.py
@@ -95,7 +95,7 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
         # Setting name to None with has_entity_name=True makes this the "Main" entity
         self._attr_name = None
-        self._attr_model = self.device_data.model
+        self._attr_model = self.device_data.model if self.device_data else None
 
         _LOGGER.debug(
             "Naming Debug - Entity: %s | Class: %s | has_entity_name: %s "
@@ -110,9 +110,9 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
         )
 
     @property
-    def device_data(self) -> MerakiDevice:
+    def device_data(self) -> MerakiDevice | None:
         """Return the device data from the coordinator."""
-        return self.coordinator.get_device(self._device_serial) or MerakiDevice()
+        return self.coordinator.get_device(self._device_serial)
 
     async def async_added_to_hass(self) -> None:
         """Handle when entity is added to hass."""
@@ -120,6 +120,7 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
 
         if (
             self.coordinator.config_entry.options.get(CONF_RTSP_STREAM_ENABLED, False)
+            and self.device_data
             and not self.device_data.rtsp_url
         ):
             # Move the blocking API call to a background task to prevent Setup timeout
@@ -150,7 +151,8 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
                     url,
                 )
                 # Update the device data model directly so the UI can use it
-                self.device_data.rtsp_url = url
+                if self.device_data:
+                    self.device_data.rtsp_url = url
                 self.async_write_ha_state()
             else:
                 _LOGGER.debug(
@@ -174,7 +176,7 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
             _LOGGER.debug("Cannot fetch snapshot: Camera serial is missing.")
             return None
 
-        if self.device_data.status != "online":
+        if not self.device_data or self.device_data.status != "online":
             _LOGGER.debug("Skipping snapshot for offline camera: %s", self.name)
             return None
 
@@ -205,7 +207,11 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
     @property
     def is_streaming(self) -> bool:
         """Return True if the camera is streaming."""
-        if not self._device_serial or self.device_data.rtsp_url is None:
+        if (
+            not self._device_serial
+            or not self.device_data
+            or self.device_data.rtsp_url is None
+        ):
             return False
         return True
 
@@ -220,7 +226,7 @@ class MerakiRTSPStreamCamera(MerakiEntity, Camera):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs = {}
-        if rtsp_url := self.device_data.rtsp_url:
+        if self.device_data and (rtsp_url := self.device_data.rtsp_url):
             attrs["rtsp_url"] = rtsp_url
         return attrs
 

--- a/tests/camera/test_regressions.py
+++ b/tests/camera/test_regressions.py
@@ -1,0 +1,42 @@
+"""Tests for camera NameError and None fallback regressions."""
+
+from unittest.mock import MagicMock
+import pytest
+from custom_components.meraki_ha.camera import MerakiRTSPStreamCamera
+from tests.const import MOCK_CAMERA_DEVICE
+
+@pytest.fixture
+def mock_coordinator_no_device():
+    """Coordinator that returns None for get_device."""
+    coordinator = MagicMock()
+    coordinator.get_device.return_value = None
+    coordinator.data = {} # Ensure available() fails
+    return coordinator
+
+@pytest.fixture
+def camera_no_device(
+    mock_coordinator_no_device,
+    mock_config_entry,
+    mock_camera_service,
+):
+    """Camera entity where coordinator returns None for device."""
+    return MerakiRTSPStreamCamera(
+        coordinator=mock_coordinator_no_device,
+        device=MOCK_CAMERA_DEVICE,
+        camera_service=mock_camera_service,
+        config_entry=mock_config_entry,
+    )
+
+def test_camera_device_data_none_safe(camera_no_device):
+    """Test that device_data returning None doesn't crash."""
+    # This would have crashed before if it used MerakiDevice() fallback without import
+    assert camera_no_device.device_data is None
+
+    # Test property access safety
+    assert camera_no_device.available is False
+    assert camera_no_device.is_streaming is False
+    assert camera_no_device.extra_state_attributes == {}
+
+async def test_camera_image_none_safe(camera_no_device):
+    """Test that async_camera_image handles None device_data."""
+    assert await camera_no_device.async_camera_image() is None


### PR DESCRIPTION
This change addresses a reported `NameError` in `camera.py` by eliminating the use of a model class instantiation as a fallback value. Instead of returning a dummy `MerakiDevice()` object when a device is missing from the coordinator, the code now returns `None`. Corresponding defensive checks were added to ensure the camera entity handles a missing device gracefully, allowing the integration's base availability logic to correctly mark the entity as unavailable in Home Assistant. Existing tests and a new regression test verify the fix.

Fixes #2698

---
*PR created automatically by Jules for task [3392361938070073495](https://jules.google.com/task/3392361938070073495) started by @brewmarsh*