### PR TITLE
Standardize log filtering for staging tests

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -183,7 +183,7 @@ jobs:
           import sys
           from pathlib import Path
 
-          # Action 1: Define a list of IGNORE_PATTERNS (regex)
+          # IGNORE_REGEX defines the list of regexes for log lines that should be ignored during CI/CD auditing.
           IGNORE_REGEX = [
               re.compile(r"entity_registry is logging too frequently", re.I),
               re.compile(
@@ -270,7 +270,7 @@ jobs:
                   if "meraki" in line.lower() and any(
                       level in line.upper() for level in ("ERROR", "CRITICAL", "WARNING")
                   ):
-                      # Action 2: Filter logs based on IGNORE_PATTERNS
+                      # Filter logs based on IGNORE_REGEX
                       if any(pattern.search(line) for pattern in IGNORE_REGEX):
                           continue
 

--- a/scripts/query_logs.py
+++ b/scripts/query_logs.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta, timezone
 
 import requests  # type: ignore
 
-# Action 1: Define a list of IGNORE_PATTERNS (regex)
+# IGNORE_REGEX defines the list of regexes for log lines that should be ignored during CI/CD auditing.
 IGNORE_REGEX = [
     re.compile(r"entity_registry is logging too frequently", re.I),
     re.compile(
@@ -30,6 +30,10 @@ IGNORE_REGEX = [
 
 def is_actual_failure(message: str) -> bool:
     """Check if the log message represents an actual failure."""
+    # Ignore all errors or warnings not related to the meraki_ha integration
+    if "meraki" not in message.lower():
+        return False
+
     return not any(pattern.search(message) for pattern in IGNORE_REGEX)
 
 
@@ -67,7 +71,6 @@ def main():
 
     logs = response.json().get("data", [])
 
-    # Action 2: Filter logs based on IGNORE_PATTERNS
     actual_errors = []
     for log in logs:
         # Better Stack logs usually have a 'message' field

--- a/tests/utils/log_parser.py
+++ b/tests/utils/log_parser.py
@@ -2,11 +2,14 @@ import re
 
 # IGNORE_PATTERNS defines the list of regexes for log lines that should be ignored during CI/CD auditing.
 IGNORE_PATTERNS = [
-    re.compile(r"homeassistant\.helpers\.entity_registry is logging too frequently", re.I),
-    re.compile(r"Network traffic analysis is not enabled for network", re.I),
-    re.compile(r"Vlan tracking is not enabled for network", re.I),
-    re.compile(r"Appliance port tracking is not enabled for network", re.I)
+    re.compile(r"entity_registry is logging too frequently", re.I),
+    re.compile(
+        r"(Network traffic analysis|Vlan tracking|Appliance port tracking) is not enabled",
+        re.I,
+    ),
+    re.compile(r"Meraki API Informational Error.*Status 400", re.I),
 ]
+
 
 def is_fatal_error(log_line: str) -> bool:
     """
@@ -17,7 +20,12 @@ def is_fatal_error(log_line: str) -> bool:
     if "[WARNING]" not in log_line and "[ERROR]" not in log_line:
         return False
 
+    # Ignore all errors or warnings not related to the meraki_ha integration
+    if "meraki" not in log_line.lower():
+        return False
+
     return not any(pattern.search(log_line) for pattern in IGNORE_PATTERNS)
+
 
 def filter_logs(log_lines: list[str]) -> list[str]:
     """


### PR DESCRIPTION
This change standardizes the log filtering logic used during staging tests and CI/CD auditing. It defines a consistent set of acceptable warnings (like entity registry throttling and disabled Meraki features) and ensures that only logs containing the "meraki" keyword are flagged as potential failures. This reduces noise from unrelated Home Assistant system logs and prevents false positive test failures.

Fixes #2719

---
*PR created automatically by Jules for task [1330013959514303803](https://jules.google.com/task/1330013959514303803) started by @brewmarsh*