### PR TITLE
⚡ Bolt: Optimize `MerakiNetworkHealthSensor` by caching offline calculations

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,16 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_count_cache: int = 0
+        self._offline_devices_cache: list[str] = []
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_count_cache = 0
+            self._offline_devices_cache = []
             return
 
         data = self.coordinator.data
@@ -64,7 +68,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         elif isinstance(data, list):
             devices = data
 
-        self._family_devices_cache = [
+        family_devices = [
             d
             for d in devices
             if getattr(d, "network_id", None) == self._network_id
@@ -76,6 +80,20 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
                 )
             )
         ]
+        self._family_devices_cache = family_devices
+
+        offline_devices = []
+        for d in family_devices:
+            if str(getattr(d, "status", "offline")).lower() not in (
+                "online",
+                "alerting",
+                "dormant",
+            ):
+                offline_devices.append(
+                    getattr(d, "name", getattr(d, "serial", "unknown"))
+                )
+        self._offline_count_cache = len(offline_devices)
+        self._offline_devices_cache = offline_devices
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -91,20 +109,13 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Calculate the aggregated state of the device family."""
-        devices = self._family_devices
+        devices = self._family_devices_cache
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
-
-        if offline_count == 0:
+        if self._offline_count_cache == 0:
             return "Online"
-        if offline_count < len(devices):
+        if self._offline_count_cache < len(devices):
             return "Degraded"
         return "Offline"
 
@@ -112,20 +123,13 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Provide detailed fractional attributes for Lovelace cards."""
         base_attributes = super().extra_state_attributes
-        devices = self._family_devices
-
-        offline_devices = [
-            getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        ]
+        devices = self._family_devices_cache
 
         base_attributes.update(
             {
                 "total_devices": len(devices),
-                "online_devices": len(devices) - len(offline_devices),
-                "offline_devices": offline_devices,
+                "online_devices": len(devices) - self._offline_count_cache,
+                "offline_devices": self._offline_devices_cache,
                 "hardware_family": self._family_name,
             }
         )

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 **What**: Added pre-calculated caches `_offline_count_cache` and `_offline_devices_cache` to `MerakiNetworkHealthSensor` during `_compute_device_cache` updates.

🎯 **Why**: The properties `native_value` and `extra_state_attributes` on Home Assistant sensors are evaluated frequently. Prior to this change, each getter individually computed the `offline_devices` count by iterating through `_family_devices` via generator comprehension. This redundant, N-time iterative traversal on a property fetch negatively affects performance when called hundreds of times.

📊 **Impact**: Turning these getters into O(1) responses instead of O(N). The recalculation of the offline device list now happens exactly *once* per update interval rather than on every access.

🔬 **Measurement**: Verified tests pass using `pytest tests/sensor/test_network_health.py` and validated Home Assistant core functionality natively by resolving properties from the local node.

---
*PR created automatically by Jules for task [14315851082718135408](https://jules.google.com/task/14315851082718135408) started by @brewmarsh*