### PR TITLE
chore(release): promote hotfix v2.5.2 to main

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.5.1-gamma.3"
+current_version = "2.5.2"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.5.2"
+current_version = "2.5.2-gamma.2"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.5.1-gamma.2"
+current_version = "2.5.1-gamma.3"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.5.1"
+current_version = "2.5.1-gamma.2"
 commit = false
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<release>[a-z]+)\\.(?P<build>\\d+))?"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         run: echo "tag=v$(jq -r .version custom_components/meraki_ha/manifest.json)" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_version.outputs.tag }}
           prerelease: ${{ github.ref_name == 'beta' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.5.2] - 2026-04-08
+
+### Fixed
+
+- Downgraded `cryptography` requirement to `>=46.0.5` to resolve a fatal installation crash caused by an unsatisfiable dependency conflict with Home Assistant Core.
+
 ## [2.5.1] - 2026-04-08
 
 ### Fixed

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,10 +1,17 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": ["webrtc", "frontend"],
-  "codeowners": ["@brewmarsh"],
+  "after_dependencies": [
+    "webrtc",
+    "frontend"
+  ],
+  "codeowners": [
+    "@brewmarsh"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -24,7 +31,9 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": ["meraki_ha"],
+  "loggers": [
+    "meraki_ha"
+  ],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -44,5 +53,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.5.1"
+  "version": "2.5.1-gamma.2"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,10 +1,17 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": ["webrtc", "frontend"],
-  "codeowners": ["@brewmarsh"],
+  "after_dependencies": [
+    "webrtc",
+    "frontend"
+  ],
+  "codeowners": [
+    "@brewmarsh"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -24,7 +31,9 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": ["meraki_ha"],
+  "loggers": [
+    "meraki_ha"
+  ],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
@@ -44,5 +53,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.5.2"
+  "version": "2.5.2-gamma.2"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -53,5 +53,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.5.1-gamma.2"
+  "version": "2.5.1-gamma.3"
 }

--- a/custom_components/meraki_ha/manifest.json
+++ b/custom_components/meraki_ha/manifest.json
@@ -1,17 +1,10 @@
 {
   "domain": "meraki_ha",
   "name": "Cisco Meraki",
-  "after_dependencies": [
-    "webrtc",
-    "frontend"
-  ],
-  "codeowners": [
-    "@brewmarsh"
-  ],
+  "after_dependencies": ["webrtc", "frontend"],
+  "codeowners": ["@brewmarsh"],
   "config_flow": true,
-  "dependencies": [
-    "http"
-  ],
+  "dependencies": ["http"],
   "dhcp": [
     {
       "hostname": "meraki*",
@@ -31,16 +24,14 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/brewmarsh/meraki-homeassistant/issues",
-  "loggers": [
-    "meraki_ha"
-  ],
+  "loggers": ["meraki_ha"],
   "quality_scale": "platinum",
   "requirements": [
     "aiodns>=4.0.0",
     "aiofiles>=24.1.0",
     "aiohttp>=3.13.4",
     "braintrust>=0.12.0",
-    "cryptography>=46.0.7",
+    "cryptography>=46.0.5",
     "diskcache==5.6.3",
     "meraki==1.54.0",
     "orjson>=3.9.0",
@@ -53,5 +44,5 @@
     "urllib3>=1.26.5",
     "webrtc-models==0.3.0"
   ],
-  "version": "2.5.1-gamma.3"
+  "version": "2.5.2"
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.3.0-beta.3630",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.3.0-beta.3630",
+      "version": "2.5.1",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.5.1-gamma.2",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.5.1-gamma.2",
+      "version": "2.5.2",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meraki-ha-frontend",
-  "version": "2.5.1",
+  "version": "2.5.1-gamma.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meraki-ha-frontend",
-      "version": "2.5.1",
+      "version": "2.5.1-gamma.2",
       "dependencies": {
         "@material/mwc-list": "^0.27.0",
         "lit": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.5.1-gamma.2",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.5.1-gamma.3",
+  "version": "2.5.2",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.5.1-gamma.2",
+  "version": "2.5.1-gamma.3",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meraki-ha-frontend",
   "private": true,
-  "version": "2.5.2",
+  "version": "2.5.2-gamma.2",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.5.1",
+  "version": "2.5.1-gamma.2",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.5.2",
+  "version": "2.5.2-gamma.2",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.5.1-gamma.2",
+  "version": "2.5.1-gamma.3",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki-homeassistant",
-  "version": "2.5.1-gamma.3",
+  "version": "2.5.2",
   "description": "Meraki Home Assistant Integration",
   "scripts": {
     "test:ui": "playwright test",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp>=3.13.4
 bandit==1.7.9
 braintrust>=0.12.0
 codecov
-cryptography>=46.0.7
+cryptography>=46.0.5
 diskcache==5.6.3
 filelock==3.20.3
 fnv-hash-fast

--- a/tests/ui/guest_access_card.spec.ts
+++ b/tests/ui/guest_access_card.spec.ts
@@ -34,6 +34,33 @@ test('Guest Access Card UI Validation', async ({ page }) => {
   // Navigate to the dashboard.
   await page.goto('/');
 
+  // Action 2: Implement Login Flow if redirected to the login page
+  if (page.url().includes('/auth/authorize')) {
+    console.log('Redirected to login page. Attempting authentication...');
+
+    // Fill username
+    const username = process.env.HA_USERNAME || 'admin';
+    await page.fill('input[name="username"]', username);
+
+    // Some HA versions have a "Next" button, others show password immediately
+    const nextButton = page.locator('button:has-text("Next")');
+    if (await nextButton.isVisible()) {
+      await nextButton.click();
+    }
+
+    // Fill password
+    const password = process.env.HA_PASSWORD || 'password';
+    await page.fill('input[name="password"]', password);
+
+    // Click login button
+    await page.click('button:has-text("Log in")');
+
+    // Wait for navigation back to the app
+    await page.waitForURL((url) => !url.href.includes('/auth/authorize'), {
+      timeout: 30000,
+    });
+  }
+
   // Wait for the Home Assistant main interface to load.
   // We look for the main app-drawer-layout or similar top-level element.
   await page.waitForSelector('home-assistant', { timeout: 30000 });


### PR DESCRIPTION
Downgrade cryptography to 46.0.5 to resolve HA Core installation conflict, fix UI authentication timeouts, and align version to 2.5.2.