### PR TITLE
⚡ Bolt: Optimize MerakiNetworkHealthSensor state properties

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,16 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_count = 0
+        self._offline_devices: list[str] = []
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_count = 0
+            self._offline_devices = []
             return
 
         data = self.coordinator.data
@@ -77,6 +81,20 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             )
         ]
 
+        offline_devices_names = []
+        for d in self._family_devices_cache:
+            if str(getattr(d, "status", "offline")).lower() not in (
+                "online",
+                "alerting",
+                "dormant",
+            ):
+                offline_devices_names.append(
+                    getattr(d, "name", getattr(d, "serial", "unknown"))
+                )
+
+        self._offline_devices = offline_devices_names
+        self._offline_count = len(offline_devices_names)
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -95,16 +113,9 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
-
-        if offline_count == 0:
+        if self._offline_count == 0:
             return "Online"
-        if offline_count < len(devices):
+        if self._offline_count < len(devices):
             return "Degraded"
         return "Offline"
 
@@ -114,18 +125,11 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         base_attributes = super().extra_state_attributes
         devices = self._family_devices
 
-        offline_devices = [
-            getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        ]
-
         base_attributes.update(
             {
                 "total_devices": len(devices),
-                "online_devices": len(devices) - len(offline_devices),
-                "offline_devices": offline_devices,
+                "online_devices": len(devices) - self._offline_count,
+                "offline_devices": self._offline_devices,
                 "hardware_family": self._family_name,
             }
         )


### PR DESCRIPTION
💡 What: Cached the calculation of `offline_count` and `offline_devices` inside the `_compute_device_cache` method for the `MerakiNetworkHealthSensor`.
🎯 Why: Home Assistant frequently queries properties such as `native_value` and `extra_state_attributes`. The previous implementation iterated over the entire device list to calculate offline metrics on *every single access*. By caching these at update time, property access becomes an O(1) operation rather than O(N).
📊 Impact: Eliminates O(N) evaluations during state writes and state queries for every hardware family health sensor in the Meraki integration.
🔬 Measurement: Verify through `uv run pytest tests/sensor/test_network_health.py` and overall system latency when the network has hundreds of Meraki devices.

---
*PR created automatically by Jules for task [3480057397909612519](https://jules.google.com/task/3480057397909612519) started by @brewmarsh*