### PR TITLE
Fix metaclass conflicts in entities

### DIFF
--- a/custom_components/meraki_ha/entity.py
+++ b/custom_components/meraki_ha/entity.py
@@ -6,7 +6,9 @@ import logging
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -159,3 +161,11 @@ class MerakiSensor(MerakiEntity[T], SensorEntity, Generic[T]):
 
 class MerakiBinarySensor(MerakiEntity[T], BinarySensorEntity, Generic[T]):
     """Base Cisco Meraki binary sensor entity."""
+
+
+class MerakiSelect(MerakiEntity[T], SelectEntity, Generic[T]):
+    """Base Cisco Meraki select entity."""
+
+
+class MerakiSwitch(MerakiEntity[T], SwitchEntity, Generic[T]):
+    """Base Cisco Meraki switch entity."""

--- a/custom_components/meraki_ha/meraki_select/rf_profile.py
+++ b/custom_components/meraki_ha/meraki_select/rf_profile.py
@@ -3,23 +3,23 @@
 import logging
 from typing import Any
 
-from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.components.select import SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ..coordinators import MerakiMainCoordinator
 from ..core.api import MerakiApiClientProtocol
+from ..entity import MerakiSelect
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiRFProfileSelect(CoordinatorEntity, SelectEntity):
+class MerakiRFProfileSelect(MerakiSelect):
     """Representation of a Meraki RF Profile select entity."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/meraki_select/vpn.py
+++ b/custom_components/meraki_ha/meraki_select/vpn.py
@@ -2,23 +2,23 @@
 
 import logging
 
-from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.components.select import SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..coordinators import MerakiMainCoordinator
 from ..core.api import MerakiApiClientProtocol
 from ..core.models.network import MerakiNetwork, MerakiVpn
+from ..entity import MerakiSelect
 from ..helpers.device_info_helpers import resolve_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiVpnSelect(CoordinatorEntity, SelectEntity):
+class MerakiVpnSelect(MerakiSelect):
     """Representation of a Meraki VPN select entity."""
 
     entity_category = EntityCategory.CONFIG

--- a/custom_components/meraki_ha/sensor/client_tracker.py
+++ b/custom_components/meraki_ha/sensor/client_tracker.py
@@ -3,23 +3,23 @@
 import logging
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ..coordinators import MerakiMainCoordinator
 from ..core.utils.naming_utils import standardize_device_name
+from ..entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 CLIENT_TRACKER_DEVICE_ID = "client_tracker"
 
 
-class ClientTrackerDeviceSensor(CoordinatorEntity, SensorEntity):
+class ClientTrackerDeviceSensor(MerakiSensor):
     """A sensor representing the Client Tracker device itself."""
 
     _attr_has_entity_name = True
@@ -63,7 +63,7 @@ class ClientTrackerDeviceSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_value = 0
 
 
-class MerakiClientSensor(CoordinatorEntity, SensorEntity):
+class MerakiClientSensor(MerakiSensor):
     """Representation of a Meraki client as a sensor."""
 
     _attr_has_entity_name = True

--- a/custom_components/meraki_ha/sensor/device/appliance_port.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_port.py
@@ -6,21 +6,20 @@ import logging
 from typing import Any
 
 from custom_components.meraki_ha.const.integration import DOMAIN
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.models import MerakiAppliancePort
 from ...core.models.device import MerakiDevice
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiAppliancePortSensor(CoordinatorEntity, SensorEntity):
+class MerakiAppliancePortSensor(MerakiSensor):
     """Representation of a Meraki appliance port sensor."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/sensor/device/appliance_uplink.py
+++ b/custom_components/meraki_ha/sensor/device/appliance_uplink.py
@@ -5,17 +5,16 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import standardize_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models import MerakiApplianceDevice
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiApplianceUplinkSensor(CoordinatorEntity, SensorEntity):
+class MerakiApplianceUplinkSensor(MerakiSensor):
     """Representation of a Meraki appliance uplink sensor."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/sensor/device/camera_analytics.py
+++ b/custom_components/meraki_ha/sensor/device/camera_analytics.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ...coordinators import MerakiCameraCoordinator
+from ...entity import MerakiSensor
 from ...helpers.device_info_helpers import resolve_device_info
 
 if TYPE_CHECKING:
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiAnalyticsSensor(CoordinatorEntity, SensorEntity):
+class MerakiAnalyticsSensor(MerakiSensor):
     """Base class for Meraki analytics sensors."""
 
     coordinator: MerakiCameraCoordinator

--- a/custom_components/meraki_ha/sensor/device/camera_audio_detection.py
+++ b/custom_components/meraki_ha/sensor/device/camera_audio_detection.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiCameraCoordinator
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiCameraAudioDetectionSensor(CoordinatorEntity, SensorEntity):
+class MerakiCameraAudioDetectionSensor(MerakiSensor):
     """Representation of a Meraki Camera Audio Detection Status sensor."""
 
     coordinator: MerakiCameraCoordinator

--- a/custom_components/meraki_ha/sensor/device/camera_sense_status.py
+++ b/custom_components/meraki_ha/sensor/device/camera_sense_status.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiCameraCoordinator
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiCameraSenseStatusSensor(CoordinatorEntity, SensorEntity):
+class MerakiCameraSenseStatusSensor(MerakiSensor):
     """Representation of a Meraki Camera Sense Status sensor."""
 
     coordinator: MerakiCameraCoordinator

--- a/custom_components/meraki_ha/sensor/device/data_usage.py
+++ b/custom_components/meraki_ha/sensor/device/data_usage.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfInformation
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiDataUsageSensor(CoordinatorEntity, SensorEntity):
+class MerakiDataUsageSensor(MerakiSensor):
     """Representation of a Meraki appliance data usage sensor."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_firmware_status.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import standardize_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiFirmwareStatusSensor(CoordinatorEntity, SensorEntity):
+class MerakiFirmwareStatusSensor(MerakiSensor):
     """Representation of a Meraki Device Firmware Status Sensor."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan1_connectivity.py
@@ -5,17 +5,16 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -26,10 +25,7 @@ STATE_CONNECTED = "Connected"
 STATE_DISCONNECTED = "Disconnected"
 
 
-class MerakiWAN1ConnectivitySensor(
-    CoordinatorEntity,
-    SensorEntity,
-):
+class MerakiWAN1ConnectivitySensor(MerakiSensor):
     """Representation of a Meraki WAN1 Connectivity Sensor."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
+++ b/custom_components/meraki_ha/sensor/device/meraki_wan2_connectivity.py
@@ -5,17 +5,16 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, cast
 
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import format_device_name
+from ...entity import MerakiSensor
 
 if TYPE_CHECKING:
     from ...core.models.device import MerakiDevice
@@ -26,10 +25,7 @@ STATE_CONNECTED = "Connected"
 STATE_DISCONNECTED = "Disconnected"
 
 
-class MerakiWAN2ConnectivitySensor(
-    CoordinatorEntity,
-    SensorEntity,
-):
+class MerakiWAN2ConnectivitySensor(MerakiSensor):
     """Representation of a Meraki WAN2 Connectivity Sensor."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/sensor/org/org_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_clients.py
@@ -4,23 +4,20 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import standardize_device_name
+from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiOrganizationSSIDClientsSensor(
-    CoordinatorEntity,
-    SensorEntity,
-):
+class MerakiOrganizationSSIDClientsSensor(MerakiSensor):
     """Representation of a Meraki Organization SSID Clients sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -74,10 +71,7 @@ class MerakiOrganizationSSIDClientsSensor(
         )
 
 
-class MerakiOrganizationWirelessClientsSensor(
-    CoordinatorEntity,
-    SensorEntity,
-):
+class MerakiOrganizationWirelessClientsSensor(MerakiSensor):
     """Representation of a Meraki Organization Wireless Clients sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -130,10 +124,7 @@ class MerakiOrganizationWirelessClientsSensor(
         )
 
 
-class MerakiOrganizationApplianceClientsSensor(
-    CoordinatorEntity,
-    SensorEntity,
-):
+class MerakiOrganizationApplianceClientsSensor(MerakiSensor):
     """Representation of a Meraki Organization Appliance Clients sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
+++ b/custom_components/meraki_ha/sensor/org/org_device_type_clients.py
@@ -2,21 +2,21 @@
 
 import logging
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.utils.naming_utils import standardize_device_name
+from ...entity import MerakiSensor
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiOrganizationDeviceTypeClientsSensor(CoordinatorEntity, SensorEntity):
+class MerakiOrganizationDeviceTypeClientsSensor(MerakiSensor):
     """Representation of a Meraki organization-level client counter by device type."""
 
     coordinator: MerakiMainCoordinator

--- a/custom_components/meraki_ha/switch/meraki_client_blocker.py
+++ b/custom_components/meraki_ha/switch/meraki_client_blocker.py
@@ -3,24 +3,21 @@
 import logging
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ..core.coordinators.ssid_firewall_coordinator import SsidFirewallCoordinator
+from ..entity import MerakiSwitch
 from ..helpers.device_info_helpers import resolve_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiClientBlockerSwitch(
-    CoordinatorEntity,
-    SwitchEntity,
-):
+class MerakiClientBlockerSwitch(MerakiSwitch):
     """Representation of a Meraki Client Blocker switch entity."""
 
     entity_category = EntityCategory.CONFIG


### PR DESCRIPTION
This PR fixes the `TypeError: metaclass conflict` errors that were occurring in various sensor, select, and switch entities. The root cause was multiple inheritance directly from `CoordinatorEntity` and core HA entities like `SensorEntity` or `SelectEntity`. The solution follows the project standard outlined in `AGENTS.md` by utilizing centralized base classes (`MerakiSensor`, `MerakiSelect`, `MerakiSwitch`) defined in `entity.py`.

Changes:
- Added `MerakiSelect` and `MerakiSwitch` to `custom_components/meraki_ha/entity.py`.
- Updated all relevant files in `meraki_select`, `switch`, and `sensor` directories to inherit from these base classes.
- Verified fix by running `pytest`.

---
*PR created automatically by Jules for task [11880485652724345403](https://jules.google.com/task/11880485652724345403) started by @brewmarsh*