### PR TITLE
⚡ Bolt: Cache network health offline devices to speed up Home Assistant properties

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,14 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_devices_cache: list[Any] = []
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_devices_cache = []
             return
 
         data = self.coordinator.data
@@ -77,6 +79,13 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             )
         ]
 
+        self._offline_devices_cache = [
+            d
+            for d in self._family_devices_cache
+            if str(getattr(d, "status", "offline")).lower()
+            not in ("online", "alerting", "dormant")
+        ]
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -95,12 +104,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
+        offline_count = len(self._offline_devices_cache)
 
         if offline_count == 0:
             return "Online"
@@ -116,9 +120,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
 
         offline_devices = [
             getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
+            for d in self._offline_devices_cache
         ]
 
         base_attributes.update(

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 What: The optimization implemented
This PR caches the list of offline devices within the `_compute_device_cache` phase during a coordinator update. The properties `native_value` and `extra_state_attributes` now reference this cached list directly rather than re-computing their own subsets using list comprehensions and generator expressions on every property access.

🎯 Why: The performance problem it solves
Home Assistant aggressively polls property getters like `native_value` and `extra_state_attributes` on each state change or frontend render loop. Previously, these getters iterated over the list of cached family devices and ran string conversions and lowercasing checks (e.g. `str(getattr(d, "status", "offline")).lower()`). By caching the final output during updates, we reduce O(N) workloads in properties to simple O(1) length checks and localized cache reads.

📊 Impact: Expected performance improvement
Reduces redundant O(N) processing by an order of magnitude, as property access frequency significantly outpaces update frequency in Home Assistant, speeding up state reporting and lowering CPU usage during render cycles.

🔬 Measurement: How to verify the improvement
Tests have been executed and validated against `tests/sensor/test_network_health.py`, verifying that the correct strings ('Online', 'Degraded', 'Offline') and expected attributes format are correctly extracted. No behaviour changes, merely an algorithmic efficiency bump.

---
*PR created automatically by Jules for task [6711570716969640381](https://jules.google.com/task/6711570716969640381) started by @brewmarsh*