### PR TITLE
Add reauth flow

### DIFF
--- a/custom_components/meraki_ha/config_flow.py
+++ b/custom_components/meraki_ha/config_flow.py
@@ -16,12 +16,15 @@ from .const.config import (
     CONF_MERAKI_ORG_ID,
 )
 from .const.integration import DOMAIN
+from .reauth_flow import async_step_reauth
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Meraki."""
+
+    async_step_reauth = async_step_reauth
 
     VERSION = 2
 

--- a/tests/test_reauth_flow.py
+++ b/tests/test_reauth_flow.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock, patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant import config_entries, setup
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.meraki_ha.const.integration import DOMAIN
+from custom_components.meraki_ha.const.config import CONF_MERAKI_API_KEY, CONF_MERAKI_ORG_ID
+
+async def test_reauth_flow(hass: HomeAssistant) -> None:
+    """Test the reauthentication flow."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_MERAKI_API_KEY: "old-api-key",
+            CONF_MERAKI_ORG_ID: "old-org-id"
+        },
+        entry_id="test_reauth_entry_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth"
+
+    with patch(
+        "custom_components.meraki_ha.reauth_flow.validate_meraki_credentials",
+        new_callable=AsyncMock,
+        return_value=True
+    ), patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        new_callable=AsyncMock,
+        return_value=True
+    ) as mock_reload:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_MERAKI_API_KEY: "new-api-key",
+                CONF_MERAKI_ORG_ID: "new-org-id",
+            },
+        )
+
+    assert result2["type"] == FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+
+    assert entry.data[CONF_MERAKI_API_KEY] == "new-api-key"
+    assert entry.data[CONF_MERAKI_ORG_ID] == "new-org-id"
+    mock_reload.assert_called_once_with(entry.entry_id)


### PR DESCRIPTION
Added missing reauth flow implementation to allow users to update their credentials smoothly without having to recreate the entire integration.

---
*PR created automatically by Jules for task [9228894564126824859](https://jules.google.com/task/9228894564126824859) started by @brewmarsh*