### PR TITLE
Fix CI pipeline ModuleNotFoundError for 'meraki' dependency

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -190,7 +190,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          if ! uv run --with pytest-homeassistant-custom-component --with pytest-cov --with PyTurboJPEG pytest tests/ \
+          if ! uv run --with pytest-homeassistant-custom-component --with pytest-cov --with PyTurboJPEG --with "meraki==1.54.0" pytest tests/ \
             --cov=custom_components/meraki_ha \
             --cov-report=term-missing \
             --cov-fail-under=80 2>&1 | tee pytest_output.txt; then

--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -80,7 +80,7 @@ jobs:
         run: uv pip install --system -r requirements_dev.txt
 
       - name: Install HA Custom Component
-        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205" "pytest>=8.3.4" PyTurboJPEG==1.7.5
+        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205" "pytest>=8.3.4" PyTurboJPEG==1.7.5 "meraki==1.54.0"
 
       - name: Force Clean DNS Stack
         run: |
@@ -123,7 +123,7 @@ jobs:
         run: uv pip install --system -r requirements_dev.txt
 
       - name: Install HA Custom Component
-        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205" "pytest>=8.3.4" PyTurboJPEG==1.7.5
+        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205" "pytest>=8.3.4" PyTurboJPEG==1.7.5 "meraki==1.54.0"
 
       - name: Force Clean DNS Stack
         run: |
@@ -191,7 +191,7 @@ jobs:
         run: uv pip install --system -r requirements_dev.txt
 
       - name: Install HA Custom Component
-        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205" "pytest>=8.3.4" PyTurboJPEG==1.7.5
+        run: uv pip install --system "pytest-homeassistant-custom-component>=0.13.205" "pytest>=8.3.4" PyTurboJPEG==1.7.5 "meraki==1.54.0"
 
       - name: Force Clean DNS Stack
         run: |


### PR DESCRIPTION
This PR addresses the immediate failure in the CI/CD pipeline where the GitHub Actions test runner crashes during the Pytest collection phase with `ModuleNotFoundError: No module named 'meraki'`.

Changes:
1.  **reusable-quality-checks.yaml**: Added `meraki==1.54.0` to the `uv pip install` command in the `type-check`, `security`, and `test` jobs. This ensures the dependency is present in the system-level Python environment used by the runner.
2.  **deploy-staging.yaml**: Added `--with "meraki==1.54.0"` to the `uv run` command for executing pytest. This ensures the ephemeral environment created by `uv` includes the Meraki SDK.

These changes follow the project's standard of using `uv` for dependency management and pinning the Meraki SDK version to `1.54.0` as specified in the integration's `manifest.json`.

Fixes #2801

---
*PR created automatically by Jules for task [3395417305889184904](https://jules.google.com/task/3395417305889184904) started by @brewmarsh*