### PR TITLE
Fix Meraki HA Test Suite Availability and Logging

### DIFF
--- a/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
+++ b/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
@@ -17,7 +17,7 @@ from custom_components.meraki_ha.types import MerakiDevice
 @pytest.fixture
 def mock_coordinator_mt_binary(mock_coordinator: MagicMock) -> MagicMock:
     """Fixture for a mocked MerakiDataCoordinator with MT binary data."""
-    devices = [
+    devices_data = [
         {
             "serial": "mt20-1",
             "name": "MT20 Sensor",
@@ -63,10 +63,21 @@ def mock_coordinator_mt_binary(mock_coordinator: MagicMock) -> MagicMock:
         },
     ]
     # Ensure coordinator data has devices for availability check
-    mock_coordinator.data = {"devices": [MerakiDevice.from_dict(d) for d in devices]}
-    mock_coordinator.devices_by_serial = {
-        d.serial: d for d in mock_coordinator.data["devices"]
+    mock_coordinator.data = {
+        "devices": [MerakiDevice.from_dict(d) for d in devices_data],
+        "devices_by_serial": {d["serial"]: MerakiDevice.from_dict(d) for d in devices_data},
     }
+    # Double ensure 'status' is explicitly 'online' in the mock objects
+    for dev in mock_coordinator.data["devices_by_serial"].values():
+        dev.status = "online"
+
+    mock_coordinator.devices_by_serial = mock_coordinator.data["devices_by_serial"]
+
+    # Mock get_device to return devices from the mapping
+    mock_coordinator.get_device.side_effect = (
+        lambda s: mock_coordinator.devices_by_serial.get(s)
+    )
+
     return mock_coordinator
 
 
@@ -128,6 +139,7 @@ def test_sensor_availability(
         MT_DOOR_DESCRIPTION,
     )
 
-    # Action 4: Correctly wipe data to test unavailability
+    # Correctly wipe data to test unavailability
+    mock_coordinator_mt_binary.data = None
     mock_coordinator_mt_binary.devices_by_serial = {}
     assert sensor.available is False

--- a/tests/button/device/test_mt15_refresh_data.py
+++ b/tests/button/device/test_mt15_refresh_data.py
@@ -24,9 +24,16 @@ def mock_coordinator_mt15(mock_coordinator: MagicMock) -> MagicMock:
     # Ensure both data structures used by MerakiEntity availability are set
     mock_coordinator.data = {
         "devices": [device],
+        "devices_by_serial": {"mt15-1": device},
     }
-    mock_coordinator.devices_by_serial = {"mt15-1": device}
+    mock_coordinator.devices_by_serial = mock_coordinator.data["devices_by_serial"]
     mock_coordinator.last_update_success = True
+
+    # Mock get_device to return devices from the mapping
+    mock_coordinator.get_device.side_effect = (
+        lambda s: mock_coordinator.devices_by_serial.get(s)
+    )
+
     return mock_coordinator
 
 

--- a/tests/button/device/test_reboot.py
+++ b/tests/button/device/test_reboot.py
@@ -16,6 +16,10 @@ def mock_coordinator():
     coordinator = MagicMock()
     coordinator.data = {}
     coordinator.devices_by_serial = {}
+    # Mock get_device to return devices from the mapping
+    coordinator.get_device.side_effect = (
+        lambda s: coordinator.devices_by_serial.get(s)
+    )
     return coordinator
 
 
@@ -57,6 +61,13 @@ async def test_reboot_button_initialization(
     mock_config_entry: ConfigEntry,
 ):
     """Test the button initialization."""
+    # Ensure device is available for initialization if checks are performed
+    mock_coordinator.devices_by_serial = {mock_device.serial: mock_device}
+    mock_coordinator.data = {
+        "devices": [mock_device],
+        "devices_by_serial": mock_coordinator.devices_by_serial,
+    }
+
     button = MerakiRebootButton(
         mock_coordinator, mock_control_service, mock_device, mock_config_entry
     )
@@ -73,9 +84,12 @@ async def test_reboot_button_availability(
     mock_config_entry: ConfigEntry,
 ):
     """Test the button availability."""
-    # Action 4: Setup coordinator data for MerakiEntity availability
+    # Setup coordinator data for MerakiEntity availability
     mock_coordinator.devices_by_serial = {"Q2XX-XXXX-XXXX": mock_device}
-    mock_coordinator.data = {"devices": [mock_device]}
+    mock_coordinator.data = {
+        "devices": [mock_device],
+        "devices_by_serial": mock_coordinator.devices_by_serial,
+    }
 
     button = MerakiRebootButton(
         mock_coordinator, mock_control_service, mock_device, mock_config_entry
@@ -107,6 +121,13 @@ async def test_reboot_button_press(
     mock_config_entry: ConfigEntry,
 ):
     """Test the button press action."""
+    # Ensure device is available for serial lookup
+    mock_coordinator.devices_by_serial = {mock_device.serial: mock_device}
+    mock_coordinator.data = {
+        "devices": [mock_device],
+        "devices_by_serial": mock_coordinator.devices_by_serial,
+    }
+
     button = MerakiRebootButton(
         mock_coordinator, mock_control_service, mock_device, mock_config_entry
     )

--- a/tests/camera/test_snapshot_error_handling.py
+++ b/tests/camera/test_snapshot_error_handling.py
@@ -32,7 +32,7 @@ async def test_camera_image_api_error(
     mock_camera: MerakiRTSPStreamCamera,
     mock_camera_service: AsyncMock,
 ) -> None:
-    """Test that camera image returns None and logs warning on API error."""
+    """Test that camera image returns None and logs debug on API error."""
     mock_camera.hass = hass
 
     # Mock generate_snapshot to raise an APIError (simulating Meraki 500)
@@ -44,8 +44,8 @@ async def test_camera_image_api_error(
         image = await mock_camera.async_camera_image()
 
         assert image is None
-        mock_logger.warning.assert_called_once()
-        assert "Failed to fetch camera snapshot" in mock_logger.warning.call_args[0][0]
+        mock_logger.debug.assert_called_once()
+        assert "Failed to fetch camera snapshot" in mock_logger.debug.call_args[0][0]
 
 
 @pytest.mark.asyncio
@@ -54,7 +54,7 @@ async def test_camera_image_download_error(
     mock_camera: MerakiRTSPStreamCamera,
     mock_camera_service: AsyncMock,
 ) -> None:
-    """Test that camera image returns None and logs warning on download error."""
+    """Test that camera image returns None and logs debug on download error."""
     mock_camera.hass = hass
     mock_camera_service.generate_snapshot.return_value = (
         "https://meraki.com/snapshot.jpg"
@@ -72,7 +72,7 @@ async def test_camera_image_download_error(
             image = await mock_camera.async_camera_image()
 
             assert image is None
-            mock_logger.warning.assert_called_once()
+            mock_logger.debug.assert_called_once()
             assert (
-                "Failed to fetch camera snapshot" in mock_logger.warning.call_args[0][0]
+                "Failed to fetch camera snapshot" in mock_logger.debug.call_args[0][0]
             )


### PR DESCRIPTION
Fixed several failing tests in the `meraki_ha` integration. 
1. **Entity Availability**: Updated tests for MT binary sensors, MT15 refresh button, and reboot buttons to correctly mock the data structures required by the base `MerakiEntity.available` property. This included adding `get_device` to the mock coordinators and ensuring the `devices_by_serial` mapping is present in `coordinator.data`. Mocked devices now explicitly include `status="online"` where required.
2. **Camera Logger Assertions**: Adjusted `tests/camera/test_snapshot_error_handling.py` to check for `debug` level logs when snapshot fetching fails, as the implementation uses `_LOGGER.debug` for these transient or expected failures.
3. **Environment Setup**: Ensured test dependencies from `requirements_test.txt` are installed for proper execution.

Fixes #2783

---
*PR created automatically by Jules for task [6388812558514918183](https://jules.google.com/task/6388812558514918183) started by @brewmarsh*