### PR TITLE
fix: align test mocks with entity availability and logger logic

### DIFF
--- a/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
+++ b/tests/binary_sensor/device/test_meraki_mt_binary_sensor.py
@@ -129,5 +129,5 @@ def test_sensor_availability(
     )
 
     # Action 4: Correctly wipe data to test unavailability
-    mock_coordinator_mt_binary.devices_by_serial = {}
+    mock_coordinator_mt_binary.data = None
     assert sensor.available is False

--- a/tests/button/device/test_mt15_refresh_data.py
+++ b/tests/button/device/test_mt15_refresh_data.py
@@ -24,8 +24,10 @@ def mock_coordinator_mt15(mock_coordinator: MagicMock) -> MagicMock:
     # Ensure both data structures used by MerakiEntity availability are set
     mock_coordinator.data = {
         "devices": [device],
+        "devices_by_serial": {"mt15-1": device},
     }
     mock_coordinator.devices_by_serial = {"mt15-1": device}
+    mock_coordinator.get_device.return_value = device
     mock_coordinator.last_update_success = True
     return mock_coordinator
 

--- a/tests/button/device/test_reboot.py
+++ b/tests/button/device/test_reboot.py
@@ -16,6 +16,7 @@ def mock_coordinator():
     coordinator = MagicMock()
     coordinator.data = {}
     coordinator.devices_by_serial = {}
+    coordinator.get_device = MagicMock(return_value=None)
     return coordinator
 
 
@@ -75,7 +76,13 @@ async def test_reboot_button_availability(
     """Test the button availability."""
     # Action 4: Setup coordinator data for MerakiEntity availability
     mock_coordinator.devices_by_serial = {"Q2XX-XXXX-XXXX": mock_device}
-    mock_coordinator.data = {"devices": [mock_device]}
+    mock_coordinator.data = {
+        "devices": [mock_device],
+        "devices_by_serial": {"Q2XX-XXXX-XXXX": mock_device},
+    }
+    mock_coordinator.get_device.side_effect = (
+        lambda serial: mock_coordinator.devices_by_serial.get(serial)
+    )
 
     button = MerakiRebootButton(
         mock_coordinator, mock_control_service, mock_device, mock_config_entry
@@ -89,6 +96,12 @@ async def test_reboot_button_availability(
     # MT10 does NOT have "reboot" capability
     mock_device.model = "MT10"
     # Need to trigger update because button stores its own _device
+    button._handle_coordinator_update()
+    assert button.available is False
+
+    # Unknown model with no reboot capability (manually overriding DEVICE_CAPABILITIES is hard,
+    # so we test a known MT model that doesn't have it in the matrix).
+    mock_device.model = "MT20"
     button._handle_coordinator_update()
     assert button.available is False
 

--- a/tests/camera/test_snapshot_error_handling.py
+++ b/tests/camera/test_snapshot_error_handling.py
@@ -44,8 +44,8 @@ async def test_camera_image_api_error(
         image = await mock_camera.async_camera_image()
 
         assert image is None
-        mock_logger.warning.assert_called_once()
-        assert "Failed to fetch camera snapshot" in mock_logger.warning.call_args[0][0]
+        mock_logger.debug.assert_called_once()
+        assert "Failed to fetch camera snapshot" in mock_logger.debug.call_args[0][0]
 
 
 @pytest.mark.asyncio
@@ -72,7 +72,7 @@ async def test_camera_image_download_error(
             image = await mock_camera.async_camera_image()
 
             assert image is None
-            mock_logger.warning.assert_called_once()
+            mock_logger.debug.assert_called_once()
             assert (
-                "Failed to fetch camera snapshot" in mock_logger.warning.call_args[0][0]
+                "Failed to fetch camera snapshot" in mock_logger.debug.call_args[0][0]
             )


### PR DESCRIPTION
- Update `tests/binary_sensor/device/test_meraki_mt_binary_sensor.py` to correctly test unavailability by setting `coordinator.data = None`.
- Update `tests/button/device/test_mt15_refresh_data.py` and `tests/button/device/test_reboot.py` to include consistent coordinator data structures (`devices_by_serial` inside `data`) and ensure 'status': 'online' for availability checks.
- Add `get_device` mock to `test_reboot.py` to fix availability logic failures.
- Update `tests/camera/test_snapshot_error_handling.py` to assert `debug` logs instead of `warning`, matching the implementation in `camera.py`.

## 🛠 Integration Contribution Summary

### 🎯 Versioning & Type

**PR Title Format:** `[major|minor|patch] Short Description`

- [ ] **Type:** (Bug fix / New feature / Breaking change)

### 🔗 Context

- **Linked Issue:** Fixes #
- **Milestone:** v2.3.0 (2026.1 Infrastructure Update)

### 🛠 2026.1 Compliance Checklist

- [ ] **Naming:** Implemented `has_entity_name: true` & Sentence case.
- [ ] **Translations:** Updated `strings.json` and linked `en.json`.
- [ ] **Categorization:** Moved technical metadata to `DIAGNOSTIC`.
- [ ] **Refactoring:** Followed `ROADMAP.md` instructions.

### ✍️ Documentation & Quality

- [ ] **Comments:** I have commented code in complex Meraki API logic areas.
- [ ] **Self-Review:** I have verified this code generates no new `meraki_ha` warnings.
- [ ] **Roadmap:** I have marked the task as complete in `ROADMAP.md` (if applicable).

---

**Contributor Type:**

- [ ] Human Developer
- [ ] Jules AI Agent

_Please review for 2026.1 architectural alignment before merging into beta._
