### PR TITLE
⚡ Bolt: [performance improvement] Pre-compute VLAN list properties

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Single-Pass Iteration for Multiple Counts
 **Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
 **Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.
+## 2024-05-18 - [Bolt: Pre-compute property getters]
+**Learning:** In Home Assistant integrations using `CoordinatorEntity`, evaluating O(N) loops or building lists inside property getters (like `native_value` and `extra_state_attributes`) creates significant overhead, as these properties are evaluated repeatedly by the event loop (not just when data changes).
+**Action:** Always shift expensive computations (e.g., iterating through VLAN data lists) into `_handle_coordinator_update()` or a custom `_update_state()` method, cache the results to instance variables, and return the cached values in the property getters.

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -7,6 +7,7 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
+from homeassistant.core import callback
 
 from ...coordinators import MerakiMainCoordinator
 from ...core.entities.meraki_network_entity import MerakiNetworkEntity
@@ -28,37 +29,51 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         super().__init__(coordinator, config_entry, network_data)
         self._attr_unique_id = f"meraki-network-{network_data.id}-vlans-list"
         self._attr_name = f"{network_data.name} VLANs"
+        self._vlans_cache: list[str] = []
+        self._attr_native_value = 0
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Update the state based on coordinator data."""
+        self._vlans_cache = []
+        self._attr_native_value = 0
+
+        if not self._network:
+            return
+
+        vlans_data = self.coordinator.data.get("vlans", {})
+        if not isinstance(vlans_data, dict):
+            return
+
+        vlans = vlans_data.get(self._network.id, [])
+        if not isinstance(vlans, list):
+            return
+
+        self._attr_native_value = len(vlans)
+
+        for vlan in vlans:
+            if isinstance(vlan, dict) and "id" in vlan:
+                self._vlans_cache.append(
+                    vlan.get("name") or f"VLAN {vlan.get('id')}"
+                )
+            elif hasattr(vlan, "id"):
+                name = getattr(vlan, "name", None) or f"VLAN {vlan.id}"
+                self._vlans_cache.append(name)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         attrs = super().extra_state_attributes
-        vlan_list = []
-        if self._network:
-            vlans_data = self.coordinator.data.get("vlans", {})
-            if isinstance(vlans_data, dict):
-                vlans = vlans_data.get(self._network.id, [])
-                if isinstance(vlans, list):
-                    for vlan in vlans:
-                        if isinstance(vlan, dict) and "id" in vlan:
-                            vlan_list.append(
-                                vlan.get("name") or f"VLAN {vlan.get('id')}"
-                            )
-                        elif hasattr(vlan, "id"):
-                            name = getattr(vlan, "name", None) or f"VLAN {vlan.id}"
-                            vlan_list.append(name)
-        attrs["vlans"] = vlan_list
+        attrs["vlans"] = self._vlans_cache
         return attrs
 
     @property
     def native_value(self) -> int:
         """Return the number of VLANs."""
-        if not self._network:
-            return 0
-        vlans_data = self.coordinator.data.get("vlans", {})
-        if not isinstance(vlans_data, dict):
-            return 0
-        vlans = vlans_data.get(self._network.id, [])
-        if not isinstance(vlans, list):
-            return 0
-        return len(vlans)
+        return self._attr_native_value

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -30,13 +30,13 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         self._attr_unique_id = f"meraki-network-{network_data.id}-vlans-list"
         self._attr_name = f"{network_data.name} VLANs"
         self._vlans_cache: list[str] = []
-        self._attr_native_value = 0
+        self._native_value_cache: int = 0
         self._update_state()
 
     def _update_state(self) -> None:
         """Update the state based on coordinator data."""
         self._vlans_cache = []
-        self._attr_native_value = 0
+        self._native_value_cache = 0
 
         if not self._network:
             return
@@ -49,7 +49,7 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
         if not isinstance(vlans, list):
             return
 
-        self._attr_native_value = len(vlans)
+        self._native_value_cache = len(vlans)
 
         for vlan in vlans:
             if isinstance(vlan, dict) and "id" in vlan:
@@ -74,4 +74,4 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
     @property
     def native_value(self) -> int:
         """Return the number of VLANs."""
-        return self._attr_native_value
+        return self._native_value_cache

--- a/custom_components/meraki_ha/sensor/network/vlans_list.py
+++ b/custom_components/meraki_ha/sensor/network/vlans_list.py
@@ -53,9 +53,7 @@ class VlansListSensor(MerakiNetworkEntity, SensorEntity):
 
         for vlan in vlans:
             if isinstance(vlan, dict) and "id" in vlan:
-                self._vlans_cache.append(
-                    vlan.get("name") or f"VLAN {vlan.get('id')}"
-                )
+                self._vlans_cache.append(vlan.get("name") or f"VLAN {vlan.get('id')}")
             elif hasattr(vlan, "id"):
                 name = getattr(vlan, "name", None) or f"VLAN {vlan.id}"
                 self._vlans_cache.append(name)

--- a/tests/sensor/network/test_vlans_list.py
+++ b/tests/sensor/network/test_vlans_list.py
@@ -62,19 +62,12 @@ async def test_vlans_list_sensor_creation_enabled(mock_coordinator):
 
     # Run the setup
     discovery_service = DeviceDiscoveryService(
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator,
-        mock_coordinator.config_entry,
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
-        MagicMock(),
+        main_coordinator=mock_coordinator,
+        config_entry=mock_coordinator.config_entry,
+        meraki_client=MagicMock(),
+        camera_service=MagicMock(),
+        control_service=MagicMock(),
+        network_control_service=MagicMock(),
     )
     await discovery_service.discover_entities()
     sensors = discovery_service.all_entities


### PR DESCRIPTION
💡 What: Shifted O(N) list parsing and evaluations for `VlansListSensor` from property getters into `_update_state()`, hooked to `_handle_coordinator_update`.
🎯 Why: Home Assistant accesses `native_value` and `extra_state_attributes` frequently on the main event loop. Performing O(N) iterations on these getters wastes CPU and slows down the state machine.
📊 Impact: Eliminates redundant O(N) operations, converting property access to O(1) attribute reads. 
🔬 Measurement: Verify using python profiling during frequent state updates, or running `pytest tests/sensor/network/test_vlans_list_unit.py` which guarantees functionality remains identical while optimizing execution.

---
*PR created automatically by Jules for task [13326110761499067230](https://jules.google.com/task/13326110761499067230) started by @brewmarsh*