### PR TITLE
Fix guest-access-card GroupPolicy type export

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.3558",
+  "version": "2.3.0-beta.3559",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.3558",
+      "version": "2.3.0-beta.3559",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/src/types/meraki.ts
+++ b/frontend/src/types/meraki.ts
@@ -11,3 +11,9 @@ export interface SSID {
   networkId: string;
   authMode?: string;
 }
+
+export interface GroupPolicy {
+  networkId: string;
+  groupPolicyId: string;
+  name: string;
+}

--- a/frontend/src/utils/meraki-data.ts
+++ b/frontend/src/utils/meraki-data.ts
@@ -1,14 +1,8 @@
 // src/utils/meraki-data.ts
 import { HomeAssistant } from '../types/ha';
-import { Network, SSID } from '../types/meraki';
+import { Network, SSID, GroupPolicy } from '../types/meraki';
 import { WsCommand } from '../types/websocket';
 import { safeCallWS } from './api';
-
-export interface GroupPolicy {
-  networkId: string;
-  groupPolicyId: string;
-  name: string;
-}
 
 export class MerakiDataProvider {
   /**


### PR DESCRIPTION
This change fixes a TypeScript compilation error where the `GroupPolicy` type was being imported by `meraki-guest-access-card.ts` but was not exported by `types/meraki.ts`. I added the `GroupPolicy` interface to the centralized types file and updated `meraki-data.ts` to use this shared definition, removing its local duplicate. Verified the fix by running `npm run type-check` in the frontend directory.

Fixes #2755

---
*PR created automatically by Jules for task [2258205091417716658](https://jules.google.com/task/2258205091417716658) started by @brewmarsh*