### PR TITLE
test: Add unit tests for sensor entities to improve code coverage

### DIFF
--- a/tests/sensor/device/test_camera_sense_status.py
+++ b/tests/sensor/device/test_camera_sense_status.py
@@ -1,0 +1,108 @@
+"""Tests for the Meraki Camera Sense Status sensor."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.sensor.device.camera_sense_status import (
+    MerakiCameraSenseStatusSensor,
+)
+from custom_components.meraki_ha.core.models.device import MerakiDevice
+from homeassistant.const import EntityCategory
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mocked MerakiCameraCoordinator."""
+    coordinator = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {}
+    # Ensure data is truthy for availability check
+    coordinator.data = {"status": "online"}
+    return coordinator
+
+
+def test_camera_sense_status_sensor(mock_coordinator):
+    """Test the camera sense status sensor."""
+    hass = MagicMock()
+
+    # Create a mock device with sense enabled
+    device = MerakiDevice(
+        serial="test_serial",
+        name="Test Camera",
+        model="MV2",
+        mac="00:11:22:33:44:55",
+        network_id="net1",
+        product_type="camera",
+        sense_settings={"senseEnabled": True},
+    )
+    # Ensure device is online for availability
+    device.status = "online"
+
+    mock_coordinator.get_device.return_value = device
+
+    sensor = MerakiCameraSenseStatusSensor(
+        mock_coordinator, device, mock_coordinator.config_entry
+    )
+
+    assert sensor.unique_id == "test_serial_camera_sense_status"
+    assert "Sense Enabled" in sensor.name
+    assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor.native_value == "enabled"
+    assert sensor.icon == "mdi:camera-iris"
+    assert sensor.available is True
+
+    # Mock hass for the sensor
+    sensor.hass = hass
+    sensor.async_write_ha_state = MagicMock()
+
+    # Update with disabled sense
+    device.sense_settings = {"senseEnabled": False}
+    sensor._handle_coordinator_update()
+
+    assert sensor.native_value == "disabled"
+    assert sensor.icon == "mdi:camera-off-outline"
+    assert sensor.available is True
+
+    # Update with missing senseEnabled data
+    device.sense_settings = {}
+    sensor._handle_coordinator_update()
+
+    assert sensor.native_value is None
+    assert sensor.icon == "mdi:camera-question"
+    assert sensor.available is True
+
+    # Test with sense_settings being None
+    device.sense_settings = None
+    sensor._handle_coordinator_update()
+    assert sensor.native_value is None
+    assert sensor.icon == "mdi:camera-question"
+    assert sensor.available is False
+
+    # Test missing coordinator data
+    mock_coordinator.data = None
+    assert sensor.available is False
+    mock_coordinator.data = {"status": "online"}
+
+    # Test missing device data
+    mock_coordinator.get_device.return_value = None
+    sensor._handle_coordinator_update()
+    assert sensor.native_value is None
+    assert sensor.icon == "mdi:help-rhombus"
+    assert sensor.available is False
+
+
+def test_camera_sense_status_missing_serial(mock_coordinator):
+    """Test that ValueError is raised if serial is missing."""
+    device = MerakiDevice(
+        serial=None,
+        name="Test Camera",
+        model="MV2",
+        mac="00:11:22:33:44:55",
+        network_id="net1",
+        product_type="camera",
+    )
+    with pytest.raises(ValueError, match="Device serial cannot be None"):
+        MerakiCameraSenseStatusSensor(
+            mock_coordinator, device, mock_coordinator.config_entry
+        )

--- a/tests/sensor/network/test_ssid_auth_mode.py
+++ b/tests/sensor/network/test_ssid_auth_mode.py
@@ -1,0 +1,37 @@
+"""Tests for the Meraki SSID Auth Mode sensor."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.sensor.network.ssid_auth_mode import (
+    MerakiSSIDAuthModeSensor,
+)
+from homeassistant.const import EntityCategory
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mocked MerakiMainCoordinator."""
+    coordinator = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {}
+    coordinator.data = {
+        "ssids": {
+            0: {"number": 0, "name": "Test SSID", "authMode": "psk", "networkId": "net1"}
+        }
+    }
+    return coordinator
+
+
+def test_ssid_auth_mode_sensor(mock_coordinator):
+    """Test the SSID Auth Mode sensor."""
+    ssid_data = {"number": 0, "name": "Test SSID", "authMode": "psk", "networkId": "net1"}
+
+    sensor = MerakiSSIDAuthModeSensor(
+        mock_coordinator, mock_coordinator.config_entry, ssid_data
+    )
+
+    assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor.native_value == "psk"
+    assert sensor.icon == "mdi:lock"

--- a/tests/sensor/network/test_ssid_availability.py
+++ b/tests/sensor/network/test_ssid_availability.py
@@ -1,0 +1,35 @@
+"""Tests for the Meraki SSID Availability sensor."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.sensor.network.ssid_availability import (
+    MerakiSSIDAvailabilitySensor,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mocked MerakiMainCoordinator."""
+    coordinator = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {}
+    coordinator.data = {
+        "ssids": {
+            0: {"number": 0, "name": "Test SSID", "enabled": True, "networkId": "net1"}
+        }
+    }
+    return coordinator
+
+
+def test_ssid_availability_sensor(mock_coordinator):
+    """Test the SSID Availability sensor."""
+    ssid_data = {"number": 0, "name": "Test SSID", "enabled": True, "networkId": "net1"}
+
+    sensor = MerakiSSIDAvailabilitySensor(
+        mock_coordinator, mock_coordinator.config_entry, ssid_data
+    )
+
+    assert sensor.native_value is True
+    assert sensor.icon == "mdi:check-circle-outline"

--- a/tests/sensor/network/test_ssid_band_selection.py
+++ b/tests/sensor/network/test_ssid_band_selection.py
@@ -1,0 +1,37 @@
+"""Tests for the Meraki SSID Band Selection sensor."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.meraki_ha.sensor.network.ssid_band_selection import (
+    MerakiSSIDBandSelectionSensor,
+)
+from homeassistant.const import EntityCategory
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Fixture for a mocked MerakiMainCoordinator."""
+    coordinator = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {}
+    coordinator.data = {
+        "ssids": {
+            0: {"number": 0, "name": "Test SSID", "bandSelection": "Dual band operation with Band Steering", "networkId": "net1"}
+        }
+    }
+    return coordinator
+
+
+def test_ssid_band_selection_sensor(mock_coordinator):
+    """Test the SSID Band Selection sensor."""
+    ssid_data = {"number": 0, "name": "Test SSID", "bandSelection": "Dual band operation with Band Steering", "networkId": "net1"}
+
+    sensor = MerakiSSIDBandSelectionSensor(
+        mock_coordinator, mock_coordinator.config_entry, ssid_data
+    )
+
+    assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor.native_value == "Dual band operation with Band Steering"
+    assert sensor.icon == "mdi:wifi-arrow-up-down"


### PR DESCRIPTION
This pull request adds several unit tests for different sensor entities in the integration to raise the code coverage above the CI requirement of 75%.

Specifically tested:
- `MerakiCameraSenseStatusSensor`
- `MerakiSSIDAuthModeSensor`
- `MerakiSSIDAvailabilitySensor`
- `MerakiSSIDBandSelectionSensor`

The `uv run` tests have been executed with `pytest-cov` to verify that coverage reaches 75.03%.

---
*PR created automatically by Jules for task [8522074972813140812](https://jules.google.com/task/8522074972813140812) started by @brewmarsh*