### PR TITLE
Fix MerakiClient access and IPSK policy handling

### DIFF
--- a/custom_components/meraki_ha/services/__init__.py
+++ b/custom_components/meraki_ha/services/__init__.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 
 if TYPE_CHECKING:
@@ -60,21 +60,24 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
         ipsk_manager: IPSKManager | None = hass.data[DOMAIN].get("ipsk_manager")
         if not ipsk_manager:
-            raise HomeAssistantError("IPSK Manager not initialized")
+            raise ServiceValidationError("IPSK Manager not initialized")
 
         config_entry_id = _find_config_entry_by_network(hass, network_id)
         if not config_entry_id:
-            raise HomeAssistantError(f"Network ID {network_id} not found")
+            raise ServiceValidationError(f"Network ID {network_id} not found")
 
-        if not group_policy_id or group_policy_id == "CREATE":
+        # Handle policy logic
+        if group_policy_id == "NONE":
+            # Explicitly no policy
+            pass
+        elif not group_policy_id or group_policy_id == "CREATE":
             group_policy_id = await ipsk_manager.get_or_create_guest_policy(
                 config_entry_id, network_id
             )
-
-        if not group_policy_id:
-            raise HomeAssistantError(
-                "A Group Policy ID is required but could not be determined or created."
-            )
+            if not group_policy_id:
+                raise ServiceValidationError(
+                    "A Group Policy ID is required but could not be determined or created."
+                )
 
         await ipsk_manager.create_guest_key(
             config_entry_id=config_entry_id,
@@ -97,22 +100,24 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
         ipsk_manager: IPSKManager | None = hass.data[DOMAIN].get("ipsk_manager")
         if not ipsk_manager:
-            raise HomeAssistantError("IPSK Manager not initialized")
+            raise ServiceValidationError("IPSK Manager not initialized")
 
         config_entry_id = _find_config_entry_by_network(hass, network_id)
         if not config_entry_id:
-            raise HomeAssistantError(f"Network ID {network_id} not found")
+            raise ServiceValidationError(f"Network ID {network_id} not found")
 
-        # Handle automatic group policy creation
-        if not group_policy or group_policy == "CREATE":
+        # Handle policy logic
+        if group_policy == "NONE":
+            # Explicitly no policy
+            pass
+        elif not group_policy or group_policy == "CREATE":
             group_policy = await ipsk_manager.get_or_create_guest_policy(
                 config_entry_id, network_id
             )
-
-        if not group_policy:
-            raise HomeAssistantError(
-                "A Group Policy ID is required but could not be determined or created."
-            )
+            if not group_policy:
+                raise ServiceValidationError(
+                    "A Group Policy ID is required but could not be determined or created."
+                )
 
         # Map frontend parameters to the underlying IPSK manager method
         await ipsk_manager.create_guest_key(

--- a/custom_components/meraki_ha/services/ipsk_manager.py
+++ b/custom_components/meraki_ha/services/ipsk_manager.py
@@ -82,7 +82,7 @@ class IPSKManager:
 
         try:
             # Check if it already exists
-            policies = await client.networks.get_group_policies(network_id)
+            policies = await client.network.get_group_policies(network_id)
             for policy in policies:
                 if policy.get("name") == policy_name:
                     return str(policy["groupPolicyId"])
@@ -140,11 +140,16 @@ class IPSKManager:
                 f"Meraki client not found for config entry {config_entry_id}"
             )
 
+        # Handle "NONE" policy fallback
+        effective_policy_id = group_policy_id
+        if effective_policy_id == "NONE":
+            effective_policy_id = None
+
         result = await client.wireless.create_identity_psk(
             network_id,
             ssid_number,
             name,
-            group_policy_id,
+            effective_policy_id,
             passphrase,
         )
 

--- a/tests/test_ipsk_fix.py
+++ b/tests/test_ipsk_fix.py
@@ -1,0 +1,124 @@
+"""Tests for Meraki IPSK Services regression fix."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.const.integration import DOMAIN
+from custom_components.meraki_ha.services import async_setup_services
+from homeassistant.exceptions import ServiceValidationError
+
+
+@pytest.fixture(autouse=True)
+def auto_domain_init(hass):
+    """Initialize DOMAIN data."""
+    hass.data[DOMAIN] = {}
+
+
+@pytest.fixture
+def mock_ipsk_manager(hass):
+    """Mock IPSK Manager."""
+    manager = MagicMock()
+    manager.create_guest_key = AsyncMock()
+    manager.get_or_create_guest_policy = AsyncMock(return_value="GP_MOCK")
+    hass.data[DOMAIN]["ipsk_manager"] = manager
+    return manager
+
+
+@pytest.fixture
+def mock_coordinator(hass):
+    """Mock Main Coordinator."""
+    coordinator = MagicMock()
+    coordinator.networks_by_id = {"N_12345": MagicMock()}
+
+    hass.data[DOMAIN]["test_entry_id"] = {"main_coordinator": coordinator}
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_generate_guest_access_none_policy(
+    hass, mock_ipsk_manager, mock_coordinator
+):
+    """Test NONE policy handling in generate_guest_access."""
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "N_12345",
+        "ssid": 1,
+        "duration": 60,
+        "guest_name": "Service Guest",
+        "group_policy": "NONE",
+    }
+
+    await hass.services.async_call(
+        DOMAIN, "generate_guest_access", service_data, blocking=True
+    )
+
+    # Should NOT call get_or_create_guest_policy
+    assert not mock_ipsk_manager.get_or_create_guest_policy.called
+
+    # Should call create_guest_key with group_policy_id="NONE"
+    # Note: the services/__init__.py passes "NONE" to manager,
+    # and manager converts it to None.
+    mock_ipsk_manager.create_guest_key.assert_called_once_with(
+        config_entry_id="test_entry_id",
+        network_id="N_12345",
+        ssid_number="1",
+        duration_minutes=60,
+        name="Service Guest",
+        passphrase=None,
+        group_policy_id="NONE",
+    )
+
+@pytest.mark.asyncio
+async def test_create_guest_key_none_policy(
+    hass, mock_ipsk_manager, mock_coordinator
+):
+    """Test NONE policy handling in create_guest_key service."""
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "N_12345",
+        "ssid_number": 1,
+        "duration_minutes": 60,
+        "name": "Technical Guest",
+        "group_policy_id": "NONE",
+    }
+
+    await hass.services.async_call(
+        DOMAIN, "create_guest_key", service_data, blocking=True
+    )
+
+    # Should NOT call get_or_create_guest_policy
+    assert not mock_ipsk_manager.get_or_create_guest_policy.called
+
+    mock_ipsk_manager.create_guest_key.assert_called_once_with(
+        config_entry_id="test_entry_id",
+        network_id="N_12345",
+        ssid_number="1",
+        duration_minutes=60,
+        name="Technical Guest",
+        passphrase=None,
+        group_policy_id="NONE",
+    )
+
+@pytest.mark.asyncio
+async def test_service_validation_error_on_policy_failure(
+    hass, mock_ipsk_manager, mock_coordinator
+):
+    """Test ServiceValidationError when policy creation fails."""
+    mock_ipsk_manager.get_or_create_guest_policy.return_value = None
+    await async_setup_services(hass)
+
+    service_data = {
+        "network_id": "N_12345",
+        "ssid": 1,
+        "duration": 60,
+        "guest_name": "Service Guest",
+        "group_policy": "CREATE",
+    }
+
+    with pytest.raises(ServiceValidationError, match="A Group Policy ID is required"):
+        await hass.services.async_call(
+            DOMAIN, "generate_guest_access", service_data, blocking=True
+        )

--- a/tests/test_ipsk_manager.py
+++ b/tests/test_ipsk_manager.py
@@ -33,6 +33,53 @@ def manager(hass):
 
 
 @pytest.mark.asyncio
+async def test_create_guest_key_none_policy(hass, mock_meraki_client, manager):
+    """Test creating a guest key with NONE policy."""
+    await manager.async_setup()
+
+    client = mock_meraki_client
+    client.network = MagicMock()
+    client.network.get_group_policies = AsyncMock(return_value=[])
+
+    key = await manager.create_guest_key(
+        config_entry_id="test_entry_id",
+        network_id="N_12345",
+        ssid_number="1",
+        duration_minutes=60,
+        name="Guest User",
+        group_policy_id="NONE",
+    )
+
+    assert key["identity_psk_id"] == "mock_ipsk_id"
+    # Verify that NONE is converted to None when calling the SDK
+    mock_meraki_client.wireless.create_identity_psk.assert_called_once_with(
+        "N_12345", "1", "Guest User", None, None
+    )
+    manager.async_unload()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_guest_policy_fix_check(hass, mock_meraki_client, manager):
+    """Test get_or_create_guest_policy uses the correct client attribute."""
+    await manager.async_setup()
+
+    client = mock_meraki_client
+    client.network = MagicMock()
+    client.network.get_group_policies = AsyncMock(return_value=[])
+    client.dashboard = MagicMock()
+    client.dashboard.networks._session.post = AsyncMock(
+        return_value={"groupPolicyId": "NEW_GP"}
+    )
+    client.run_sync = AsyncMock(return_value={"groupPolicyId": "NEW_GP"})
+
+    policy_id = await manager.get_or_create_guest_policy("test_entry_id", "N_12345")
+
+    assert policy_id == "NEW_GP"
+    client.network.get_group_policies.assert_called_once_with("N_12345")
+    manager.async_unload()
+
+
+@pytest.mark.asyncio
 async def test_create_guest_key(hass, mock_meraki_client, manager):
     """Test creating a guest key."""
     await manager.async_setup()


### PR DESCRIPTION
This change fixes a backend regression in `ipsk_manager.py` where an invalid attribute `.networks` was accessed on the `MerakiClient` object. It refactors the call to use the correct `.network` endpoint. 

Additionally, it implements robust handling for the "NONE" policy selection from the frontend:
1. The `generate_guest_access` and `create_guest_key` services now explicitly check for the "NONE" string and skip the automatic group policy lookup/creation.
2. The `IPSKManager.create_guest_key` method converts "NONE" to `None` before passing it to the Meraki SDK to ensure no policy is applied.
3. User-facing service errors now raise `ServiceValidationError` to provide better feedback in the Home Assistant UI.

Unit tests have been added to verify these fixes and prevent future regressions.

Fixes #2707

---
*PR created automatically by Jules for task [4750057562664492129](https://jules.google.com/task/4750057562664492129) started by @brewmarsh*