### PR TITLE
⚡ Bolt: Optimize Meraki PoE Usage Sensor

### DIFF
--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import UnitOfPower
@@ -67,7 +67,9 @@ class MerakiPoeUsageSensor(MerakiSensor):
             if isinstance(port, dict) and "portId" in port:
                 usage_wh = port.get("powerUsageInWh", 0) or 0
                 total_poe_usage_wh += usage_wh
-                attrs[f"port_{port['portId']}_power_usage_wh"] = port.get("powerUsageInWh")
+                attrs[f"port_{port['portId']}_power_usage_wh"] = port.get(
+                    "powerUsageInWh"
+                )
 
         if total_poe_usage_wh > 0:
             self._attr_native_value = round(total_poe_usage_wh / 24, 2)

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -51,6 +51,30 @@ class MerakiPoeUsageSensor(MerakiSensor):
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Update sensor state and attributes efficiently."""
+        ports_statuses = self._device.switch_ports
+        if not isinstance(ports_statuses, list):
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        total_poe_usage_wh = 0
+        attrs = {}
+        for port in ports_statuses:
+            if isinstance(port, dict) and "portId" in port:
+                usage_wh = port.get("powerUsageInWh", 0) or 0
+                total_poe_usage_wh += usage_wh
+                attrs[f"port_{port['portId']}_power_usage_wh"] = port.get("powerUsageInWh")
+
+        if total_poe_usage_wh > 0:
+            self._attr_native_value = round(total_poe_usage_wh / 24, 2)
+        else:
+            self._attr_native_value = 0.0
+
+        self._attr_extra_state_attributes = attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -59,36 +83,5 @@ class MerakiPoeUsageSensor(MerakiSensor):
             device = self.coordinator.get_device(self._device.serial)
             if device:
                 self._device = device
+                self._update_state()
                 self.async_write_ha_state()
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the state of the sensor."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return None
-
-        total_poe_usage_wh = sum(
-            port.get("powerUsageInWh", 0) or 0
-            for port in ports_statuses
-            if isinstance(port, dict)
-        )
-
-        # The API returns power usage in Wh over the last day.
-        # We divide by 24 to get the average power in Watts.
-        if total_poe_usage_wh > 0:
-            return round(total_poe_usage_wh / 24, 2)
-        return 0.0
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return {}
-
-        return {
-            f"port_{port['portId']}_power_usage_wh": port.get("powerUsageInWh")
-            for port in ports_statuses
-            if isinstance(port, dict) and "portId" in port
-        }


### PR DESCRIPTION
💡 What: Refactored `MerakiPoeUsageSensor` to calculate `_attr_native_value` and `_attr_extra_state_attributes` exactly once per data update via a unified `_update_state` method.
🎯 Why: Home Assistant properties like `native_value` and `extra_state_attributes` are accessed frequently on the main event loop. Previously, both getters independently traversed the `ports_statuses` list causing redundant O(N) operations.
📊 Impact: Halves the computational overhead for every time the PoE properties are read, yielding a small reduction in CPU utilization.
🔬 Measurement: Run unit tests using `pytest tests/sensor/device/test_poe_usage.py` to ensure accurate property calculations are maintained and code coverage is not negatively impacted.

---
*PR created automatically by Jules for task [9912113306257859448](https://jules.google.com/task/9912113306257859448) started by @brewmarsh*