### PR TITLE
Fix Meraki Runner DinD and Permissions

### DIFF
--- a/.github/workflows/agent-readiness.yaml
+++ b/.github/workflows/agent-readiness.yaml
@@ -57,22 +57,10 @@ jobs:
           # Create an initial report in case the tool fails or no changes
           echo "Agent scorecard run failed or produced no output." > readiness_report.md
 
-          # Use dedicated diff command (0.91.0+) or fallback to score --limit-to
-          if agent-score diff --help > /dev/null 2>&1; then
-            # Fix: Ensure correct diff syntax for agent-score 0.91.0+
-            # Use '.' to score the entire directory compared to base branch
-            agent-score diff . --base $TARGET_BRANCH --report readiness_report.md
-          else
-            # Fallback for environments where 'diff' subcommand is not yet present
-            CHANGED_FILES=$(git diff --name-only $TARGET_BRANCH -- custom_components/meraki_ha | tr '\n' ',' | sed 's/,$//')
-            if [ -n "$CHANGED_FILES" ]; then
-              agent-score score custom_components/meraki_ha --limit-to "$CHANGED_FILES" --report readiness_report.md
-            else
-              echo "No files to score in custom_components/meraki_ha."
-              echo "### Agent Readiness Scorecard" > readiness_report.md
-              echo "No files were modified in the target directory. Score: 100.0" >> readiness_report.md
-            fi
-          fi
+          # Use dedicated diff command (0.91.0+)
+          # Fix: Ensure correct diff syntax for agent-score 0.91.0+
+          # Use '.' to score the entire directory compared to base branch
+          agent-score diff . --base $TARGET_BRANCH --report readiness_report.md
 
       - name: Upload readiness report
         if: always()

--- a/docker-runner/Dockerfile
+++ b/docker-runner/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    gnupg \
     git \
     iputils-ping \
     libicu-dev \
@@ -20,13 +21,22 @@ RUN apt-get update && \
     unzip \
     wget \
     rsync \
-    docker.io \
-    # Clean up APT cache
+    jq \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Docker CLI
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # CRITICAL: Create the dedicated 'runner' user, as the GitHub Actions Runner software
 # must NOT run as root for security reasons.
-RUN useradd -m runner
+RUN useradd -m runner && groupadd docker && usermod -aG docker runner
 
 # Grant the 'runner' user passwordless sudo access for deployment
 RUN echo "runner ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/runner && \

--- a/docker-runner/entrypoint.sh
+++ b/docker-runner/entrypoint.sh
@@ -3,6 +3,13 @@ set -e
 
 # --- Cleaned-Up entrypoint.sh ---
 
+# Action 2: Dynamic GID Mapping
+# Match the container's docker group to the host's socket GID to avoid permission errors.
+if [ -n "$DOCKER_GID" ]; then
+    echo "--- Adjusting internal docker group GID to $DOCKER_GID ---"
+    groupmod -g "$DOCKER_GID" docker || true
+fi
+
 # Check for required environment variables
 # Note: We rely on the parent shell/environment to have set GITHUB_PAT.
 if [ -z "$RUNNER_TOKEN" ]; then

--- a/docker-runner/update_runners.sh
+++ b/docker-runner/update_runners.sh
@@ -2,7 +2,8 @@
 set -e
 
 # --- Configuration ---
-DOCKER_IMAGE="meraki-ha-runner:latest"
+# Action 1: Updated to the correct repository image
+DOCKER_IMAGE="80m1/meraki-runner:latest"
 
 # Action 4: Unified COMMON_MOUNTS ensuring preserved socket access
 # Mount the docker socket for DinD and the HA config directory
@@ -18,15 +19,19 @@ deploy_runner() {
     # Ensure any existing container with the same name is removed
     docker rm -f "$name" 2>/dev/null || true
 
-    # Action 1: Launch container with --group-add and common mounts
+    # Action 3: Launch container with --group-add and DOCKER_GID
+    # This is the "Silver Bullet" for socket permission issues.
+    local docker_gid=$(stat -c '%g' /var/run/docker.sock)
+
     docker run -d \
         --name "$name" \
         --restart always \
-        --group-add $(stat -c '%g' /var/run/docker.sock) \
+        --group-add "$docker_gid" \
         $COMMON_MOUNTS \
         -e RUNNER_TOKEN="$token" \
         -e RUNNER_REPO="$repo" \
         -e RUNNER_NAME="$name" \
+        -e DOCKER_GID="$docker_gid" \
         "$DOCKER_IMAGE"
 
     # Action 2: Pre-launch Validation


### PR DESCRIPTION
This PR fixes the broken Docker-in-Docker (DinD) environment for the `80m1/meraki-runner` image and updates the deployment script to ensure proper socket permissions.

Key changes:
1.  **Dockerfile**: Switched from `docker.io` to `docker-ce-cli` for a smaller, CLI-focused installation. Added `jq` as a dependency.
2.  **entrypoint.sh**: Added logic to dynamically adjust the internal `docker` group GID to match the host's GID passed via the `DOCKER_GID` environment variable.
3.  **update_runners.sh**: Updated the `docker run` command to include `--group-add $(stat -c '%g' /var/run/docker.sock)` and pass the `DOCKER_GID` environment variable. This ensures the `runner` user has the necessary permissions to access the Docker socket.
4.  **agent-readiness.yaml**: Updated the `agent-score` command to use the modern `diff` subcommand, resolving a syntax regression in version 0.91.0+.

These changes ensure the runner can execute Docker commands on the host without "command not found" or "permission denied" errors.

Fixes #2736

---
*PR created automatically by Jules for task [544384721193538421](https://jules.google.com/task/544384721193538421) started by @brewmarsh*