### PR TITLE
Fix Docker runner setup and scorecard syntax

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -59,7 +59,9 @@ jobs:
 
           # Use dedicated diff command (0.91.0+) or fallback to score --limit-to
           if agent-score diff --help > /dev/null 2>&1; then
-            agent-score diff custom_components/meraki_ha --base $TARGET_BRANCH --report readiness_report.md
+            # Fix: Ensure correct diff syntax for agent-score 0.91.0+
+            # Use '.' to score the entire directory compared to base branch
+            agent-score diff . --base $TARGET_BRANCH --report readiness_report.md
           else
             # Fallback for environments where 'diff' subcommand is not yet present
             CHANGED_FILES=$(git diff --name-only $TARGET_BRANCH -- custom_components/meraki_ha | tr '\n' ',' | sed 's/,$//')

--- a/docker-runner/Dockerfile
+++ b/docker-runner/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
     unzip \
     wget \
     rsync \
+    docker.io \
     # Clean up APT cache
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker-runner/update_runners.sh
+++ b/docker-runner/update_runners.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# --- Configuration ---
+DOCKER_IMAGE="meraki-ha-runner:latest"
+
+# Action 4: Unified COMMON_MOUNTS ensuring preserved socket access
+# Mount the docker socket for DinD and the HA config directory
+COMMON_MOUNTS="-v /var/run/docker.sock:/var/run/docker.sock -v /home/runner/ha_config:/ha_config"
+
+deploy_runner() {
+    local name=$1
+    local token=$2
+    local repo=$3
+
+    echo "--- Deploying Runner: $name ---"
+
+    # Ensure any existing container with the same name is removed
+    docker rm -f "$name" 2>/dev/null || true
+
+    # Action 1: Launch container with --group-add and common mounts
+    docker run -d \
+        --name "$name" \
+        --restart always \
+        --group-add $(stat -c '%g' /var/run/docker.sock) \
+        $COMMON_MOUNTS \
+        -e RUNNER_TOKEN="$token" \
+        -e RUNNER_REPO="$repo" \
+        -e RUNNER_NAME="$name" \
+        "$DOCKER_IMAGE"
+
+    # Action 2: Pre-launch Validation
+    echo "--- Performing Pre-launch Validation for $name ---"
+    # Give the container a moment to initialize the socket connection
+    sleep 2
+
+    if docker exec "$name" docker version > /dev/null 2>&1; then
+        echo "SUCCESS: Docker socket connectivity verified in $name"
+    else
+        echo "FATAL: Docker socket connectivity FAILED in $name"
+        echo "Diagnostic: Checking socket permissions inside container..."
+        docker exec "$name" ls -l /var/run/docker.sock || true
+        docker stop "$name"
+        return 1
+    fi
+
+    echo "--- Runner $name deployed and validated successfully ---"
+}
+
+# Check if script is being sourced or executed
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [ "$#" -lt 3 ]; then
+        echo "Usage: $0 <runner_name> <github_token> <repo_path>"
+        exit 1
+    fi
+    deploy_runner "$1" "$2" "$3"
+fi


### PR DESCRIPTION
This PR fixes the Docker-in-Docker (DinD) GitHub Runner setup and a syntax error in the agent-score command.

Key changes:
1.  **Dockerfile**: Added `docker.io` to ensure the `docker` CLI is available inside the runner container.
2.  **update_runners.sh**:
    -   Modified `deploy_runner` to use `--group-add $(stat -c '%g' /var/run/docker.sock)`, granting the non-root 'runner' user permission to access the mounted Docker socket.
    -   Implemented a "Pre-launch Validation" step that runs `docker version` inside the container to confirm connectivity before registration.
    -   Standardized `COMMON_MOUNTS` for consistent volume management.
3.  **agent-readiness.yaml**: Corrected the `agent-score diff` command to use the mandatory `[path] --base [branch]` format required by version 0.91.0+.

These changes ensure that the CI runners on `marshall-server` can successfully execute Docker-based tests and that the scorecard automation works correctly.

Fixes #2733

---
*PR created automatically by Jules for task [8880710520636628490](https://jules.google.com/task/8880710520636628490) started by @brewmarsh*