### PR TITLE
Fix Test Suite 9: Remove Broad Mocks and Resolve Pollution

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,12 +5,6 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock
 
-# Mock meraki if not installed to avoid ModuleNotFoundError during collection
-try:
-    import meraki  # noqa: F401
-except ImportError:
-    sys.modules["meraki"] = MagicMock()
-    sys.modules["meraki.exceptions"] = MagicMock()
 
 from typing import Any
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,26 +26,6 @@ def cleanup_ipsk_manager(hass: HomeAssistant) -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_meraki():
-    """Mock meraki module to avoid installation issues."""
-    if "meraki" not in sys.modules:
-        mock_meraki_module = MagicMock()
-        mock_exceptions_module = MagicMock()
-
-        # Create a mock exception class
-        class MockAPIError(Exception):
-            pass
-
-        mock_exceptions_module.APIError = MockAPIError
-
-        # Link them
-        mock_meraki_module.exceptions = mock_exceptions_module
-
-        sys.modules["meraki"] = mock_meraki_module
-        sys.modules["meraki.exceptions"] = mock_exceptions_module
-
-
-@pytest.fixture(autouse=True)
 def mock_aiortc():
     """Mock aiortc module to avoid installation issues."""
     if "aiortc" not in sys.modules:


### PR DESCRIPTION
This change fixes a set of failures in the meraki_ha test suite. 

1. **Migration Test Fix**: In `tests/test_migration.py`, the `MockConfigEntry` was being treated as a `MagicMock` instead of the real class because of global module-level mocking in other files (specifically `tests/core/parsers/test_appliance_parser.py`). By removing these broad `sys.modules` overrides, `MockConfigEntry` now correctly preserves state (like `entry.version`) during migration.

2. **BaseException Crash Fix**: The `MerakiClient.run_sync` method was crashing when encountering a simulated `meraki.APIError` because the `meraki` module was being mocked globally in `tests/conftest.py` and `tests/__init__.py`. This caused `APIError` to be a `MagicMock` which does not inherit from `BaseException`. Removing these broad mocks ensures the real `meraki.exceptions.APIError` is used, allowing it to be raised and caught normally.

3. **Dependency Alignment**: All test dependencies from `requirements_test.txt` were installed to ensure the real `meraki` and `homeassistant` testing utilities are available for the suite.

Fixes #2789

---
*PR created automatically by Jules for task [4320404253144746575](https://jules.google.com/task/4320404253144746575) started by @brewmarsh*