### PR TITLE
⚡ Bolt: [performance improvement] Optimize PoE usage sensor O(N) calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Single-Pass Iteration for Multiple Counts
 **Learning:** Performing multiple `sum(1 for ...)` operations on the same list to extract different counts (like "critical" and "warning" alerts) creates a hidden O(k*N) inefficiency.
 **Action:** Refactor multiple generator counts into a single `for` loop to perform an O(N) pass, reducing loop overhead and redundant dictionary lookups.
+## 2025-02-12 - Prevent Home Assistant Event Loop Blocking via O(N) Property Avoidance
+**Learning:** Home Assistant core heavily polls sensor properties (`native_value`, `extra_state_attributes`) on the main event loop during rendering and state updates. Performing O(N) calculations (like list filtering or aggregation) inside property getters leads to repeated, blocking computations and degrades system performance.
+**Action:** When implementing or refactoring Home Assistant entities, perform complex calculations in `_handle_coordinator_update` or `__init__`, cache the results in standard `_attr_*` variables, and ensure property getters simply return those pre-computed values in O(1) time.

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -51,6 +51,39 @@ class MerakiPoeUsageSensor(MerakiSensor):
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{device.serial}_poe_usage"
         self._attr_name = "PoE Usage"
+        self._attr_native_value = None
+        self._attr_extra_state_attributes = {}
+        self._update_state()
+
+    def _update_state(self) -> None:
+        """Compute native value and attributes from device data (O(N) operation)."""
+        ports_statuses = self._device.switch_ports
+        if not isinstance(ports_statuses, list):
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        # Bolt Performance: Calculate total and per-port usage in a single pass O(N)
+        # rather than computing these dynamically on every property access.
+        total_poe_usage_wh = 0.0
+        attrs = {}
+
+        for port in ports_statuses:
+            if isinstance(port, dict):
+                port_id = port.get("portId")
+                usage = port.get("powerUsageInWh", 0) or 0
+                total_poe_usage_wh += usage
+                if port_id is not None:
+                    attrs[f"port_{port_id}_power_usage_wh"] = port.get("powerUsageInWh")
+
+        # The API returns power usage in Wh over the last day.
+        # We divide by 24 to get the average power in Watts.
+        if total_poe_usage_wh > 0:
+            self._attr_native_value = round(total_poe_usage_wh / 24, 2)
+        else:
+            self._attr_native_value = 0.0
+
+        self._attr_extra_state_attributes = attrs
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -59,36 +92,15 @@ class MerakiPoeUsageSensor(MerakiSensor):
             device = self.coordinator.get_device(self._device.serial)
             if device:
                 self._device = device
+                self._update_state()
                 self.async_write_ha_state()
 
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return None
-
-        total_poe_usage_wh = sum(
-            port.get("powerUsageInWh", 0) or 0
-            for port in ports_statuses
-            if isinstance(port, dict)
-        )
-
-        # The API returns power usage in Wh over the last day.
-        # We divide by 24 to get the average power in Watts.
-        if total_poe_usage_wh > 0:
-            return round(total_poe_usage_wh / 24, 2)
-        return 0.0
+        return self._attr_native_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        ports_statuses = self._device.switch_ports
-        if not isinstance(ports_statuses, list):
-            return {}
-
-        return {
-            f"port_{port['portId']}_power_usage_wh": port.get("powerUsageInWh")
-            for port in ports_statuses
-            if isinstance(port, dict) and "portId" in port
-        }
+        return self._attr_extra_state_attributes

--- a/custom_components/meraki_ha/sensor/device/poe_usage.py
+++ b/custom_components/meraki_ha/sensor/device/poe_usage.py
@@ -98,7 +98,9 @@ class MerakiPoeUsageSensor(MerakiSensor):
     @property
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        return self._attr_native_value
+        if self._attr_native_value is None:
+            return None
+        return float(str(self._attr_native_value))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/tests/sensor/test_switch_port_generation.py
+++ b/tests/sensor/test_switch_port_generation.py
@@ -143,15 +143,15 @@ async def test_switch_port_generation_and_linkage(
     for port_entity_id in [port_1_status, port_2_status]:
         registry_entry = entity_registry.async_get(port_entity_id)
         assert registry_entry is not None
-        assert registry_entry.device_id is not None, (
-            f"Entity {port_entity_id} is orphaned (no device_id)"
-        )
+        assert (
+            registry_entry.device_id is not None
+        ), f"Entity {port_entity_id} is orphaned (no device_id)"
 
         # Verify device actually exists and links properly
         device_entry = device_registry.async_get(registry_entry.device_id)
-        assert device_entry is not None, (
-            f"Device {registry_entry.device_id} not found in registry"
-        )
+        assert (
+            device_entry is not None
+        ), f"Device {registry_entry.device_id} not found in registry"
 
         # In Meraki_HA, typically the device identifiers includes the domain and serial
         assert ("meraki_ha", "Q2KX-ACU9-ZAVN") in device_entry.identifiers


### PR DESCRIPTION
💡 What: The optimization refactored `MerakiPoeUsageSensor` to calculate the total and per-port PoE usage in a single pass O(N) only when data arrives in `_handle_coordinator_update` and `__init__`, rather than calculating it on every access to the `native_value` and `extra_state_attributes` properties.
🎯 Why: Home Assistant core heavily polls these property getters on the main event loop, leading to degraded performance when properties recalculate state in O(N) operations unnecessarily on every poll.
📊 Impact: Eliminates O(N) loop blocking operations dynamically executed on the Home Assistant main event loop every time the sensor properties are read.
🔬 Measurement: Verify using `uv run pytest tests/sensor/device/test_poe_usage.py` that existing logic passes and run `./run_checks.sh` to see that performance logic is clean.

---
*PR created automatically by Jules for task [15312043269580987007](https://jules.google.com/task/15312043269580987007) started by @brewmarsh*