### PR TITLE
⚡ Bolt: Cache offline devices in NetworkHealthSensor

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,14 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_devices_cache: list[Any] = []
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_devices_cache = []
             return
 
         data = self.coordinator.data
@@ -77,6 +79,15 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             )
         ]
 
+        # Bolt Performance: Pre-calculate offline devices during coordinator update
+        # to avoid O(N) filtering and string manipulation on every property access.
+        self._offline_devices_cache = [
+            d
+            for d in self._family_devices_cache
+            if str(getattr(d, "status", "offline")).lower()
+            not in ("online", "alerting", "dormant")
+        ]
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -95,12 +106,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
+        offline_count = len(self._offline_devices_cache)
 
         if offline_count == 0:
             return "Online"
@@ -116,9 +122,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
 
         offline_devices = [
             getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
+            for d in self._offline_devices_cache
         ]
 
         base_attributes.update(


### PR DESCRIPTION
💡 What: Moved offline device filtering from `native_value` and `extra_state_attributes` to `_compute_device_cache()` using a new `_offline_devices_cache`.

🎯 Why: Home Assistant evaluates sensor properties frequently (e.g. state machine updates, lovelace renders). Calculating the offline device list on every read triggered multiple O(N) loops with string manipulation, wasting CPU cycles on mostly static data. 

📊 Impact: Reduces property evaluation from O(N) to O(1), saving string allocations and iteration time on each state read. The list is now computed once per API update rather than on every access.

🔬 Measurement: Review `sensor/network_health.py` and run `pytest tests/sensor/test_network_health.py` to ensure behavior remains identical.

---
*PR created automatically by Jules for task [5292975628072931220](https://jules.google.com/task/5292975628072931220) started by @brewmarsh*