### PR TITLE
⚡ Bolt: Optimize network client counting in network_control_service

### DIFF
--- a/custom_components/meraki_ha/services/network_control_service.py
+++ b/custom_components/meraki_ha/services/network_control_service.py
@@ -40,10 +40,8 @@ class NetworkControlService:
         if not isinstance(clients, list):
             return 0
 
-        return len(
-            [
-                client
-                for client in clients
-                if isinstance(client, dict) and client.get("networkId") == network_id
-            ]
+        return sum(
+            1
+            for client in clients
+            if isinstance(client, dict) and client.get("networkId") == network_id
         )

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 What: Replaced `len([client for client in clients if ...])` with `sum(1 for client in clients if ...)` in `NetworkControlService.get_network_client_count`.
🎯 Why: Avoiding intermediate list allocations using generator expressions improves memory usage and reduces garbage collection overhead in code executing hot loops.
📊 Impact: Uses less memory during iterations and reduces overhead for counting items.
🔬 Measurement: Verify correctness through existing unit tests for `get_network_client_count`.

---
*PR created automatically by Jules for task [3257142627467126329](https://jules.google.com/task/3257142627467126329) started by @brewmarsh*