### PR TITLE
⚡ Bolt: Optimize network health sensor getters to O(1)

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,16 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_devices_cache: list[str] = []
+        self._offline_count: int = 0
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_devices_cache = []
+            self._offline_count = 0
             return
 
         data = self.coordinator.data
@@ -64,18 +68,32 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         elif isinstance(data, list):
             devices = data
 
-        self._family_devices_cache = [
-            d
-            for d in devices
-            if getattr(d, "network_id", None) == self._network_id
-            and (
+        family_devices = []
+        offline_devices = []
+        offline_count = 0
+
+        for d in devices:
+            if getattr(d, "network_id", None) == self._network_id and (
                 (getattr(d, "model", "") or "").startswith(self._family_prefix)
                 or (
                     self._family_prefix == "MS"
                     and (getattr(d, "model", "") or "").startswith("GS")
                 )
-            )
-        ]
+            ):
+                family_devices.append(d)
+                if str(getattr(d, "status", "offline")).lower() not in (
+                    "online",
+                    "alerting",
+                    "dormant",
+                ):
+                    offline_devices.append(
+                        getattr(d, "name", getattr(d, "serial", "unknown"))
+                    )
+                    offline_count += 1
+
+        self._family_devices_cache = family_devices
+        self._offline_devices_cache = offline_devices
+        self._offline_count = offline_count
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -95,16 +113,9 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
-
-        if offline_count == 0:
+        if self._offline_count == 0:
             return "Online"
-        if offline_count < len(devices):
+        if self._offline_count < len(devices):
             return "Degraded"
         return "Offline"
 
@@ -114,18 +125,11 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         base_attributes = super().extra_state_attributes
         devices = self._family_devices
 
-        offline_devices = [
-            getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        ]
-
         base_attributes.update(
             {
                 "total_devices": len(devices),
-                "online_devices": len(devices) - len(offline_devices),
-                "offline_devices": offline_devices,
+                "online_devices": len(devices) - self._offline_count,
+                "offline_devices": self._offline_devices_cache,
                 "hardware_family": self._family_name,
             }
         )


### PR DESCRIPTION
* 💡 What: Pre-calculate offline device counts and attributes in `_compute_device_cache()` rather than dynamically calculating them in property getters.
* 🎯 Why: Property getters like `native_value` and `extra_state_attributes` evaluate frequently (especially during state updates or Lovelace rendering). Currently they perform O(N) list comprehensions, object allocations, and string manipulations on every access.
* 📊 Impact: Changes multiple O(N) generator iterations into a single O(N) loop that caches the results, changing the time complexity of the getters themselves to O(1).
* 🔬 Measurement: Profiling CPU time spent on entity state generation and property access for large Meraki networks should show a marked decrease.

---
*PR created automatically by Jules for task [13716216484188964010](https://jules.google.com/task/13716216484188964010) started by @brewmarsh*