### PR TITLE
Fix websocket_api mocking crashes and refine test isolation

### DIFF
--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -17,35 +17,16 @@ from custom_components.meraki_ha.const.config import (
 )
 from custom_components.meraki_ha.const.integration import DOMAIN
 
+@pytest.fixture(autouse=True)
+def verify_cleanup() -> Generator[None, None, None]:
+    """Override verify_cleanup to avoid spurious thread errors."""
+    yield
+
 MOCK_DATA = {
     "org_name": "Test Org",
     "networks": [{"id": "N_123", "name": "Test Network"}],
     "devices": [],
 }
-
-
-@pytest.fixture(autouse=True)
-def bypass_platform_setup() -> Generator[None, None, None]:
-    """Override global fixture to allow component setup."""
-    yield
-
-
-@pytest.fixture(autouse=True)
-def mock_http(hass: HomeAssistant) -> None:
-    """Override global fixture to avoid mocking http."""
-    pass
-
-
-@pytest.fixture(autouse=True)
-def mock_frontend(hass: HomeAssistant) -> None:
-    """Override global fixture to avoid mocking frontend."""
-    pass
-
-
-@pytest.fixture(autouse=True)
-def verify_cleanup() -> Generator[None, None, None]:
-    """Override verify_cleanup to avoid spurious thread errors."""
-    yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def mock_aiortc():
         sys.modules["aiortc.contrib.media"] = MagicMock()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_http(hass):
     """Mock the http component."""
     hass.http = MagicMock()
@@ -45,7 +45,7 @@ def mock_http(hass):
     hass.http.async_register_static_paths = AsyncMock()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_frontend(hass):
     """Mock the frontend component."""
     hass.data["frontend_extra_module_url"] = set()
@@ -65,7 +65,7 @@ def auto_enable_custom_integrations(
     yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def bypass_platform_setup() -> Generator[None, None, None]:
     """Bypass platform setup to avoid hass_frontend dependency."""
     with patch("homeassistant.setup.async_setup_component", return_value=True):

--- a/tests/core/parsers/test_appliance_parser.py
+++ b/tests/core/parsers/test_appliance_parser.py
@@ -2,18 +2,6 @@
 
 import logging
 
-# Mock homeassistant before imports if necessary
-import sys
-from unittest.mock import MagicMock
-
-sys.modules["homeassistant"] = MagicMock()
-sys.modules["homeassistant.const"] = MagicMock()
-sys.modules["homeassistant.core"] = MagicMock()
-sys.modules["homeassistant.helpers"] = MagicMock()
-sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
-sys.modules["pytest_homeassistant_custom_component"] = MagicMock()
-sys.modules["pytest_homeassistant_custom_component.common"] = MagicMock()
-
 from custom_components.meraki_ha.core.parsers.appliance import (  # noqa: E402
     parse_appliance_data,
 )

--- a/tests/meraki_select/test_content_filtering_select.py
+++ b/tests/meraki_select/test_content_filtering_select.py
@@ -1,6 +1,6 @@
 """Test the Meraki content filtering select entity."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -128,6 +128,8 @@ async def test_content_filtering_select_entity(
     mock_config_entry: MockConfigEntry,
     mock_meraki_client: AsyncMock,
     mock_data_fetch_manager: AsyncMock,
+    mock_http,
+    mock_frontend,
 ) -> None:
     """Test the content filtering select entity is created and functional."""
     assert await async_setup_component(hass, "http", {})
@@ -184,12 +186,15 @@ async def test_content_filtering_select_entity(
         # Verify API called with Security categories
         mock_meraki_client.appliance.update_network_appliance_content_filtering.assert_called_with(
             network_id=MOCK_NETWORK.id,
-            blockedUrlCategories=[
-                "meraki:contentFiltering/category/8",
-                "meraki:contentFiltering/category/9",
-                "meraki:contentFiltering/category/11",
-            ],
+            blockedUrlCategories=ANY,
         )
+        # Verify call arguments more flexibly since list order can vary
+        call_args = mock_meraki_client.appliance.update_network_appliance_content_filtering.call_args
+        assert set(call_args.kwargs["blockedUrlCategories"]) == {
+            "meraki:contentFiltering/category/8",
+            "meraki:contentFiltering/category/9",
+            "meraki:contentFiltering/category/11",
+        }
 
         # Ensure integration unloads while mocks are still active
         assert await hass.config_entries.async_unload(mock_config_entry.entry_id)

--- a/tests/meraki_select/test_meraki_content_filtering.py
+++ b/tests/meraki_select/test_meraki_content_filtering.py
@@ -103,6 +103,8 @@ async def test_content_filtering_select_entity(
     mock_config_entry: MockConfigEntry,
     mock_meraki_client: AsyncMock,
     mock_data_fetch_manager: AsyncMock,
+    mock_http,
+    mock_frontend,
 ) -> None:
     """Test the content filtering select entity is created and functional."""
     assert await async_setup_component(hass, "http", {})

--- a/tests/meraki_select/test_meraki_content_filtering_repro.py
+++ b/tests/meraki_select/test_meraki_content_filtering_repro.py
@@ -105,6 +105,8 @@ async def test_content_filtering_select_dict_response(
     mock_config_entry: MockConfigEntry,
     mock_meraki_client: AsyncMock,
     mock_data_fetch_manager: AsyncMock,
+    mock_http,
+    mock_frontend,
 ) -> None:
     """Test that the content filtering select entity handles dictionary responses."""
     assert await async_setup_component(hass, "http", {})

--- a/tests/meraki_select/test_rf_profile_select.py
+++ b/tests/meraki_select/test_rf_profile_select.py
@@ -96,6 +96,8 @@ async def test_rf_profile_select_entity(
     mock_config_entry: MockConfigEntry,
     mock_meraki_client: AsyncMock,
     mock_data_fetch_manager: AsyncMock,
+    mock_http,
+    mock_frontend,
 ) -> None:
     """Test the RF Profile select entity is created and functional."""
     assert await async_setup_component(hass, "http", {})

--- a/tests/meraki_select/test_vpn_select.py
+++ b/tests/meraki_select/test_vpn_select.py
@@ -91,6 +91,8 @@ async def test_vpn_select_entity(
     mock_config_entry: MockConfigEntry,
     mock_meraki_client: AsyncMock,
     mock_data_fetch_manager: AsyncMock,
+    mock_http,
+    mock_frontend,
 ) -> None:
     """Test the VPN select entity is created and functional."""
     assert await async_setup_component(hass, "http", {})

--- a/tests/test_static_path.py
+++ b/tests/test_static_path.py
@@ -1,6 +1,6 @@
 """Test static path registration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.core import HomeAssistant
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.meraki_ha.const.integration import DOMAIN
 
 
-async def test_static_path_registration(hass: HomeAssistant) -> None:
+async def test_static_path_registration(hass: HomeAssistant, mock_http, mock_frontend) -> None:
     """Test that static path registration uses the new async method."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -21,9 +21,23 @@ async def test_static_path_registration(hass: HomeAssistant) -> None:
     # Ensure frontend is in components to trigger the registration block
     hass.config.components.add("frontend")
 
+    mock_api_client = MagicMock()
+    mock_api_client.async_setup = AsyncMock()
+    mock_api_client.unregister_webhook = AsyncMock()
+    mock_dfm = MagicMock()
+    mock_dfm.async_initialize = AsyncMock()
+    mock_dfm.get_all_data = AsyncMock(return_value={})
+    mock_dfm.get_sensor_data = AsyncMock(return_value={})
+    mock_dfm.get_device_data = AsyncMock(return_value={})
     with (
-        patch("custom_components.meraki_ha.create_api_client"),
-        patch("custom_components.meraki_ha.coordinators.base.DataFetchManager"),
+        patch(
+            "custom_components.meraki_ha.create_api_client",
+            return_value=mock_api_client,
+        ),
+        patch(
+            "custom_components.meraki_ha.coordinators.base.DataFetchManager",
+            return_value=mock_dfm,
+        ),
         patch("custom_components.meraki_ha.async_register_webhook", return_value=None),
     ):
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_webhook_fault_tolerance.py
+++ b/tests/test_webhook_fault_tolerance.py
@@ -18,7 +18,7 @@ def mock_api_client():
 
 @pytest.mark.asyncio
 async def test_async_register_webhook_fault_tolerance(
-    hass: HomeAssistant, mock_api_client
+    hass: HomeAssistant, mock_api_client, mock_http
 ):
     """Test that async_register_webhook does not raise exceptions."""
     mock_api_client.register_webhook.side_effect = Exception("API Error")


### PR DESCRIPTION
The `websocket_api` component was crashing in tests due to broad `MagicMock` objects masquerading as core Home Assistant components or the integration itself. This PR removes aggressive module-level mocking and shifts from global `autouse` fixtures for `http` and `frontend` to explicit fixture usage. This allows Home Assistant's loader to correctly resolve dependencies during WebSocket client setup.

Key changes:
1. Deleted `sys.modules` manipulation in `tests/core/parsers/test_appliance_parser.py`.
2. Changed `mock_http`, `mock_frontend`, and `bypass_platform_setup` to non-autouse fixtures in `tests/conftest.py`.
3. Refactored `tests/api/test_websocket.py` to work with real component loading.
4. Updated approximately 7 test files to explicitly request necessary mocks.
5. Fixed `AsyncMock` vs `MagicMock` conflicts in `tests/test_static_path.py` that appeared once real component setup was triggered.

Fixes #2836

---
*PR created automatically by Jules for task [10741784637549954579](https://jules.google.com/task/10741784637549954579) started by @brewmarsh*