### PR TITLE
Fix test suite 7 - Topology tests remediation

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -33,4 +33,4 @@ async def test_network_device_creation(
     )
     assert device is not None
     # Refactor: New name format for Virtual Controller
-    assert device.name == "[Network] Site A"
+    assert device.name == "Site: Site A"


### PR DESCRIPTION
Updated tests/test_topology.py to use the correct 'Site: {name}' naming convention for network devices. Verified that no broad module-level patches are present in the file to ensure proper dependency resolution during Home Assistant setup. The file was written in its entirety to satisfy the requirement for complete merged file output and ensuring a clean state for the test suite.

Fixes #2787

---
*PR created automatically by Jules for task [14734559081873616536](https://jules.google.com/task/14734559081873616536) started by @brewmarsh*