### PR TITLE
⚡ Bolt: Avoid intermediate list allocation during counting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Prevent List Allocation For Counting
+**Learning:** Found instances where `len([x for x in list if condition])` was used. This creates a full list in memory just to get the length.
+**Action:** Use a generator expression instead with `sum(1 for x in list if condition)` to save memory and avoid an intermediate list allocation. This improves performance inside `network_control_service.py` where client dictionaries are counted.

--- a/custom_components/meraki_ha/services/network_control_service.py
+++ b/custom_components/meraki_ha/services/network_control_service.py
@@ -40,10 +40,8 @@ class NetworkControlService:
         if not isinstance(clients, list):
             return 0
 
-        return len(
-            [
-                client
-                for client in clients
-                if isinstance(client, dict) and client.get("networkId") == network_id
-            ]
+        return sum(
+            1
+            for client in clients
+            if isinstance(client, dict) and client.get("networkId") == network_id
         )

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 **What**: Replaces list comprehension counting with generator expression `sum(1 for ...)`.
🎯 **Why**: When identifying matching network clients, the previous code materialized an entire list in memory solely to call `len()` on it. This creates unnecessary overhead and Garbage Collection churn.
📊 **Impact**: Reduces peak memory allocation slightly and avoids unnecessary processing overhead during client-count retrieval in `network_control_service.py`.
🔬 **Measurement**: Verified tests pass completely and safely avoids `len([...])` pattern.

Fixes list allocation for counting instances.

---
*PR created automatically by Jules for task [12570658445930648034](https://jules.google.com/task/12570658445930648034) started by @brewmarsh*