### PR TITLE
chore(release): promote hotfix v2.5.1 to main

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.3.0-beta.3629"
+current_version = "2.3.0-beta.3630"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.3.0-beta.3628"
+current_version = "2.3.0-beta.3629"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.3.0-beta.3630"
+current_version = "2.3.0-beta.3631"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.3.0-beta.3631"
+current_version = "2.3.0-beta.3630"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.3.0-beta.3631"
+current_version = "2.5.1"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## [2.3.0-beta.3630] - 2026-04-08
+## [2.5.1] - 2026-04-08
 
 ### Fixed
 
 - Downgraded `PyJWT` requirement to `2.10.1` to resolve a fatal installation crash caused by an unsatisfiable dependency conflict with Home Assistant Core.
+
+## [2.5.0] - 2026-04-08
+
+### Minor Release
+
+- Promoted all features and fixes from beta.
+- Full details available in the GitHub Release notes.
 
 ## [2.3.0-beta.3627] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.3.0-beta.3630] - 2026-04-08
+
+### Fixed
+
+- Downgraded `PyJWT` requirement to `2.10.1` to resolve a fatal installation crash caused by an unsatisfiable dependency conflict with Home Assistant Core.
+
 ## [2.3.0-beta.3627] - 2026-04-08
 
 ### Security

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,17 +1,10 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": [
-    "webrtc",
-    "frontend"
-  ],
-  "codeowners": [
-    "@brewmarsh"
-  ],
+  "after_dependencies": ["webrtc", "frontend"],
+  "codeowners": ["@brewmarsh"],
   "config_flow": true,
-  "dependencies": [
-    "http"
-  ],
+  "dependencies": ["http"],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -31,9 +24,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": [
-    "meraki_ha"
-  ],
+  "loggers": ["meraki_ha"],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -53,5 +44,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.3.0-beta.3631"
+  "version": "2.3.0-beta.3630"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -53,5 +53,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.3.0-beta.3629"
+  "version": "2.3.0-beta.3630"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,17 +1,10 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": [
-    "webrtc",
-    "frontend"
-  ],
-  "codeowners": [
-    "@brewmarsh"
-  ],
+  "after_dependencies": ["webrtc", "frontend"],
+  "codeowners": ["@brewmarsh"],
   "config_flow": true,
-  "dependencies": [
-    "http"
-  ],
+  "dependencies": ["http"],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -31,9 +24,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": [
-    "meraki_ha"
-  ],
+  "loggers": ["meraki_ha"],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -46,12 +37,12 @@
     "orjson>=3.9.0",
     "pillow>=12.1.1",
     "pycares>=4.11.0",
-    "PyJWT>=2.12.0",
+    "PyJWT>=2.10.1",
     "pyOpenSSL>=26.0.0",
     "python-dotenv",
     "requests>=2.33.0",
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.3.0-beta.3629"
+  "version": "2.3.0-beta.3630"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,10 +1,17 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": ["webrtc", "frontend"],
-  "codeowners": ["@brewmarsh"],
+  "after_dependencies": [
+    "webrtc",
+    "frontend"
+  ],
+  "codeowners": [
+    "@brewmarsh"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -24,7 +31,9 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": ["meraki_ha"],
+  "loggers": [
+    "meraki_ha"
+  ],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -44,5 +53,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.3.0-beta.3630"
+  "version": "2.3.0-beta.3631"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,10 +1,17 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": ["webrtc", "frontend"],
-  "codeowners": ["@brewmarsh"],
+  "after_dependencies": [
+    "webrtc",
+    "frontend"
+  ],
+  "codeowners": [
+    "@brewmarsh"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -24,7 +31,9 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": ["meraki_ha"],
+  "loggers": [
+    "meraki_ha"
+  ],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -44,5 +53,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.3.0-beta.3628"
+  "version": "2.3.0-beta.3629"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,17 +1,10 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": [
-    "webrtc",
-    "frontend"
-  ],
-  "codeowners": [
-    "@brewmarsh"
-  ],
+  "after_dependencies": ["webrtc", "frontend"],
+  "codeowners": ["@brewmarsh"],
   "config_flow": true,
-  "dependencies": [
-    "http"
-  ],
+  "dependencies": ["http"],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -31,9 +24,7 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": [
-    "meraki_ha"
-  ],
+  "loggers": ["meraki_ha"],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -53,5 +44,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.3.0-beta.3631"
+  "version": "2.5.1"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.3629",
+  "version": "2.3.0-beta.3630",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.3629",
+      "version": "2.3.0-beta.3630",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.3628",
+  "version": "2.3.0-beta.3629",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.3628",
+      "version": "2.3.0-beta.3629",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.3627",
+  "version": "2.3.0-beta.3628",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.3627",
+      "version": "2.3.0-beta.3628",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.3.0-beta.3629",
+  "version": "2.3.0-beta.3630",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.3.0-beta.3631",
+  "version": "2.5.1",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.3.0-beta.3630",
+  "version": "2.3.0-beta.3631",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.3.0-beta.3628",
+  "version": "2.3.0-beta.3629",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.3.0-beta.3631",
+  "version": "2.3.0-beta.3630",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.3.0-beta.3630",
+  "version": "2.3.0-beta.3631",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.3.0-beta.3631",
+  "version": "2.3.0-beta.3630",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.3.0-beta.3628",
+  "version": "2.3.0-beta.3629",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.3.0-beta.3629",
+  "version": "2.3.0-beta.3630",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.3.0-beta.3631",
+  "version": "2.5.1",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meraki_ha"
-version = "2.3.0-beta.1735"
+version = "2.3.0-beta.1736"
 dependencies = [
     "baml-py>=0.219.0",
     "tree-sitter>=0.25.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pre-commit
 psutil-home-assistant==0.0.1
 py==1.11.0
 pycares>=4.11.0
-PyJWT>=2.12.0
+PyJWT>=2.10.1
 pyOpenSSL>=26.0.0
 python-dotenv
 pytest-asyncio


### PR DESCRIPTION
Downgrade PyJWT to 2.10.1 to resolve HA Core installation crash and align version to 2.5.1.