### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate offline counts in network health sensor cache

### DIFF
--- a/custom_components/meraki_ha/sensor/network_health.py
+++ b/custom_components/meraki_ha/sensor/network_health.py
@@ -46,12 +46,16 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
             self._attr_icon = "mdi:server-network"
 
         self._family_devices_cache: list[Any] = []
+        self._offline_count_cache = 0
+        self._offline_devices_cache: list[str] = []
         self._compute_device_cache()
 
     def _compute_device_cache(self) -> None:
         """Compute the device cache to avoid O(M) scans on every property access."""
         if not self.coordinator.data:
             self._family_devices_cache = []
+            self._offline_count_cache = 0
+            self._offline_devices_cache = []
             return
 
         data = self.coordinator.data
@@ -64,18 +68,32 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         elif isinstance(data, list):
             devices = data
 
-        self._family_devices_cache = [
-            d
-            for d in devices
-            if getattr(d, "network_id", None) == self._network_id
-            and (
+        family_devices = []
+        offline_devices = []
+        offline_count = 0
+
+        for d in devices:
+            if getattr(d, "network_id", None) == self._network_id and (
                 (getattr(d, "model", "") or "").startswith(self._family_prefix)
                 or (
                     self._family_prefix == "MS"
                     and (getattr(d, "model", "") or "").startswith("GS")
                 )
-            )
-        ]
+            ):
+                family_devices.append(d)
+                if str(getattr(d, "status", "offline")).lower() not in (
+                    "online",
+                    "alerting",
+                    "dormant",
+                ):
+                    offline_count += 1
+                    offline_devices.append(
+                        getattr(d, "name", getattr(d, "serial", "unknown"))
+                    )
+
+        self._family_devices_cache = family_devices
+        self._offline_count_cache = offline_count
+        self._offline_devices_cache = offline_devices
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -95,12 +113,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         if not devices:
             return "N/A"
 
-        offline_count = sum(
-            1
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        )
+        offline_count = self._offline_count_cache
 
         if offline_count == 0:
             return "Online"
@@ -113,13 +126,7 @@ class MerakiNetworkHealthSensor(MerakiNetworkEntity, SensorEntity):
         """Provide detailed fractional attributes for Lovelace cards."""
         base_attributes = super().extra_state_attributes
         devices = self._family_devices
-
-        offline_devices = [
-            getattr(d, "name", getattr(d, "serial", "unknown"))
-            for d in devices
-            if str(getattr(d, "status", "offline")).lower()
-            not in ("online", "alerting", "dormant")
-        ]
+        offline_devices = self._offline_devices_cache
 
         base_attributes.update(
             {

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 **What**: The optimization moves the calculation of `offline_devices` and `offline_count` in `MerakiNetworkHealthSensor` out of the `@property` getters (`native_value` and `extra_state_attributes`) and caches them during the `_compute_device_cache` method which runs when coordinator data updates.
🎯 **Why**: Home Assistant queries entity properties frequently (every update cycle). Previously, each property access iterated through the network devices to check for "offline" status. This caused redundant O(N) evaluations in hot loops, wasting CPU cycles and potentially blocking the async event loop.
📊 **Impact**: Reduces CPU cycles per property access from O(N) to O(1), improving update performance for the entity by eliminating redundant list comprehension loops.
🔬 **Measurement**: Verified the functionality of the sensor remains unchanged via unit tests. Run `pytest tests/sensor/test_network_health.py` to verify the state extraction logic correctly returns `Online`, `Offline`, or `Degraded`.

---
*PR created automatically by Jules for task [1970561709872145266](https://jules.google.com/task/1970561709872145266) started by @brewmarsh*