### PR TITLE
⚡ Bolt: Optimize PoeUsageSensor property getters to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Single-Pass Iteration for Multiple Counts
 **Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
 **Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.
+
+## 2026-08-27 - Property Getter Optimization
+**Learning:** Home Assistant's property getters like `native_value` and `extra_state_attributes` are evaluated frequently on the main event loop. Performing O(N) operations inside these properties degrades system performance.
+**Action:** Move O(N) calculations (such as summing over ports or filtering lists) into `_update_state` or `_handle_coordinator_update` which run only when data changes. Store results in `_attr_native_value` or `_attr_extra_state_attributes` for O(1) retrieval.

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import UnitOfPower
@@ -51,22 +51,16 @@ class MerakiPoeUsageSensor(MerakiSensor):
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
+        self._update_state()
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        if self._device.serial:
-            device = self.coordinator.get_device(self._device.serial)
-            if device:
-                self._device = device
-                self.async_write_ha_state()
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the state of the sensor."""
+    def _update_state(self) -> None:
+        """Update the state attributes based on current device data."""
         ports_statuses = self._device.switch_ports
+
         if not isinstance(ports_statuses, list):
-            return None
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
 
         total_poe_usage_wh = sum(
             port.get("powerUsageInWh", 0) or 0
@@ -77,18 +71,22 @@ class MerakiPoeUsageSensor(MerakiSensor):
         # The API returns power usage in Wh over the last day.
         # We divide by 24 to get the average power in Watts.
         if total_poe_usage_wh > 0:
-            return round(total_poe_usage_wh / 24, 2)
-        return 0.0
+            self._attr_native_value = round(total_poe_usage_wh / 24, 2)
+        else:
+            self._attr_native_value = 0.0
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return {}
-
-        return {
+        self._attr_extra_state_attributes = {
             f"port_{port['portId']}_power_usage_wh": port.get("powerUsageInWh")
             for port in ports_statuses
             if isinstance(port, dict) and "portId" in port
         }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self._device.serial:
+            device = self.coordinator.get_device(self._device.serial)
+            if device:
+                self._device = device
+                self._update_state()
+                self.async_write_ha_state()


### PR DESCRIPTION
💡 What: The optimization moves the iteration logic required for PoE usage and port calculations out of the frequently-polled `native_value` and `extra_state_attributes` getters in `MerakiPoeUsageSensor`. The logic now resides in `_update_state`, executing only when data updates arrive via `_handle_coordinator_update` and caching results in `_attr_*`.
🎯 Why: Home Assistant accesses property getters synchronously on the main event loop for state changes, frontend rendering, and template evaluations. O(N) operations within these getters block the loop and scale poorly as device counts increase.
📊 Impact: Performance degradation directly scales away. Property accesses change from O(N) where N is port status count to O(1) attribute lookups, significantly reducing CPU spikes on large switch deployments.
🔬 Measurement: Verify the fix by observing reduced execution time spent in state updates for the PoE usage sensor entity when profiled in Home Assistant.

---
*PR created automatically by Jules for task [17040554866868448421](https://jules.google.com/task/17040554866868448421) started by @brewmarsh*