### PR TITLE
⚡ Bolt: [performance improvement] O(1) attribute access for PoE Sensor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Single-Pass Iteration for Multiple Counts
 **Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
 **Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.
+## 2024-05-19 - [O(1) Property Access in MerakiPoeUsageSensor]
+**Learning:** Home Assistant evaluates Sensor property getters (like `native_value` and `extra_state_attributes`) frequently on the main event loop. Performing O(N) operations (e.g. iterating over device ports) in these getters causes significant performance overhead.
+**Action:** Always perform O(N) calculations in lifecycle methods that run only when new data arrives (e.g., `_update_state` called from `_handle_coordinator_update`) and store the results in internal `_attr_*` properties for O(1) retrieval.

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import UnitOfPower
@@ -51,6 +51,34 @@ class MerakiPoeUsageSensor(MerakiSensor):
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Update the internal state and attributes."""
+        ports_statuses = self._device.switch_ports
+        if not isinstance(ports_statuses, list):
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        total_poe_usage_wh = 0
+        attributes = {}
+
+        for port in ports_statuses:
+            if isinstance(port, dict):
+                power = port.get("powerUsageInWh", 0) or 0
+                total_poe_usage_wh += power
+                if "portId" in port:
+                    port_id = port["portId"]
+                    key = f"port_{port_id}_power_usage_wh"
+                    attributes[key] = port.get("powerUsageInWh")
+
+        if total_poe_usage_wh > 0:
+            self._attr_native_value = round(total_poe_usage_wh / 24, 2)
+        else:
+            self._attr_native_value = 0.0
+
+        self._attr_extra_state_attributes = attributes
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -59,36 +87,5 @@ class MerakiPoeUsageSensor(MerakiSensor):
             device = self.coordinator.get_device(self._device.serial)
             if device:
                 self._device = device
+                self._update_state()
                 self.async_write_ha_state()
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the state of the sensor."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return None
-
-        total_poe_usage_wh = sum(
-            port.get("powerUsageInWh", 0) or 0
-            for port in ports_statuses
-            if isinstance(port, dict)
-        )
-
-        # The API returns power usage in Wh over the last day.
-        # We divide by 24 to get the average power in Watts.
-        if total_poe_usage_wh > 0:
-            return round(total_poe_usage_wh / 24, 2)
-        return 0.0
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return {}
-
-        return {
-            f"port_{port['portId']}_power_usage_wh": port.get("powerUsageInWh")
-            for port in ports_statuses
-            if isinstance(port, dict) and "portId" in port
-        }

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 **What:** Refactored `MerakiPoeUsageSensor` to move property calculations into a single `_update_state()` function.

🎯 **Why:** Home Assistant reads sensor properties (like `native_value` and `extra_state_attributes`) frequently during state updates. Because these calculations contained O(N) iteration loops over all switch ports, this led to unnecessarily heavy main-loop processing every time the property was accessed. By shifting calculation to a single loop that runs exactly once when new coordinator data arrives, we save unnecessary CPU cycles.

📊 **Impact:** Reduces O(N) evaluations in properties to O(1) attribute access, removing two O(N) iterations every time the property is requested. Reduces loop overhead per property call by combining operations into a single update loop.

🔬 **Measurement:** Verify tests run correctly (`pytest tests/sensor/device/test_poe_usage.py`) and check Home Assistant UI performance on networks with high port density.

---
*PR created automatically by Jules for task [10069961886157509736](https://jules.google.com/task/10069961886157509736) started by @brewmarsh*