### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,6 +1,7 @@
-## 2024-05-18 - [Optimize PoE Usage Sensor Properties]
-**Learning:** Home Assistant Sensor property getters (like `native_value` and `extra_state_attributes`) are evaluated very frequently on the main event loop. Performing O(N) operations (e.g., looping through device ports) inside these getters can block the event loop and degrade performance.
-**Action:** Move O(N) calculations to `_update_state` (called on initialization and via `_handle_coordinator_update`), store results in standard `_attr_native_value` and `_attr_extra_state_attributes` fields, and return those pre-computed values in the property getters for O(1) performance.
+## 2024-05-18 - Single-Pass Iteration for Multiple Counts
+**Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
+**Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.
+
 ## 2024-05-18 - [Optimize PoE Usage Sensor Properties]
 **Learning:** Home Assistant Sensor property getters (like `native_value` and `extra_state_attributes`) are evaluated very frequently on the main event loop. Performing O(N) operations (e.g., looping through device ports) inside these getters can block the event loop and degrade performance.
 **Action:** Move O(N) calculations to `_update_state` (called on initialization and via `_handle_coordinator_update`), store results in standard `_attr_native_value` and `_attr_extra_state_attributes` fields, and return those pre-computed values in the property getters for O(1) performance.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
-## 2024-05-18 - Single-Pass Iteration for Multiple Counts
-**Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
-**Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.
+## 2024-05-18 - [Optimize PoE Usage Sensor Properties]
+**Learning:** Home Assistant Sensor property getters (like `native_value` and `extra_state_attributes`) are evaluated very frequently on the main event loop. Performing O(N) operations (e.g., looping through device ports) inside these getters can block the event loop and degrade performance.
+**Action:** Move O(N) calculations to `_update_state` (called on initialization and via `_handle_coordinator_update`), store results in standard `_attr_native_value` and `_attr_extra_state_attributes` fields, and return those pre-computed values in the property getters for O(1) performance.
+## 2024-05-18 - [Optimize PoE Usage Sensor Properties]
+**Learning:** Home Assistant Sensor property getters (like `native_value` and `extra_state_attributes`) are evaluated very frequently on the main event loop. Performing O(N) operations (e.g., looping through device ports) inside these getters can block the event loop and degrade performance.
+**Action:** Move O(N) calculations to `_update_state` (called on initialization and via `_handle_coordinator_update`), store results in standard `_attr_native_value` and `_attr_extra_state_attributes` fields, and return those pre-computed values in the property getters for O(1) performance.

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class MerakiPoeUsageSensor(MerakiSensor):
+class MerakiPoeUsageSensor(MerakiSensor[MerakiMainCoordinator]):
     """
     Representation of a Meraki switch PoE usage sensor.
 

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -51,6 +51,36 @@ class MerakiPoeUsageSensor(MerakiSensor):
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
+        self._attr_extra_state_attributes: dict[str, Any] = {}
+        self._attr_native_value: float | None = None
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Update sensor state based on current device data."""
+        ports_statuses = self._device.switch_ports
+        if not isinstance(ports_statuses, list):
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        total_poe_usage_wh = 0.0
+        attrs = {}
+
+        for port in ports_statuses:
+            if isinstance(port, dict):
+                usage = port.get("powerUsageInWh", 0) or 0
+                total_poe_usage_wh += usage
+
+                port_id = port.get("portId")
+                if port_id is not None:
+                    attrs[f"port_{port_id}_power_usage_wh"] = port.get("powerUsageInWh")
+
+        if total_poe_usage_wh > 0:
+            self._attr_native_value = round(total_poe_usage_wh / 24, 2)
+        else:
+            self._attr_native_value = 0.0
+
+        self._attr_extra_state_attributes = attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -59,36 +89,15 @@ class MerakiPoeUsageSensor(MerakiSensor):
             device = self.coordinator.get_device(self._device.serial)
             if device:
                 self._device = device
+                self._update_state()
                 self.async_write_ha_state()
 
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return None
-
-        total_poe_usage_wh = sum(
-            port.get("powerUsageInWh", 0) or 0
-            for port in ports_statuses
-            if isinstance(port, dict)
-        )
-
-        # The API returns power usage in Wh over the last day.
-        # We divide by 24 to get the average power in Watts.
-        if total_poe_usage_wh > 0:
-            return round(total_poe_usage_wh / 24, 2)
-        return 0.0
+        return self._attr_native_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return {}
-
-        return {
-            f"port_{port['portId']}_power_usage_wh": port.get("powerUsageInWh")
-            for port in ports_statuses
-            if isinstance(port, dict) and "portId" in port
-        }
+        return self._attr_extra_state_attributes

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert (
-            registry_entry.device_id is not None
-        ), f"Entity {port_entity_id} is orphaned (no device_id)"
+        assert registry_entry.device_id is not None, (
+            f"Entity {port_entity_id} is orphaned (no device_id)"
+        )
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert (
-            device_entry is not None
-        ), f"Device {registry_entry.device_id} not found in registry"
+        assert device_entry is not None, (
+            f"Device {registry_entry.device_id} not found in registry"
+        )
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 What: Optimized the Meraki PoE Usage Sensor to evaluate port states during `_update_state` instead of continuously on property getters.
🎯 Why: Home Assistant evaluates properties like `native_value` and `extra_state_attributes` frequently on the main event loop. By performing O(N) evaluations in getters, this degraded the event loop. By doing this in `_update_state`, we ensure it is O(1).
📊 Impact: Reduced blocking time on the event loop by caching evaluations.
🔬 Measurement: Validated tests via `tests/sensor/device/test_poe_usage.py` and no breakages were observed.

---
*PR created automatically by Jules for task [14056299969742776063](https://jules.google.com/task/14056299969742776063) started by @brewmarsh*