### PR TITLE
Fix Test Suite 20: Resolve API Error Shape Mismatches and Enforce Connection Error Raising

### DIFF
--- a/tests/core/api/endpoints/test_appliance.py
+++ b/tests/core/api/endpoints/test_appliance.py
@@ -13,6 +13,7 @@ from custom_components.meraki_ha.core.api import (
 from custom_components.meraki_ha.core.api.endpoints.appliance import (
     ApplianceEndpoints,
 )
+from custom_components.meraki_ha.core.errors import MerakiConnectionError
 from tests.const import MOCK_NETWORK
 
 
@@ -75,9 +76,9 @@ async def test_get_network_vlans_failure(appliance_endpoints, mock_dashboard):
         metadata, response
     )
 
-    # Action 1: The core error handler returns {} on failure
+    # Action 1: The core error handler returns [] on failure
     result = await appliance_endpoints.get_network_vlans(MOCK_NETWORK.id)
-    assert result == {}
+    assert result == []
 
 
 @pytest.mark.asyncio
@@ -114,9 +115,9 @@ async def test_get_l3_firewall_rules_failure(appliance_endpoints, mock_dashboard
         APIError(metadata, response)
     )
 
-    # Action 1: The core error handler returns {} on failure
-    result = await appliance_endpoints.get_l3_firewall_rules(MOCK_NETWORK.id)
-    assert result == {}
+    # Action 2: Expected raises MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await appliance_endpoints.get_l3_firewall_rules(MOCK_NETWORK.id)
 
 
 @pytest.mark.asyncio

--- a/tests/core/api/endpoints/test_get_vlan_data.py
+++ b/tests/core/api/endpoints/test_get_vlan_data.py
@@ -114,5 +114,5 @@ async def test_get_vlan_data_api_error_graceful_fail(network_endpoints, mock_cli
 
     result = await network_endpoints.get_vlan_data(network_id)
 
-    # Action 1: The core error handler returns {} on failure
-    assert result == {}
+    # Action 1: The core error handler returns [] on failure
+    assert result == []

--- a/tests/core/api/endpoints/test_network.py
+++ b/tests/core/api/endpoints/test_network.py
@@ -6,6 +6,7 @@ import pytest
 from meraki.exceptions import APIError
 
 from custom_components.meraki_ha.core.api.endpoints.network import NetworkEndpoints
+from custom_components.meraki_ha.core.errors import MerakiConnectionError
 
 
 @pytest.fixture
@@ -57,10 +58,9 @@ async def test_get_group_policies_failure(network, mock_client):
 
     mock_client.run_sync.side_effect = APIError(metadata, response)
 
-    result = await network.get_group_policies("net1")
-
-    # Action 1: The core error handler returns {} on failure
-    assert result == {}
+    # Action 2: Expected raises MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await network.get_group_policies("net1")
 
 
 @pytest.mark.asyncio
@@ -98,10 +98,9 @@ async def test_get_network_events_failure(network, mock_client):
 
     mock_client.run_sync.side_effect = APIError(metadata, response)
 
-    result = await network.get_network_events("N_123")
-
-    # Action 1: The core error handler returns {} on failure
-    assert result == {}
+    # Action 2: Expected raises MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await network.get_network_events("N_123")
 
 
 @pytest.mark.asyncio

--- a/tests/core/api/endpoints/test_switch_normalization.py
+++ b/tests/core/api/endpoints/test_switch_normalization.py
@@ -6,6 +6,7 @@ import pytest
 from meraki.exceptions import APIError
 
 from custom_components.meraki_ha.core.api.endpoints.switch import SwitchEndpoints
+from custom_components.meraki_ha.core.errors import MerakiConnectionError
 
 
 @pytest.fixture
@@ -51,10 +52,9 @@ async def test_get_device_switch_ports_statuses_failure(switch_endpoints, mock_c
 
     mock_client.run_sync.side_effect = APIError(metadata, response)
 
-    result = await switch_endpoints.get_device_switch_ports_statuses("serial")
-
-    # Action 1: The core error handler returns {} on failure
-    assert result == {}
+    # Action 2: Expected raises MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await switch_endpoints.get_device_switch_ports_statuses("serial")
 
 
 @pytest.mark.asyncio
@@ -79,7 +79,6 @@ async def test_get_switch_ports_failure(switch_endpoints, mock_client):
 
     mock_client.run_sync.side_effect = APIError(metadata, response)
 
-    result = await switch_endpoints.get_switch_ports("s1")
-
-    # Action 1: The core error handler returns {} on failure
-    assert result == {}
+    # Action 2: Expected raises MerakiConnectionError
+    with pytest.raises(MerakiConnectionError):
+        await switch_endpoints.get_switch_ports("s1")


### PR DESCRIPTION
This submission fixes several failures in the `meraki_ha` Pytest suite caused by recent changes to `APIError` handling. 

Key changes include:
1. **Shape Mismatch Fixes**: Endpoints like `get_network_vlans` and `get_vlan_data` now correctly assert an empty list `[]` upon failure, matching their intended return type during graceful degradation.
2. **Expected Raises Enforcement**: Tests for endpoints that are designed to raise translated connection errors (e.g., `get_l3_firewall_rules`, `get_group_policies`, `get_network_events`, `get_device_switch_ports_statuses`, and `get_switch_ports`) have been updated to use `pytest.raises(MerakiConnectionError)`. This ensures that the integration's error translation logic is properly verified and that tests no longer crash on unhandled exceptions.
3. **Import Updates**: `MerakiConnectionError` has been imported into the relevant test suites to support the new assertions.

All 24 tests in the affected files passed successfully after these modifications.

Fixes #2821

---
*PR created automatically by Jules for task [6374137760219815762](https://jules.google.com/task/6374137760219815762) started by @brewmarsh*