### PR TITLE
Fix sys.path problem in testing by updating pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 addopts = --import-mode=importlib
+pythonpath = .


### PR DESCRIPTION
Added `pythonpath = .` to `pytest.ini` to resolve `ModuleNotFoundError: No module named 'custom_components'` during test execution. Verified the fix by running representative tests that import from the `custom_components` directory.

Fixes #2866

---
*PR created automatically by Jules for task [49794793477959998](https://jules.google.com/task/49794793477959998) started by @brewmarsh*