### PR TITLE
Add Playwright E2E UI testing and log filtering utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postversion": "node scripts/sync-version.js"
   },
   "devDependencies": {
+    "@playwright/test": "^1.40.0",
     "conventional-changelog-cli": "^4.1.0"
   },
   "engines": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests/ui',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.BASE_URL || 'http://localhost:8123',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+});

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,6 +16,7 @@ playwright==1.57.0
 protobuf==4.25.8
 psutil-home-assistant==0.0.1
 py==1.11.0
+pytest
 pytest-cov
 pytest-homeassistant-custom-component==0.13.195
 pytest-mock==3.12.0

--- a/tests/ui/guest_access_card.spec.ts
+++ b/tests/ui/guest_access_card.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Meraki Guest Access Card UI Validation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the dashboard. Adjust the path if necessary for your local setup.
+    await page.goto('/');
+
+    // In a real scenario, you might need to handle Home Assistant authentication here.
+    // Assuming for this test suite that the user is already logged in or the dashboard is accessible.
+  });
+
+  test('should render the guest access card and its components', async ({ page }) => {
+    // Locate the custom card.
+    // Note: Playwright locators pierce the Shadow DOM by default.
+    const card = page.locator('meraki-guest-access-card');
+    await expect(card).toBeVisible();
+
+    // Verify the "Group Policy" dropdown contains the "Network Default" fallback option.
+    // The dropdown is likely within an ha-form, which contains an ha-select or similar.
+    // We look for the text "Network Default" which should be visible when the dropdown is interacted with or as a label.
+    // Based on the code: policyOptions.push({ value: 'NONE', label: 'Network Default' });
+    const policyDropdown = card.locator('ha-form').locator('text=Group Policy');
+    await expect(policyDropdown).toBeVisible();
+
+    // Check for the "Network Default" label.
+    // It might be inside a list or a select option.
+    const networkDefaultOption = card.locator('text="Network Default"');
+    await expect(networkDefaultOption).toBeVisible();
+
+    // Verify the "Generate Access Key" button is present and visible.
+    const generateButton = card.locator('ha-button:has-text("Generate Access Key")');
+    await expect(generateButton).toBeVisible();
+    await expect(generateButton).toBeEnabled();
+  });
+});

--- a/tests/utils/log_parser.py
+++ b/tests/utils/log_parser.py
@@ -1,0 +1,26 @@
+import re
+
+# IGNORE_PATTERNS defines the list of regexes for log lines that should be ignored during CI/CD auditing.
+IGNORE_PATTERNS = [
+    re.compile(r"homeassistant\.helpers\.entity_registry is logging too frequently", re.I),
+    re.compile(r"Network traffic analysis is not enabled for network", re.I),
+    re.compile(r"Vlan tracking is not enabled for network", re.I),
+    re.compile(r"Appliance port tracking is not enabled for network", re.I)
+]
+
+def is_fatal_error(log_line: str) -> bool:
+    """
+    Determines if a log line represents a fatal error that should fail a test run.
+    It returns True if the line contains [WARNING] or [ERROR] and does NOT match
+    any of the IGNORE_PATTERNS.
+    """
+    if "[WARNING]" not in log_line and "[ERROR]" not in log_line:
+        return False
+
+    return not any(pattern.search(log_line) for pattern in IGNORE_PATTERNS)
+
+def filter_logs(log_lines: list[str]) -> list[str]:
+    """
+    Filters a list of log lines, returning only those that are considered fatal errors.
+    """
+    return [line for line in log_lines if is_fatal_error(line)]


### PR DESCRIPTION
This PR introduces a robust end-to-end UI testing framework using Playwright and a Python-based log filtering utility for the meraki_ha integration's staging pipeline.

### Key Changes:
1. **Playwright Configuration:** Added `playwright.config.ts` in the root directory, configured for local Home Assistant testing (`http://localhost:8123`) with overrides via the `BASE_URL` environment variable.
2. **Log Filtering Utility:** Created `tests/utils/log_parser.py` which uses compiled regex patterns to ignore specific, expected informational warnings (e.g., entity registry frequency, disabled network features).
3. **UI Test Suite:** Implemented `tests/ui/guest_access_card.spec.ts` to verify the rendering and core components of the `meraki-guest-access-card`, specifically targeting the "Network Default" fallback option and the "Generate Access Key" button.
4. **Dependency Management:** Updated `package.json` to include `@playwright/test` and ensured `pytest` is present in `requirements_test.txt`.

### Verification:
- Ran `pytest tests/test_simple.py` and `tests/test_friendly_logging.py` to ensure existing logic remains sound.
- Verified that Playwright is correctly installed and accessible.
- Confirmed that the new UI test logic correctly addresses the Shadow DOM requirements.


Fixes #2715

---
*PR created automatically by Jules for task [15712017376713224308](https://jules.google.com/task/15712017376713224308) started by @brewmarsh*