### PR TITLE
Fix switch normalization tests

### DIFF
--- a/tests/core/api/endpoints/test_switch_normalization.py
+++ b/tests/core/api/endpoints/test_switch_normalization.py
@@ -13,6 +13,11 @@ def mock_client():
     """Mock the Meraki API client."""
     client = MagicMock()
     client.run_sync = AsyncMock()
+
+    async def mock_run_with_cache(cache_key, func, ttl=None):
+        return await func()
+
+    client.run_with_cache = AsyncMock(side_effect=mock_run_with_cache)
     return client
 
 
@@ -23,48 +28,21 @@ def switch_endpoints(mock_client):
 
 
 @pytest.mark.asyncio
-async def test_get_organization_switch_ports_normalization(
+async def test_get_device_switch_ports_statuses_normalization(
     switch_endpoints, mock_client
 ):
-    """Test get_organization_switch_ports normalizes portId."""
+    """Test get_device_switch_ports_statuses returns properly."""
     mock_client.run_sync.return_value = [{"portId": "1", "enabled": True}]
 
-    result = await switch_endpoints.get_organization_switch_ports("org_id")
+    result = await switch_endpoints.get_device_switch_ports_statuses("serial")
 
     assert result == [{"portId": "1", "enabled": True}]
     assert mock_client.run_sync.call_count == 1
 
 
 @pytest.mark.asyncio
-async def test_get_organization_switch_ports_failure(switch_endpoints, mock_client):
-    """Test failure gracefully returns empty list."""
-    metadata = {"tags": ["test"], "operation": "test_op"}
-    response = MagicMock()
-    response.status_code = 400
-    response.json.return_value = {"errors": ["Some API Error"]}
-
-    # Instantiate the REAL APIError, no module patching needed
-    mock_client.run_sync.side_effect = APIError(metadata, response)
-
-    result = await switch_endpoints.get_organization_switch_ports("org_id")
-
-    assert result == []
-
-
-@pytest.mark.asyncio
-async def test_get_device_switch_ports_normalization(switch_endpoints, mock_client):
-    """Test get_device_switch_ports normalizes portId."""
-    mock_client.run_sync.return_value = [{"portId": "1", "enabled": True}]
-
-    result = await switch_endpoints.get_device_switch_ports("serial")
-
-    assert result == [{"portId": "1", "enabled": True}]
-    assert mock_client.run_sync.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_get_device_switch_ports_failure(switch_endpoints, mock_client):
-    """Test failure gracefully returns empty list."""
+async def test_get_device_switch_ports_statuses_failure(switch_endpoints, mock_client):
+    """Test failure raises MerakiConnectionError but is wrapped correctly."""
     metadata = {"tags": ["test"], "operation": "test_op"}
     response = MagicMock()
     response.status_code = 400
@@ -72,26 +50,25 @@ async def test_get_device_switch_ports_failure(switch_endpoints, mock_client):
 
     mock_client.run_sync.side_effect = APIError(metadata, response)
 
-    result = await switch_endpoints.get_device_switch_ports("serial")
-
-    assert result == []
+    from custom_components.meraki_ha.core.errors import MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await switch_endpoints.get_device_switch_ports_statuses("serial")
 
 
 @pytest.mark.asyncio
 async def test_get_switch_ports_normalization(switch_endpoints, mock_client):
-    """Test get_switch_ports normalizes portId."""
+    """Test get_switch_ports returns properly."""
     mock_client.run_sync.return_value = [{"portId": "1", "enabled": True}]
 
-    result = await switch_endpoints.get_switch_ports(["s1"])
+    result = await switch_endpoints.get_switch_ports("s1")
 
-    # The batch switch port endpoint maps serials to their ports
-    assert result == {"s1": [{"portId": "1", "enabled": True}]}
+    assert result == [{"portId": "1", "enabled": True}]
     assert mock_client.run_sync.call_count == 1
 
 
 @pytest.mark.asyncio
 async def test_get_switch_ports_failure(switch_endpoints, mock_client):
-    """Test failure gracefully returns empty dict."""
+    """Test failure raises MerakiConnectionError."""
     metadata = {"tags": ["test"], "operation": "test_op"}
     response = MagicMock()
     response.status_code = 400
@@ -99,7 +76,6 @@ async def test_get_switch_ports_failure(switch_endpoints, mock_client):
 
     mock_client.run_sync.side_effect = APIError(metadata, response)
 
-    result = await switch_endpoints.get_switch_ports(["s1"])
-
-    # The batch switch port endpoint returns an empty dict on failure
-    assert result == {}
+    from custom_components.meraki_ha.core.errors import MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await switch_endpoints.get_switch_ports("s1")


### PR DESCRIPTION
Fixes the failing tests in `tests/core/api/endpoints/test_switch_normalization.py` which were calling hallucinated or improperly defined methods. It also updates the mocks to successfully use the async cache decorators.

---
*PR created automatically by Jules for task [13742817539547102071](https://jules.google.com/task/13742817539547102071) started by @brewmarsh*