### PR TITLE
Fix unawaited coroutine warnings in appliance strategy and graceful degradation tests

### DIFF
--- a/tests/core/coordinator_helpers/test_graceful_degradation.py
+++ b/tests/core/coordinator_helpers/test_graceful_degradation.py
@@ -56,6 +56,8 @@ async def test_async_gather_with_timeout_graceful_traffic_analysis(
 
     tasks = {"test_traffic": traffic_error_coro()}
 
+    import asyncio
+
     with patch(
         "custom_components.meraki_ha.core.coordinator_helpers.batch_utils._LOGGER"
     ) as mock_logger:
@@ -64,6 +66,11 @@ async def test_async_gather_with_timeout_graceful_traffic_analysis(
         )
 
         results = await async_gather_with_timeout(tasks, label="Test Graceful")
+
+    # Clean up unawaited coroutines
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
 
     # Assert correct return type
     assert results["test_traffic"] is None

--- a/tests/core/fetch_strategies/test_appliance_strategy.py
+++ b/tests/core/fetch_strategies/test_appliance_strategy.py
@@ -54,13 +54,26 @@ def test_build_network_tasks_skips_disabled(strategy, disabled_features):
     # Patch async methods to avoid unawaited coroutine warnings
     with (
         patch.object(
-            strategy.device_helper, "get_appliance_ports", return_value=[]
+            strategy.device_helper,
+            "get_appliance_ports",
+            new_callable=MagicMock,
+            return_value=[],
         ),
         patch.object(
-            strategy.uplink_helper, "get_uplink_performance", return_value=[]
+            strategy.uplink_helper,
+            "get_uplink_performance",
+            new_callable=MagicMock,
+            return_value=[],
         ),
     ):
         strategy.build_network_tasks(network_id, tasks)
+
+    import asyncio
+
+    # Clean up unawaited coroutines
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
 
     assert f"traffic_{network_id}" not in tasks
     assert f"vlans_{network_id}" not in tasks
@@ -75,13 +88,26 @@ def test_build_network_tasks_includes_enabled(strategy, disabled_features):
     # Patch async methods to avoid unawaited coroutine warnings
     with (
         patch.object(
-            strategy.device_helper, "get_appliance_ports", return_value=[]
+            strategy.device_helper,
+            "get_appliance_ports",
+            new_callable=MagicMock,
+            return_value=[],
         ),
         patch.object(
-            strategy.uplink_helper, "get_uplink_performance", return_value=[]
+            strategy.uplink_helper,
+            "get_uplink_performance",
+            new_callable=MagicMock,
+            return_value=[],
         ),
     ):
         strategy.build_network_tasks(network_id, tasks)
+
+    import asyncio
+
+    # Clean up unawaited coroutines
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
 
     assert f"traffic_{network_id}" in tasks
     assert f"vlans_{network_id}" in tasks
@@ -109,15 +135,24 @@ def test_build_network_tasks_respects_feature_flags(mock_client, disabled_featur
         patch.object(
             strategy_enabled.device_helper,
             "get_appliance_ports",
+            new_callable=MagicMock,
             return_value=[],
         ),
         patch.object(
             strategy_enabled.uplink_helper,
             "get_uplink_performance",
+            new_callable=MagicMock,
             return_value=[],
         ),
     ):
         strategy_enabled.build_network_tasks(network_id, tasks)
+
+    import asyncio
+
+    # Clean up unawaited coroutines
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
 
     assert f"vpn_status_{network_id}" in tasks
     assert f"l3_firewall_rules_{network_id}" in tasks
@@ -138,15 +173,22 @@ def test_build_network_tasks_respects_feature_flags(mock_client, disabled_featur
         patch.object(
             strategy_disabled.device_helper,
             "get_appliance_ports",
+            new_callable=MagicMock,
             return_value=[],
         ),
         patch.object(
             strategy_disabled.uplink_helper,
             "get_uplink_performance",
+            new_callable=MagicMock,
             return_value=[],
         ),
     ):
         strategy_disabled.build_network_tasks(network_id, tasks)
+
+    # Clean up unawaited coroutines
+    for task in tasks.values():
+        if asyncio.iscoroutine(task):
+            task.close()
 
     assert f"vpn_status_{network_id}" not in tasks
     assert f"l3_firewall_rules_{network_id}" not in tasks
@@ -217,7 +259,11 @@ def test_process_device_details_ports(strategy):
         ]
     }
 
-    strategy.process_device_details(mock_device, detail_data, None)
+    # Patch uplink_helper to avoid unawaited coroutine warnings
+    with patch.object(
+        strategy.uplink_helper, "get_uplink_performance", new_callable=MagicMock
+    ):
+        strategy.process_device_details(mock_device, detail_data, None)
 
     assert len(mock_device.appliance_ports) == 2
     assert mock_device.appliance_ports[0].number == 1


### PR DESCRIPTION
This PR fixes several `RuntimeWarning: coroutine was never awaited` warnings in the pytest suite for `tests/core/coordinator_helpers/test_graceful_degradation.py` and `tests/core/fetch_strategies/test_appliance_strategy.py`. 

The fixes include:
1. Adding explicit cleanup loops to close coroutine objects in task dictionaries that were being populated but not fully gathered or awaited in the tests.
2. Using `new_callable=MagicMock` when patching async methods that are called in a way where an `AsyncMock` (which returns a coroutine by default) is not desired or appropriate for the test's execution flow.
3. Patching unawaited async helper calls in synchronous test methods.

All affected tests have been verified to pass with warnings enabled (`-W always`).

Fixes #2786

---
*PR created automatically by Jules for task [18195401466666835574](https://jules.google.com/task/18195401466666835574) started by @brewmarsh*