### PR TITLE
⚡ Bolt: Optimize calculate_network_health with single-pass iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Single-Pass Iteration for Multiple Counts
+**Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
+**Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.

--- a/custom_components/meraki_ha/core/utils/network_utils.py
+++ b/custom_components/meraki_ha/core/utils/network_utils.py
@@ -40,8 +40,16 @@ def calculate_network_health(data: dict[str, Any]) -> float:
     # Check alerts
     alerts = data.get("alerts", [])
     if alerts:
-        critical = sum(1 for a in alerts if a.get("severity") == "critical")
-        warning = sum(1 for a in alerts if a.get("severity") == "warning")
+        # Bolt Performance: Calculate both critical and warning alert counts
+        # in a single pass O(N) rather than two sequential O(N) iterations.
+        critical = 0
+        warning = 0
+        for a in alerts:
+            severity = a.get("severity")
+            if severity == "critical":
+                critical += 1
+            elif severity == "warning":
+                warning += 1
         score -= critical * 10 + warning * 5
 
     # Check client health

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 What: Replaced two separate `sum(1 for ...)` generator expressions in `calculate_network_health` with a single `for` loop to count both 'critical' and 'warning' alerts simultaneously.

🎯 Why: The previous implementation performed two sequential iterations over the `alerts` list (O(2N) time complexity) and executed duplicate `.get("severity")` dictionary lookups for each alert.

📊 Impact: Reduces time complexity to O(N) and halves the number of dictionary lookups required when processing network alerts.

🔬 Measurement: Verifiable via code inspection. Tests in `test_network_utils.py` continue to pass, proving behavior is identical while execution is more efficient.

---
*PR created automatically by Jules for task [3821505929897589734](https://jules.google.com/task/3821505929897589734) started by @brewmarsh*