### PR TITLE
⚡ Bolt: [performance improvement] Cache offline devices in MerakiNetworkHealthSensor

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,14 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_devices_cache: list[str] = []
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_devices_cache = []
             return
 
         data = self.coordinator.data
@@ -77,6 +79,13 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             )
         ]
 
+        self._offline_devices_cache = [
+            getattr(d, "name", getattr(d, "serial", "unknown"))
+            for d in self._family_devices_cache
+            if str(getattr(d, "status", "offline")).lower()
+            not in ("online", "alerting", "dormant")
+        ]
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -95,12 +104,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
+        offline_count = len(self._offline_devices_cache)
 
         if offline_count == 0:
             return "Online"
@@ -113,13 +117,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         """Provide detailed fractional attributes for Lovelace cards."""
         base_attributes = super().extra_state_attributes
         devices = self._family_devices
-
-        offline_devices = [
-            getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        ]
+        offline_devices = self._offline_devices_cache
 
         base_attributes.update(
             {


### PR DESCRIPTION
💡 What: The optimization introduces a `_offline_devices_cache` list in `MerakiNetworkHealthSensor` that is populated during `_compute_device_cache`. The property getters `native_value` and `extra_state_attributes` were updated to read directly from this cache.
🎯 Why: Home Assistant frequently evaluates properties like `native_value` and `extra_state_attributes`. Previously, both of these getters performed duplicate iterations and list comprehensions (O(N)) over `self._family_devices` to compute offline counts and device lists. This caused redundant computation during every poll/access.
📊 Impact: Reduces O(N) list traversal for offline device counting from running on every property access to running exactly once per coordinator update (O(1) lookups during attribute extraction).
🔬 Measurement: Verify using tests by running `pytest tests/sensor/test_network_health.py` and via Home Assistant's profiler checking the cost of `MerakiNetworkHealthSensor` updates.

---
*PR created automatically by Jules for task [11372874636835736869](https://jules.google.com/task/11372874636835736869) started by @brewmarsh*