### PR TITLE
Fix test suite 25 mock data structures

### DIFF
--- a/tests/sensor/device/test_camera_audio_detection.py
+++ b/tests/sensor/device/test_camera_audio_detection.py
@@ -17,6 +17,8 @@ def mock_coordinator():
     coordinator = MagicMock()
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.options = {}
+    # Ensure data is truthy for availability check
+    coordinator.data = {"status": "online"}
     return coordinator
 
 
@@ -34,6 +36,8 @@ def test_camera_audio_detection_sensor(mock_coordinator):
         product_type="camera",
         sense_settings={"audioDetection": {"enabled": True}},
     )
+    # Ensure device is online for availability
+    device.status = "online"
 
     mock_coordinator.get_device.return_value = device
 
@@ -60,8 +64,15 @@ def test_camera_audio_detection_sensor(mock_coordinator):
     assert sensor.icon == "mdi:microphone"
 
     # Update with missing audio detection data
-    device.sense_settings = {}
+    # To ensure it lacks the audio detection data as per remediation requirement
+    device.sense_settings = {"some_other_key": "some_value"}
     sensor._handle_coordinator_update()
 
+    assert sensor.native_value is None
+    assert sensor.icon == "mdi:microphone-question"
+
+    # Also test with sense_settings being None
+    device.sense_settings = None
+    sensor._handle_coordinator_update()
     assert sensor.native_value is None
     assert sensor.icon == "mdi:microphone-question"

--- a/tests/sensor/device/test_connected_clients.py
+++ b/tests/sensor/device/test_connected_clients.py
@@ -14,6 +14,7 @@ from custom_components.meraki_ha.types import MerakiDevice
 def mock_data_coordinator():
     """Fixture for a mocked MerakiMainCoordinator."""
     coordinator = MagicMock()
+    coordinator.config_entry = MagicMock()
     coordinator.config_entry.options = {}
     coordinator.data = {
         "devices": [
@@ -24,6 +25,7 @@ def mock_data_coordinator():
                     "model": "MX64",
                     "productType": "appliance",
                     "networkId": "net1",
+                    "status": "online",
                 }
             ),
             MerakiDevice.from_dict(
@@ -33,6 +35,7 @@ def mock_data_coordinator():
                     "model": "MS220",
                     "productType": "switch",
                     "networkId": "net1",
+                    "status": "online",
                 }
             ),
             MerakiDevice.from_dict(
@@ -42,6 +45,7 @@ def mock_data_coordinator():
                     "model": "MR52",
                     "productType": "wireless",
                     "networkId": "net1",
+                    "status": "online",
                 }
             ),
             MerakiDevice.from_dict(
@@ -51,11 +55,12 @@ def mock_data_coordinator():
                     "model": "GX20",
                     "productType": "cellularGateway",
                     "networkId": "net1",
+                    "status": "online",
                 }
             ),
         ],
         "clients": [
-            # Client 1: Online, on net1
+            # Client 1: Online, on net1 (total 2 online for net1)
             {"networkId": "net1", "status": "Online"},
             # Client 2: Online, on net1
             {"networkId": "net1", "status": "Online"},
@@ -65,20 +70,17 @@ def mock_data_coordinator():
             {"networkId": "net2", "status": "Online"},
         ],
         "clients_by_serial": {
-            # This data is now only used for switch and wireless
+            # Switch client count: 1
             "dev_switch": [
                 {"id": "client_w1"},
             ],
+            # Wireless client count: 3
             "dev_wireless": [
                 {"id": "client_ap1"},
                 {"id": "client_ap2"},
                 {"id": "client_ap3"},
             ],
         },
-        "networks": [
-            {"id": "net1", "name": "Network 1"},
-            {"id": "net2", "name": "Network 2"},
-        ],
     }
 
     def get_device(serial):
@@ -93,9 +95,7 @@ def mock_data_coordinator():
 
 def test_connected_clients_sensor_appliance(mock_data_coordinator):
     """Test the connected clients sensor for an appliance."""
-    device = mock_data_coordinator.data["devices"][0]  # The appliance
-    # Explicitly set attribute for micro-targeted remediation
-    device.network_clients = [MagicMock()] * 2
+    device = mock_data_coordinator.get_device("dev_appliance")
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry
@@ -110,9 +110,7 @@ def test_connected_clients_sensor_appliance(mock_data_coordinator):
 
 def test_connected_clients_sensor_gateway(mock_data_coordinator):
     """Test the connected clients sensor for a cellular gateway."""
-    device = mock_data_coordinator.data["devices"][3]  # The gateway
-    # Explicitly set attribute for micro-targeted remediation
-    device.network_clients = [MagicMock()] * 2
+    device = mock_data_coordinator.get_device("dev_gateway")
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry
@@ -127,9 +125,7 @@ def test_connected_clients_sensor_gateway(mock_data_coordinator):
 
 def test_connected_clients_sensor_switch(mock_data_coordinator):
     """Test the connected clients sensor for a switch."""
-    device = mock_data_coordinator.data["devices"][1]  # The switch
-    # Explicitly set attribute for micro-targeted remediation
-    device.clients = [MagicMock()] * 1
+    device = mock_data_coordinator.get_device("dev_switch")
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry
@@ -144,9 +140,7 @@ def test_connected_clients_sensor_switch(mock_data_coordinator):
 
 def test_connected_clients_sensor_wireless(mock_data_coordinator):
     """Test the connected clients sensor for a wireless device."""
-    device = mock_data_coordinator.data["devices"][2]  # The wireless AP
-    # Explicitly set attribute for micro-targeted remediation
-    device.clients = [MagicMock()] * 3
+    device = mock_data_coordinator.get_device("dev_wireless")
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDeviceConnectedClientsSensor(
         mock_data_coordinator, device, config_entry

--- a/tests/sensor/device/test_data_usage.py
+++ b/tests/sensor/device/test_data_usage.py
@@ -12,6 +12,7 @@ from custom_components.meraki_ha.types import MerakiDevice
 def mock_data_coordinator():
     """Fixture for a mocked MerakiMainCoordinator."""
     coordinator = MagicMock()
+    coordinator.config_entry = MagicMock()
     coordinator.config_entry.options = {}
     coordinator.data = {
         "devices": [
@@ -22,11 +23,13 @@ def mock_data_coordinator():
                     "model": "MX64",
                     "productType": "appliance",
                     "networkId": "net-123",
+                    "status": "online",
                 }
             )
         ],
         "appliance_traffic": {
             "net-123": [
+                # Samples in KB. Total = 10240 KB = 10.0 MB
                 {"sent": 1024, "recv": 4096},
                 {"sent": 1024, "recv": 4096},
             ]
@@ -45,14 +48,7 @@ def mock_data_coordinator():
 
 def test_data_usage_sensor(mock_data_coordinator):
     """Test the data usage sensor."""
-    device = mock_data_coordinator.data["devices"][0]
-    # Explicitly set usage_metrics for micro-targeted remediation
-    mock_metrics = MagicMock()
-    mock_metrics.total = 10.0
-    mock_metrics.sent = 2.0
-    mock_metrics.received = 8.0
-    device.usage_metrics = mock_metrics
-
+    device = mock_data_coordinator.get_device("dev1")
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDataUsageSensor(mock_data_coordinator, device, config_entry)
     sensor.hass = MagicMock()
@@ -70,10 +66,7 @@ def test_data_usage_sensor_disabled(mock_data_coordinator):
     # Overwrite the traffic data with the disabled marker
     mock_data_coordinator.data["appliance_traffic"]["net-123"] = {"error": "disabled"}
 
-    device = mock_data_coordinator.data["devices"][0]
-    # Explicitly set state for micro-targeted remediation
-    device.traffic_analysis_enabled = False
-
+    device = mock_data_coordinator.get_device("dev1")
     config_entry = mock_data_coordinator.config_entry
     sensor = MerakiDataUsageSensor(mock_data_coordinator, device, config_entry)
     sensor.hass = MagicMock()


### PR DESCRIPTION
This PR fixes the failing tests in Suite 25 of the `meraki_ha` integration. A previous remediation attempt failed because it relied on patching attributes directly onto `MerakiDevice` objects, which several sensors ignore in favor of traversing the centralized `coordinator.data` structure.

Key changes:
- In `tests/sensor/device/test_camera_audio_detection.py`, the mock device now explicitly lacks `audioDetection` settings to verify the `None` return value.
- In `tests/sensor/device/test_connected_clients.py`, the `mock_data_coordinator` fixture was rewritten to populate `coordinator.data["clients"]` (for appliances) and `coordinator.data["clients_by_serial"]` (for other devices), matching the sensor's internal logic.
- In `tests/sensor/device/test_data_usage.py`, the fixture now uses `coordinator.data["appliance_traffic"]` instead of a `usage_metrics` device attribute.

These changes ensure the tests are robust and accurately reflect the sensor implementations.

Fixes #2831

---
*PR created automatically by Jules for task [18373163410978763810](https://jules.google.com/task/18373163410978763810) started by @brewmarsh*