### PR TITLE
Fix sensor test mocks for connected clients and data usage

### DIFF
--- a/tests/sensor/device/test_connected_clients.py
+++ b/tests/sensor/device/test_connected_clients.py
@@ -94,6 +94,8 @@ def mock_data_coordinator():
 def test_connected_clients_sensor_appliance(mock_data_coordinator):
     """Test the connected clients sensor for an appliance."""
     device = mock_data_coordinator.data["devices"][0]  # The appliance
+    # Explicitly set attribute for micro-targeted remediation
+    device.network_clients = [MagicMock()] * 2
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry
@@ -109,6 +111,8 @@ def test_connected_clients_sensor_appliance(mock_data_coordinator):
 def test_connected_clients_sensor_gateway(mock_data_coordinator):
     """Test the connected clients sensor for a cellular gateway."""
     device = mock_data_coordinator.data["devices"][3]  # The gateway
+    # Explicitly set attribute for micro-targeted remediation
+    device.network_clients = [MagicMock()] * 2
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry
@@ -124,6 +128,8 @@ def test_connected_clients_sensor_gateway(mock_data_coordinator):
 def test_connected_clients_sensor_switch(mock_data_coordinator):
     """Test the connected clients sensor for a switch."""
     device = mock_data_coordinator.data["devices"][1]  # The switch
+    # Explicitly set attribute for micro-targeted remediation
+    device.clients = [MagicMock()] * 1
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry
@@ -139,6 +145,8 @@ def test_connected_clients_sensor_switch(mock_data_coordinator):
 def test_connected_clients_sensor_wireless(mock_data_coordinator):
     """Test the connected clients sensor for a wireless device."""
     device = mock_data_coordinator.data["devices"][2]  # The wireless AP
+    # Explicitly set attribute for micro-targeted remediation
+    device.clients = [MagicMock()] * 3
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry

--- a/tests/sensor/device/test_data_usage.py
+++ b/tests/sensor/device/test_data_usage.py
@@ -32,12 +32,27 @@ def mock_data_coordinator():
             ]
         },
     }
+
+    def get_device(serial):
+        for d in coordinator.data["devices"]:
+            if d.serial == serial:
+                return d
+        return None
+
+    coordinator.get_device.side_effect = get_device
     return coordinator
 
 
 def test_data_usage_sensor(mock_data_coordinator):
     """Test the data usage sensor."""
     device = mock_data_coordinator.data["devices"][0]
+    # Explicitly set usage_metrics for micro-targeted remediation
+    mock_metrics = MagicMock()
+    mock_metrics.total = 10.0
+    mock_metrics.sent = 2.0
+    mock_metrics.received = 8.0
+    device.usage_metrics = mock_metrics
+
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDataUsageSensor(mock_data_coordinator, device, config_entry)
     sensor.hass = MagicMock()
@@ -56,6 +71,9 @@ def test_data_usage_sensor_disabled(mock_data_coordinator):
     mock_data_coordinator.data["appliance_traffic"]["net-123"] = {"error": "disabled"}
 
     device = mock_data_coordinator.data["devices"][0]
+    # Explicitly set state for micro-targeted remediation
+    device.traffic_analysis_enabled = False
+
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDataUsageSensor(mock_data_coordinator, device, config_entry)
     sensor.hass = MagicMock()


### PR DESCRIPTION
Remediated failing sensor tests by aligning mocked device attributes with the implementation logic of `MerakiDeviceConnectedClientsSensor` and `MerakiDataUsageSensor`.

- Updated `tests/sensor/device/test_connected_clients.py` to include `network_clients` and `clients` on mocked devices.
- Updated `tests/sensor/device/test_data_usage.py` to include `usage_metrics` and `traffic_analysis_enabled` on mocked devices.
- Added `get_device` mocking to the `test_data_usage.py` fixture to ensure dynamic state retrieval.
- Verified all changes with `uv run pytest`.

Fixes #2803

---
*PR created automatically by Jules for task [9668737623582449887](https://jules.google.com/task/9668737623582449887) started by @brewmarsh*