### PR TITLE
Fix Pytest suite crashes and mocking architecture

### DIFF
--- a/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
+++ b/tests/core/coordinator_helpers/test_data_fetcher_timeouts.py
@@ -31,6 +31,12 @@ def mock_client():
     client._disabled_features = set()
     client.has_dashboard = True
 
+    # Ensure run_with_cache is an AsyncMock and works
+    async def mock_run_with_cache(cache_key, func, ttl=None):
+        return await func()
+
+    client.run_with_cache = AsyncMock(side_effect=mock_run_with_cache)
+
     async def run_with_semaphore_side_effect(coro):
         """Side effect to return a completed future and close input coroutine."""
         if asyncio.iscoroutine(coro):
@@ -52,6 +58,7 @@ async def test_fetch_initial_data_timeout(data_fetch_manager, mock_client):
     """Test that _async_fetch_batch_data logs error and raises TimeoutError."""
     with patch(
         "custom_components.meraki_ha.core.coordinator_helpers.batch_utils.asyncio.wait_for",
+        new_callable=AsyncMock,
         side_effect=clean_exit_wait_for,
     ):
         with patch(
@@ -79,6 +86,7 @@ async def test_get_all_data_detailed_timeout(data_fetch_manager, mock_client):
 
     with patch(
         "custom_components.meraki_ha.core.coordinator_helpers.batch_utils.asyncio.wait_for",
+        new_callable=AsyncMock,
         side_effect=clean_exit_wait_for,
     ):
         with patch(
@@ -117,6 +125,7 @@ async def test_get_all_data_client_timeout(data_fetch_manager, mock_client):
     # We also need detail batch to succeed (or return empty) so we reach client fetch.
     with patch(
         "custom_components.meraki_ha.core.coordinator_helpers.data_fetcher.async_gather_with_timeout",
+        new_callable=AsyncMock,
         side_effect=[{}, clean_exit_wait_for],
     ):
         with patch(

--- a/tests/core/fetch_strategies/test_wireless_strategy.py
+++ b/tests/core/fetch_strategies/test_wireless_strategy.py
@@ -29,7 +29,7 @@ def strategy(mock_client, disabled_features):
     """Fixture for the WirelessFetchStrategy."""
     return WirelessFetchStrategy(
         client=mock_client,
-        _disabled_features=disabled_features,
+        disabled_features=disabled_features,
     )
 
 
@@ -43,7 +43,7 @@ def test_build_network_tasks(strategy, mock_client):
     strategy.build_network_tasks(network_id, product_types, tasks)
 
     mock_client.wireless.get_network_detail_tasks.assert_called_once_with(
-        network_id, product_types
+        network_id, product_types, static_data={}
     )
     assert "task1" in tasks
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,6 +30,7 @@ async def test_form(hass: HomeAssistant) -> None:
         ) as mock_create_client,
         patch(
             "custom_components.meraki_ha.async_setup_entry",
+            new_callable=AsyncMock,
             return_value=True,
         ) as mock_setup_entry,
     ):


### PR DESCRIPTION
This PR addresses fatal Python test crashes by remediating the mocking architecture and updating test signatures to match recent application changes. 

Key changes include:
1. **WirelessFetchStrategy Fix**: Corrected the `__init__` argument name from `_disabled_features` to `disabled_features` in `tests/core/fetch_strategies/test_wireless_strategy.py` and synchronized `test_build_network_tasks` with the updated `get_network_detail_tasks` signature.
2. **AsyncMock Conversion**: Upgraded several mocks to `AsyncMock` where they are awaited in `tests/test_config_flow.py` and `tests/core/coordinator_helpers/test_data_fetcher_timeouts.py`, ensuring compatibility with Home Assistant's asynchronous execution.
3. **Mock Client Hardening**: Added a mocked `run_with_cache` method to the `mock_client` fixture in timeout tests to prevent `TypeError: object MagicMock can't be used in 'await' expression`.
4. **Namespace Integrity**: Verified the removal of module-level patches of the `meraki` library in critical endpoint and utility tests to ensure `meraki.exceptions.APIError` remains a valid exception class for application error handlers.

Fixes #2766

---
*PR created automatically by Jules for task [3811624090962340995](https://jules.google.com/task/3811624090962340995) started by @brewmarsh*